### PR TITLE
fix(edit/hash-edit): 写入后 syntaxCheck/diff 异常不再导致工具报错

### DIFF
--- a/src/tools/__tests__/edit.test.ts
+++ b/src/tools/__tests__/edit.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import { writeFileSync, mkdirSync, rmSync, existsSync, readFileSync, statSync } from 'fs'
 
 import { join } from 'path'
-import { EDIT_FILE_TOOL } from '../edit.js'
+import { EDIT_FILE_TOOL, __buildEditSuccessResultForTests as buildEditSuccessResult } from '../edit.js'
 import type { ToolCallParams } from '../types.js'
 
 // Use a directory inside the project tree so validatePath() doesn't reject
@@ -357,3 +357,59 @@ describe('edit_file tool', () => {
   })
 })
 
+
+describe('buildEditSuccessResult — post-write enhancement failures are non-fatal', () => {
+  it('surfaces syntax-check failure as a warning, not an error', async () => {
+    const result = await buildEditSuccessResult(
+      '/cwd',
+      '/cwd/file.tsx',
+      'before',
+      'after',
+      'Applied edit',
+      {
+        syntaxCheck: async () => { throw new Error('esbuild exploded') },
+        buildFileDiff: async () => '',
+        computeChangedLineRanges: async () => [],
+      },
+    )
+    assert.ok(result.uiContent?.includes('syntax-check skipped'), 'uiContent should surface skip note')
+    assert.ok(result.content.includes('syntax-check skipped'), 'should surface skip note')
+    assert.ok(result.content.includes('esbuild exploded'), 'should include original error message')
+  })
+
+  it('surfaces diff failure as a warning while keeping syntax warning', async () => {
+    const result = await buildEditSuccessResult(
+      '/cwd',
+      '/cwd/file.tsx',
+      'before',
+      'after',
+      'Applied edit',
+      {
+        syntaxCheck: async () => '⚠️ Syntax error',
+        buildFileDiff: async () => { throw new Error('diff worker died') },
+        computeChangedLineRanges: async () => { throw new Error('ranges worker died') },
+      },
+    )
+    assert.ok(result.content.includes('diff skipped'), 'should surface diff skip note')
+    assert.ok(result.content.includes('Syntax error'), 'should keep syntax warning')
+    assert.ok(result.uiContent?.includes('Syntax error'), 'uiContent should show available warning')
+  })
+
+  it('keeps success result unchanged when enhancements pass', async () => {
+    const result = await buildEditSuccessResult(
+      '/cwd',
+      '/cwd/file.tsx',
+      'before',
+      'after',
+      'Applied edit',
+      {
+        syntaxCheck: async () => null,
+        buildFileDiff: async () => '@@ -1 +1 @@\n-before\n+after',
+        computeChangedLineRanges: async () => [{ start: 1, end: 1 }],
+      },
+    )
+    assert.equal(result.content, 'Applied edit')
+    assert.ok(result.uiContent?.includes('@@'), 'uiContent has diff')
+    assert.deepEqual(result.changedRanges, [{ start: 1, end: 1 }])
+  })
+})

--- a/src/tools/__tests__/hash-edit.test.ts
+++ b/src/tools/__tests__/hash-edit.test.ts
@@ -2,7 +2,7 @@ import { describe, it, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
 import { mkdirSync, writeFileSync, rmSync, readFileSync } from 'fs'
 import { join } from 'path'
-import { HASH_EDIT_TOOL } from '../hash-edit.js'
+import { HASH_EDIT_TOOL, __safeSyntaxCheckForTests as safeSyntaxCheck } from '../hash-edit.js'
 import { markSessionFileEdit, wasFileEditedBySession, __resetSessionFileEditsForTests } from '../read-file.js'
 import type { ToolCallParams } from '../types.js'
 
@@ -386,5 +386,19 @@ describe('hash_edit', () => {
     // 文件未被修改（全部可恢复才应用编辑）
     const newContent = readFileSync(join(cwd, 'test.ts'), 'utf-8')
     assert.equal(newContent, 'alpha\nCHANGED\ngamma\ndelta\n')
+  })
+})
+
+
+describe('safeSyntaxCheck — syntaxCheck failure is non-fatal', () => {
+  it('passes through a clean result', async () => {
+    const result = await safeSyntaxCheck('/cwd/file.ts', 'content', async () => null)
+    assert.equal(result, null)
+  })
+
+  it('returns a skip note when the checker throws', async () => {
+    const result = await safeSyntaxCheck('/cwd/file.tsx', 'content', async () => { throw new Error('esbuild exploded') })
+    assert.ok(result?.includes('syntax-check skipped'), 'should surface skip note')
+    assert.ok(result?.includes('esbuild exploded'), 'should include original error message')
   })
 })

