### PR TITLE
fix: 修复 FallbackStreamClient 中死代码导致的 fallback 失效

### DIFF
--- a/src/api/__tests__/fallback-client.test.ts
+++ b/src/api/__tests__/fallback-client.test.ts
@@ -118,4 +118,23 @@ describe('FallbackStreamClient', () => {
     client.setReasoningEffort('high')
     assert.equal(effort, 'high')
   })
+
+  it('falls back on stream_parse error (previously dead code path)', async () => {
+    const primary: StreamClient = {
+      async stream() {
+        const err = new Error('invalid SSE event')
+        ;(err as Error & { name: string }).name = 'StreamParseError'
+        throw err
+      },
+    }
+    const log: string[] = []
+    const client = new FallbackStreamClient(
+      primary, 'main',
+      [{ name: 'backup', create: () => { log.push('backup-created'); return makeClient('ok') } }],
+      (from, to) => log.push(`${from}->${to}`),
+    )
+    await client.stream(makeRequest(), makeCallbacks())
+    assert.ok(log.includes('main->backup'), 'should fall back on stream_parse error')
+    assert.ok(log.includes('backup-created'), 'backup client should be instantiated')
+  })
 })

--- a/src/api/fallback-client.ts
+++ b/src/api/fallback-client.ts
@@ -6,7 +6,7 @@
 
 import type { StreamClient, StreamCallbacks } from './stream-client.js'
 import type { OaiChatRequest } from './oai-types.js'
-import { classifyApiError } from './error-classifier.js'
+import { type ErrorCategory, classifyApiError } from './error-classifier.js'
 
 export interface FallbackEntry {
   name: string
@@ -85,10 +85,10 @@ export class FallbackStreamClient implements StreamClient {
     throw lastError
   }
 
-  private shouldFallback(category: string): boolean {
+  private shouldFallback(category: ErrorCategory): boolean {
     const fallbackCategories = new Set([
       'rate_limit', 'server_error', 'overloaded',
-      'timeout', 'connection_error', 'stream_error',
+      'timeout', 'stream_parse',
     ])
     return fallbackCategories.has(category)
   }


### PR DESCRIPTION
- 将不存在于 ErrorCategory 的 'connection_error' 和 'stream_error' 替换为实际的 'stream_parse'——这两个值从未被 classifyApiError() 产 生，导致 SSE 解析错误时 fallback 被静默跳过
- 将 category 参数类型从 string 改为 ErrorCategory，利用 TypeScript 编译期检查防止未来拼写错误
- 新增 stream_parse fallback 路径的回归测试