--- a/src/tools/edit.ts
+++ b/src/tools/edit.ts
@@ -2,7 +2,7 @@ import { readFile, stat } from 'node:fs/promises'
 import { relative } from 'node:path'
 import type { Tool, ToolCallParams } from './types.js'
 import { validatePath } from './path-validate.js'
-import { buildFileDiff, computeChangedLineRanges } from './edit-diff.js'
+import { buildFileDiff, computeChangedLineRanges, type LineRange } from './edit-diff.js'
 import { hashLine } from './hash-edit.js'
 import { getFileReadMtime, noteFileObserved, recordSuccessfulEdit, wasFileEditedBySession, incrementEditFailCount, resetEditFailCount } from './read-file.js'
 import { syntaxCheck } from './syntax-check.js'
@@ -45,6 +45,61 @@ function detectRegexPattern(oldString: string): string | null {
   }
   return null
 }
+
+/**
+ * Assemble the final ToolResult for a successful edit.
+ *
+ * Post-write enhancements (syntax-check, diff, changed-ranges) are
+ * display-only / diagnostics-narrowing. Failures here MUST NOT cause the tool
+ * call to report an error — the file is already on disk and an error would
+ * create a "write succeeded but tool reports failure" loop.
+ */
+interface EditSuccessDeps {
+  syntaxCheck?: (filePath: string, content: string) => Promise<string | null>
+  buildFileDiff?: (relPath: string, before: string, after: string) => Promise<string>
+  computeChangedLineRanges?: (before: string, after: string) => Promise<LineRange[]>
+}
+
+async function buildEditSuccessResult(
+  cwd: string,
+  filePath: string,
+  before: string,
+  after: string,
+  baseContent: string,
+  deps?: EditSuccessDeps,
+): Promise<{ content: string; uiContent?: string; changedRanges: LineRange[] }> {
+  const doSyntaxCheck = deps?.syntaxCheck ?? syntaxCheck
+  const doBuildFileDiff = deps?.buildFileDiff ?? buildFileDiff
+  const doComputeChangedLineRanges = deps?.computeChangedLineRanges ?? computeChangedLineRanges
+
+  let warn: string | null = null
+  let uiContent: string | undefined
+  let changedRanges: LineRange[] = []
+
+  try {
+    warn = await doSyntaxCheck(filePath, after)
+  } catch (e) {
+    warn = `(syntax-check skipped: ${(e as Error).message})`
+  }
+
+  try {
+    const diff = await doBuildFileDiff(relative(cwd, filePath), before, after)
+    changedRanges = await doComputeChangedLineRanges(before, after)
+    uiContent = diff ? (warn ? `${diff}\n\n${warn}` : diff) : (warn ? warn : undefined)
+  } catch (e) {
+    const note = `(diff skipped: ${(e as Error).message})`
+    warn = warn ? `${warn}\n${note}` : note
+    uiContent = warn ? warn : undefined
+  }
+
+  return {
+    content: baseContent + (warn ? '\n\n' + warn : ''),
+    uiContent,
+    changedRanges,
+  }
+}
+
+export const __buildEditSuccessResultForTests = buildEditSuccessResult
 
 
 export const EDIT_FILE_TOOL: Tool = {
@@ -151,17 +206,14 @@ Prefer edit_file for unique-string swaps; use hash_edit for whitespace-ambiguous
             const newContent = freshContent.replaceAll(oldString, newString)
             await writeFileAtomicAsync(filePath, applyEol(newContent, freshEol))
             await recordSuccessfulEdit(filePath, params.sessionId)
-          resetEditFailCount(filePath)
+            resetEditFailCount(filePath)
             const occurrences = (freshContent.match(new RegExp(escapeRegExp(oldString), 'g')) || []).length
             const expectedCount = params.input.expected_count as number | undefined
-            const warn = await syntaxCheck(filePath, newContent)
-            const ui = await editUiContent(params.cwd, filePath, freshContent, newContent, warn)
-            const changedRanges = await computeChangedLineRanges(freshContent, newContent)
-            if (expectedCount !== undefined && occurrences !== expectedCount) {
-              const base = `File was modified externally but old_string still matched. Warning: expected ${expectedCount} replacements but only replaced ${occurrences} in ${filePath}. Use grep to verify no instances were missed — different indentation or whitespace can cause partial matches with replace_all.`
-              return { content: base + (warn ? '\n\n' + warn : ''), uiContent: ui, changedRanges }
-            }
-            return { content: `File was modified externally but old_string still matched. Re-applied ${occurrences} replacement(s) in ${filePath}${warn ? '\n\n' + warn : ''}`, uiContent: ui, changedRanges }
+            const baseContent = expectedCount !== undefined && occurrences !== expectedCount
+              ? `File was modified externally but old_string still matched. Warning: expected ${expectedCount} replacements but only replaced ${occurrences} in ${filePath}. Use grep to verify no instances were missed — different indentation or whitespace can cause partial matches with replace_all.`
+              : `File was modified externally but old_string still matched. Re-applied ${occurrences} replacement(s) in ${filePath}`
+            const { content: resultContent, uiContent, changedRanges } = await buildEditSuccessResult(params.cwd, filePath, freshContent, newContent, baseContent)
+            return { content: resultContent, uiContent, changedRanges }
           }
           const firstIdx = freshContent.indexOf(oldString)
           const secondIdx = freshContent.indexOf(oldString, firstIdx + oldString.length)
@@ -172,12 +224,11 @@ Prefer edit_file for unique-string swaps; use hash_edit for whitespace-ambiguous
           await writeFileAtomicAsync(filePath, applyEol(recovered, freshEol))
           await recordSuccessfulEdit(filePath, params.sessionId)
           resetEditFailCount(filePath)
-          const warn = await syntaxCheck(filePath, recovered)
-          return {
-            content: `Applied edit to ${filePath} (file was modified externally but content still matched)${warn ? '\n\n' + warn : ''}`,
-            uiContent: await editUiContent(params.cwd, filePath, freshContent, recovered, warn),
-            changedRanges: await computeChangedLineRanges(freshContent, recovered),
-          }
+          const { content: resultContent, uiContent, changedRanges } = await buildEditSuccessResult(
+            params.cwd, filePath, freshContent, recovered,
+            `Applied edit to ${filePath} (file was modified externally but content still matched)`
+          )
+          return { content: resultContent, uiContent, changedRanges }
         }
 
         // old_string not found — show what the file actually looks like near the best guess
@@ -257,14 +308,11 @@ Prefer edit_file for unique-string swaps; use hash_edit for whitespace-ambiguous
       resetEditFailCount(filePath)
       const occurrences = (content.match(new RegExp(escapeRegExp(oldString), 'g')) || []).length
       const expectedCount = params.input.expected_count as number | undefined
-      const warn = await syntaxCheck(filePath, newContent)
-      const ui = await editUiContent(params.cwd, filePath, content, newContent, warn)
-      const changedRanges = await computeChangedLineRanges(content, newContent)
-      if (expectedCount !== undefined && occurrences !== expectedCount) {
-        const base = `Warning: expected ${expectedCount} replacements but only replaced ${occurrences} in ${filePath}. The file has been modified. Use grep to verify that no instances were missed — different indentation or whitespace can cause partial matches with replace_all.`
-        return { content: base + (warn ? '\n\n' + warn : ''), uiContent: ui, changedRanges }
-      }
-      return { content: `Replaced all ${occurrences} occurrences in ${filePath}` + (warn ? '\n\n' + warn : ''), uiContent: ui, changedRanges }
+      const baseContent = expectedCount !== undefined && occurrences !== expectedCount
+        ? `Warning: expected ${expectedCount} replacements but only replaced ${occurrences} in ${filePath}. The file has been modified. Use grep to verify that no instances were missed — different indentation or whitespace can cause partial matches with replace_all.`
+        : `Replaced all ${occurrences} occurrences in ${filePath}`
+      const { content: resultContent, uiContent, changedRanges } = await buildEditSuccessResult(params.cwd, filePath, content, newContent, baseContent)
+      return { content: resultContent, uiContent, changedRanges }
     }
 
     const firstIndex = content.indexOf(oldString)
@@ -278,7 +326,6 @@ Prefer edit_file for unique-string swaps; use hash_edit for whitespace-ambiguous
         await writeFileAtomicAsync(filePath, applyEol(recovered, eol))
         await recordSuccessfulEdit(filePath, params.sessionId)
         resetEditFailCount(filePath)
-        const warn = await syntaxCheck(filePath, recovered)
         // Surface the whitespace drift so the model can self-correct in
         // subsequent edits — without this, error accumulates across calls.
         const diff = diffBlock(oldString, fuzzy.matchedText)
@@ -287,11 +334,8 @@ Prefer edit_file for unique-string swaps; use hash_edit for whitespace-ambiguous
           `[fuzzy] your old_string had whitespace/indentation drift from the file:`,
           `[fuzzy] diff:\n${diff}`,
         ].join('\n')
-        return {
-          content: fuzzyReport + (warn ? '\n\n' + warn : ''),
-          uiContent: await editUiContent(params.cwd, filePath, content, recovered, warn),
-          changedRanges: await computeChangedLineRanges(content, recovered),
-        }
+        const { content: resultContent, uiContent, changedRanges } = await buildEditSuccessResult(params.cwd, filePath, content, recovered, fuzzyReport)
+        return { content: resultContent, uiContent, changedRanges }
       }
       const fails = incrementEditFailCount(filePath)
       const gatePrefix = fails >= 3 ? `After ${fails} consecutive edit failures on this file, you MUST re-read it before editing again.\n\n` : ''
@@ -311,12 +355,10 @@ Prefer edit_file for unique-string swaps; use hash_edit for whitespace-ambiguous
     await writeFileAtomicAsync(filePath, applyEol(newContent, eol))
     await recordSuccessfulEdit(filePath, params.sessionId)
     resetEditFailCount(filePath)
-    const warn = await syntaxCheck(filePath, newContent)
-    return {
-      content: `Applied edit to ${filePath}` + (warn ? '\n\n' + warn : ''),
-      uiContent: await editUiContent(params.cwd, filePath, content, newContent, warn),
-      changedRanges: await computeChangedLineRanges(content, newContent),
-    }
+    const { content: resultContent, uiContent, changedRanges } = await buildEditSuccessResult(
+      params.cwd, filePath, content, newContent, `Applied edit to ${filePath}`
+    )
+    return { content: resultContent, uiContent, changedRanges }
   },
 
   requiresApproval: () => true,
@@ -326,18 +368,6 @@ Prefer edit_file for unique-string swaps; use hash_edit for whitespace-ambiguous
 
 function escapeRegExp(str: string): string {
   return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-}
-
-/**
- * Assemble the display-only uiContent for a successful edit: a colored inline
- * diff (rendered by the TUI/desktop tool card) plus any syntax-check warning.
- * Returns undefined when there is nothing extra to show (card falls back to
- * the model-facing `content`).
- */
-async function editUiContent(cwd: string, filePath: string, before: string, after: string, warn: string | null): Promise<string | undefined> {
-  const diff = await buildFileDiff(relative(cwd, filePath), before, after)
-  if (!diff) return warn ? warn : undefined
-  return warn ? `${diff}\n\n${warn}` : diff
 }
 
 /**

--- a/src/tools/hash-edit.ts
+++ b/src/tools/hash-edit.ts
@@ -22,6 +22,21 @@ export function hashLine(line: string): string {
   return createHash('sha256').update(clean).digest('hex').slice(0, 8)
 }
 
+/** Run syntaxCheck, but never let it crash the tool result after a write. */
+async function safeSyntaxCheck(
+  filePath: string,
+  content: string,
+  checker: (filePath: string, content: string) => Promise<string | null> = syntaxCheck,
+): Promise<string | null> {
+  try {
+    return await checker(filePath, content)
+  } catch (e) {
+    return `(syntax-check skipped: ${(e as Error).message})`
+  }
+}
+
+export const __safeSyntaxCheckForTests = safeSyntaxCheck
+
 interface Anchor {
   line: number      // 1-based
   hash: string | null  // 8-char hex, or null for position-only mode
@@ -308,7 +323,7 @@ Note: For large new_string, the message history keeps only a short pointer
             await writeFileAtomicAsync(filePath, applyEol(newContent, eol))
             await recordSuccessfulEdit(filePath, params.sessionId)
             resetEditFailCount(filePath)
-            const warn = await syntaxCheck(filePath, newContent)
+            const warn = await safeSyntaxCheck(filePath, newContent)
             const recoveredInfo = recoveredCount > 0
               ? ` (auto-recovered ${recoveredCount} stale anchors)`
               : ''
@@ -350,7 +365,7 @@ Note: For large new_string, the message history keeps only a short pointer
     await writeFileAtomicAsync(filePath, applyEol(newContent, eol))
     await recordSuccessfulEdit(filePath, params.sessionId)
     resetEditFailCount(filePath)
-    const warn = await syntaxCheck(filePath, newContent)
+    const warn = await safeSyntaxCheck(filePath, newContent)
     const posDrift = positionDriftWarning
       ? '\n\n⚠ Position-only anchors used on a file modified since last read — line numbers may have drifted. Verify the result or use edit_file instead.'
       : ''

--- a/src/tools/syntax-check.ts
+++ b/src/tools/syntax-check.ts
@@ -34,6 +34,16 @@ function getEsbuild(): EsbuildModule | null {
 /** Files larger than this skip CSS/HTML/JSON branch checks (O(n) scans). */
 const SYNC_SCAN_SIZE_LIMIT = 2 * 1024 * 1024 // 2 MB
 
+/** Cap esbuild transform so a malformed/huge TSX file cannot hang the tool. */
+const TRANSFORM_TIMEOUT_MS = 5000
+
+async function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<never>((_, reject) => setTimeout(() => reject(new Error(`${label} timeout after ${ms}ms`)), ms)),
+  ])
+}
+
 /**
  * Language-agnostic syntax and structural integrity check for written files.
  *
@@ -64,7 +74,11 @@ export async function syntaxCheck(filePath: string, content: string): Promise<st
       // Prefer async transform — esbuild runs on its own worker, doesn't block
       // the main thread. Falls back to sync for ancient esbuild versions.
       if (esbuild.transform) {
-        await esbuild.transform(content, { loader, target: 'esnext', jsx: 'automatic' })
+        await withTimeout(
+          esbuild.transform(content, { loader, target: 'esnext', jsx: 'automatic' }),
+          TRANSFORM_TIMEOUT_MS,
+          'esbuild transform',
+        )
       } else {
         esbuild.transformSync(content, { loader, target: 'esnext', jsx: 'automatic' })
       }


### PR DESCRIPTION
- edit.ts: 抽取 buildEditSuccessResult，包起 syntaxCheck/buildFileDiff/computeChangedLineRanges
- hash-edit.ts: 抽取 safeSyntaxCheck，包起 syntaxCheck 异常
- syntax-check.ts: 给 esbuild transform 加 5s 超时
- 补充 edit.ts / hash-edit.ts 容错测试

避免文件已落盘但 post-write 增强处理失败时返回 tool error，
从而阻止 orphan tool_call → "会话中断导致工具结果丢失" 的循环。