### PR TITLE
tui: overlay subtle style overhaul — remove emojis, compact layout, thin borders

### DIFF
--- a/src/tui/__tests__/format-choice-panel.test.ts
+++ b/src/tui/__tests__/format-choice-panel.test.ts
@@ -43,10 +43,10 @@ test('renderChoicePanel: selected choice has cursor ▶', () => {
   const plain = lines.map(stripAnsi)
   // selectedIndex=1 → second choice should have ▶ cursor
   const bLine = plain.find(l => l.includes('压缩上下文'))
-  assert.ok(bLine && bLine.includes('▶'), 'selected choice has ▶ cursor')
+  assert.ok(bLine && bLine.includes('>'), 'selected choice has ▶ cursor')
   // First choice should NOT have cursor
   const aLine = plain.find(l => l.includes('降级模型'))
-  assert.ok(aLine && !aLine.includes('▶'), 'non-selected choice has no cursor')
+  assert.ok(aLine && !aLine.includes('>'), 'non-selected choice has no cursor')
 })
 
 test('renderChoicePanel: recommended choice has ★ marker', () => {

--- a/src/tui/__tests__/format-overlay.test.ts
+++ b/src/tui/__tests__/format-overlay.test.ts
@@ -79,7 +79,7 @@ describe('renderCommandPalette', () => {
     const lines = renderCommandPalette(data, 60, 15, theme)
     assert.ok(lines.some(l => stripAnsi(l).includes('Command A')))
     // Selected should have ▶ prefix
-    assert.ok(lines.some(l => stripAnsi(l).includes('▶')))
+    assert.ok(lines.some(l => stripAnsi(l).includes('>')))
   })
 
   it('shows search text in title', () => {
@@ -139,8 +139,8 @@ describe('renderChronicle', () => {
     const lines = renderChronicle(data, 80, 20, theme)
     const secondLine = lines.find(l => stripAnsi(l).includes('second'))
     const firstLine = lines.find(l => stripAnsi(l).includes('first'))
-    assert.ok(secondLine && stripAnsi(secondLine).includes('▶'), '选中行有 ▶ 游标')
-    assert.ok(firstLine && !stripAnsi(firstLine).includes('▶'), '未选中行无游标')
+    assert.ok(secondLine && stripAnsi(secondLine).includes('>'), '选中行有 > 游标')
+    assert.ok(firstLine && !stripAnsi(firstLine).includes('>'), '未选中行无游标')
   })
 
   it('footer 引导 Enter → resume（G5 诚实文案）', () => {

--- a/src/tui/__tests__/format-plan-picker.test.ts
+++ b/src/tui/__tests__/format-plan-picker.test.ts
@@ -30,7 +30,7 @@ test('renderPlanPicker: renders title and all plan titles', () => {
 test('renderPlanPicker: selected entry has ▶ cursor and shows meta', () => {
   const plain = renderPlanPicker(makeData({ selectedIndex: 1 }), 70, 20, theme).map(stripAnsi)
   const sel = plain.find(l => l.includes('权限入口三档统一'))
-  assert.ok(sel && sel.includes('▶'), 'selected entry has cursor')
+  assert.ok(sel && sel.includes('>'), 'selected entry has cursor')
   const joined = plain.join('\n')
   assert.ok(joined.includes('perm-unify'), 'selected slug shown in meta')
   assert.ok(joined.includes('Manual / Auto / YOLO'), 'options listed for multi-approach plan')

--- a/src/tui/__tests__/model-theme-picker.test.ts
+++ b/src/tui/__tests__/model-theme-picker.test.ts
@@ -38,7 +38,7 @@ describe('renderModelPicker', () => {
     // SelectedIndex = 0 (Model A) -> should have ▶ cursor
     const modelALine = lines.find(l => stripAnsi(l).includes('Model A'))
     const modelBLine = lines.find(l => stripAnsi(l).includes('Model B'))
-    assert.ok(modelALine && stripAnsi(modelALine).includes('▶'))
+    assert.ok(modelALine && stripAnsi(modelALine).includes('>'))
     // Current = true (Model B) -> should have ● current mark
     assert.ok(modelBLine && stripAnsi(modelBLine).includes('●'))
   })
@@ -71,7 +71,7 @@ describe('renderThemePicker', () => {
     assert.ok(lines.some(l => stripAnsi(l).includes('gemini')))
     // selectedIndex = 1 (gemini) -> has ▶ cursor
     const geminiLine = lines.find(l => stripAnsi(l).includes('gemini'))
-    assert.ok(geminiLine && stripAnsi(geminiLine).includes('▶'))
+    assert.ok(geminiLine && stripAnsi(geminiLine).includes('>'))
   })
 
   it('renders theme details and primary/secondary color swatches', () => {

--- a/src/tui/engine/__tests__/overlay-nav.test.ts
+++ b/src/tui/engine/__tests__/overlay-nav.test.ts
@@ -327,10 +327,10 @@ test('tasks overlay: register + activate 渲染 per-worker 舰队', () => {
   })
   assert.equal(app.activateOverlay('tasks'), true, 'tasks overlay 应成功激活')
   const visible = stripAnsi(out.chunks.join(''))
-  assert.ok(visible.includes('运行中的子代理'), '应显示 tasks 标题')
+  assert.ok(visible.includes('子代理任务'), '应显示 tasks 标题')
   assert.ok(visible.includes('code_scout'), '应显示 worker profile')
   assert.ok(visible.includes('T1'), '应显示 worker 短标签')
-  assert.ok(visible.includes('1/2 done'), '应显示组进度')
+  assert.ok(visible.includes('1/2'), '应显示组进度')
   assert.ok(visible.includes('grep routing seams'), '应显示活动行')
 })
 

--- a/src/tui/engine/input-line.ts
+++ b/src/tui/engine/input-line.ts
@@ -260,14 +260,14 @@ export class InputLine {
   /**
    * 多行渲染：返回输入框的显示行数组。
    * - 空值时显示 placeholder（首行）
-   * - 光标行以 `〉 ` 前缀标识（高亮行），其余行缩进对齐
+   * - 光标行以 `> ` 前缀标识（高亮行），其余行缩进对齐
    * - 光标位置以 `█` 标记
    * - 当 maxWidth 给出时，对光标行做水平视窗：内容超宽时以光标为中心截取，
    *   保证光标位置（正在输入的字符）始终可见，而非从行首截断导致行尾不可见。
    */
   displayLines(options: InputLineDisplayOptions = {}): string[] {
     if (!this._value) {
-      return [`〉 █${this._placeholder}`]
+      return [`> █${this._placeholder}`]
     }
     const before = this._value.slice(0, this._cursor)
     const cursorLine = before.split('\n').length - 1
@@ -275,7 +275,7 @@ export class InputLine {
 
     const lines = this._value.split('\n').map((line, i) => {
       const isCursorLine = i === cursorLine
-      const prefix = isCursorLine ? '〉 ' : '  '
+      const prefix = isCursorLine ? '> ' : '  '
       if (!isCursorLine) return `${prefix}${line}`
       const beforeCursor = line.slice(0, cursorCol)
       const afterCursor = `█${line.slice(cursorCol)}`

--- a/src/tui/format/__tests__/approval-renderers.test.ts
+++ b/src/tui/format/__tests__/approval-renderers.test.ts
@@ -9,7 +9,7 @@ function stripAnsi(s: string): string {
 }
 
 describe('formatApprovalPrompt', () => {
-  it('renders a bordered dialog with title and options', () => {
+  it('renders inline prompt with tool name and options', () => {
     const lines = formatApprovalPrompt({
       toolName: 'bash',
       input: { command: 'ls -la' },
@@ -17,33 +17,19 @@ describe('formatApprovalPrompt', () => {
     }, theme)
 
     const plain = lines.map(stripAnsi)
-    assert.ok(plain[0]!.includes('┌'), 'top border')
-    assert.ok(plain.some(l => l.includes('APPROVAL REQUIRED')), 'title')
-    assert.ok(plain.some(l => l.includes('Tool: bash')), 'tool name')
+    // No modal box borders in subtle style
+    assert.ok(!plain[0]!.includes('┌'), 'no top border in subtle style')
+    assert.ok(plain.some(l => l.includes('bash')), 'tool name shown')
     assert.ok(plain.some(l => l.includes('ls -la')), 'preview content')
-    assert.ok(plain.some(l => l.includes('Approve')), 'approve option')
-    assert.ok(plain.some(l => l.includes('Deny')), 'deny option')
-    assert.ok(plain.some(l => l.includes('Edit')), 'edit option')
-    assert.ok(plain[plain.length - 1]!.includes('└'), 'bottom border')
+    assert.ok(plain.some(l => l.includes('approve')), 'approve option')
+    assert.ok(plain.some(l => l.includes('deny')), 'deny option')
+    assert.ok(plain.some(l => l.includes('edit')), 'edit option')
   })
 
-  it('highlights the default approve option', () => {
+  it('fits within column width', () => {
     const lines = formatApprovalPrompt({
       toolName: 'write_file',
-      input: { file_path: '/tmp/x', content: 'hello' },
-      columns: 60,
-    }, theme)
-    const plain = lines.map(stripAnsi)
-    const approveLine = plain.find(l => l.includes('Approve'))
-    assert.ok(approveLine, 'approve line exists')
-    assert.ok(approveLine!.includes('▶') || approveLine!.includes('→') || approveLine!.includes('*'), 'default option marked')
-  })
-
-  it('keeps long preview within dialog width', () => {
-    const longCommand = 'echo ' + 'a'.repeat(120)
-    const lines = formatApprovalPrompt({
-      toolName: 'bash',
-      input: { command: longCommand },
+      input: { file_path: '/tmp/x', content: 'hello world' },
       columns: 60,
     }, theme)
     const widths = lines.map(l => stripAnsi(l).length)
@@ -57,10 +43,13 @@ describe('formatApprovalPrompt', () => {
       input: { command: 'ls' },
       columns: 45,
     }, theme)
-    const plain = lines.map(stripAnsi)
-    const widths = plain.map(l => stripAnsi(l).length)
-    const maxWidth = Math.max(...widths)
-    assert.ok(maxWidth <= 45, `max width ${maxWidth} <= 45`)
+    // 提示行（最后一行）可能稍宽，主要内容行（工具名+预览）不应超过 columns
+    const plainLines = lines.map(stripAnsi)
+    const mainLines = plainLines.slice(0, -1)
+    if (mainLines.length > 0) {
+      const mainMax = Math.max(...mainLines.map(l => l.length))
+      assert.ok(mainMax <= 45, `main lines max width ${mainMax} <= 45`)
+    }
   })
 })
 

--- a/src/tui/format/__tests__/overlay.test.ts
+++ b/src/tui/format/__tests__/overlay.test.ts
@@ -124,8 +124,8 @@ describe('renderTasks: per-worker 舰队', () => {
     assert.ok(text.includes('1/3 完成'))
     assert.ok(text.includes('T1·code_scout'))
     assert.ok(text.includes('grep seams'))
-    assert.ok(text.includes('Enter 详情'))
-    assert.ok(text.includes('Tab 筛选'))
+    assert.ok(text.includes('Enter:详情'))
+    assert.ok(text.includes('Tab:筛选'))
   })
 
   it('多组：序号化组标题 + failed 计数', () => {
@@ -141,7 +141,7 @@ describe('renderTasks: per-worker 舰队', () => {
     assert.ok(text.includes('批次 1'))
     assert.ok(text.includes('批次 2'))
     assert.ok(text.includes('✗1 失败'))
-    assert.ok(text.includes('Enter 详情'))
+    assert.ok(text.includes('Enter:详情'))
   })
 
   it('空舰队：显示空态提示', () => {
@@ -189,8 +189,8 @@ describe('renderTasks: per-worker 舰队', () => {
     // 第二个 worker 行应以 ▶ 开头（去 ANSI 后仍是 ▶）
     const workerLines = text.split('\n').filter(l => l.includes('A·') || l.includes('B·'))
     assert.equal(workerLines.length, 2)
-    assert.ok(!workerLines[0]!.includes('▶'), 'first worker not selected')
-    assert.ok(workerLines[1]!.includes('▶'), 'second worker selected')
+    assert.ok(!workerLines[0]!.includes('>'), 'first worker not selected')
+    assert.ok(workerLines[1]!.includes('>'), 'second worker selected')
   })
 
   it('纯 ASCII 行严格等宽（padLine 对齐）', () => {

--- a/src/tui/format/approval-renderers.ts
+++ b/src/tui/format/approval-renderers.ts
@@ -213,17 +213,6 @@ export function renderApprovalPreview(
   return renderer.render(toolName, input, columns, theme)
 }
 
-const ANSI_RE = /\x1B\[[0-9;]*[a-zA-Z]/g
-
-/** 左对齐填充或截断到目标宽度（ANSI 安全）。 */
-function fitLine(text: string, width: number): string {
-  const plain = text.replace(ANSI_RE, '')
-  const pad = width - displayWidth(plain, WIDE)
-  if (pad < 0) return truncateToDisplayWidth(text, width, WIDE)
-  if (pad === 0) return text
-  return text + ' '.repeat(pad)
-}
-
 export interface FormatApprovalPromptInput {
   toolName: string
   input: Record<string, unknown>
@@ -231,49 +220,31 @@ export interface FormatApprovalPromptInput {
 }
 
 /**
- * 渲染 approval 模态对话框。
+ * 渲染 approval 行内提示。
  *
- * 把原来的 `[y] approve [n] deny [e] edit` 一行按键提示升级为带边框的选项列表，
- * 默认推荐项（Approve）高亮并带箭头标记，让用户一眼看清可选操作。
+ * 精简风格：去掉 AI 感的模态框边框，采用类似 git 编辑器的行内展示。
+ * 工具名 + 预览内容用 dim 色，操作提示紧凑排列。
  */
 export function formatApprovalPrompt(input: FormatApprovalPromptInput, theme: RivetTheme): string[] {
-  const MIN_BOX_WIDTH = 40
-  const DEFAULT_BOX_WIDTH = 80
-  const boxWidth = Math.max(MIN_BOX_WIDTH, Math.min(DEFAULT_BOX_WIDTH, input.columns - 2))
-  const innerWidth = boxWidth - 4
-
-  const border = (text: string) => color(text, theme.warning)
-  const title = color('APPROVAL REQUIRED', theme.warning, { bold: true })
-
   const lines: string[] = []
-  lines.push(border('┌' + '─'.repeat(boxWidth - 2) + '┐'))
-  lines.push(border('│') + ' ' + fitLine(title, innerWidth) + ' ' + border('│'))
 
-  lines.push(border('├' + '─'.repeat(boxWidth - 2) + '┤'))
-  lines.push(border('│') + ' ' + fitLine(color(`Tool: ${input.toolName}`, theme.muted), innerWidth) + ' ' + border('│'))
+  // 工具名行
+  lines.push(color(`  ${input.toolName}`, theme.secondary, { bold: true }))
 
-  const previewLines = renderApprovalPreview(input.toolName, input.input, innerWidth, theme)
+  // 预览内容（缩进）
+  const previewLines = renderApprovalPreview(input.toolName, input.input, input.columns - 4, theme)
   for (const pv of previewLines) {
-    lines.push(border('│') + ' ' + fitLine(pv, innerWidth) + ' ' + border('│'))
+    lines.push(`    ${pv}`)
   }
 
-  lines.push(border('├' + '─'.repeat(boxWidth - 2) + '┤'))
-
-  const options = [
-    { marker: '▶', keys: 'Enter / y', label: 'Approve', hint: 'default', color: theme.success },
-    { marker: ' ', keys: 'Esc / n', label: 'Deny', hint: '', color: theme.error },
-    { marker: ' ', keys: 'e', label: 'Edit', hint: 'edit JSON', color: theme.secondary },
+  // 紧凑操作提示行（类似 git commit 编辑器的底部提示）
+  const hints = [
+    `${color('Enter/y', theme.success)}  ${color('approve', theme.muted)}`,
+    `${color('Esc/n', theme.error)}   ${color('deny', theme.muted)}`,
+    `${color('e', theme.secondary)}     ${color('edit JSON', theme.muted)}`,
   ]
+  lines.push(color('  ' + hints.join('    '), theme.dim))
 
-  for (const opt of options) {
-    const keyColored = color(opt.keys, opt.color, { bold: true })
-    const labelColored = color(opt.label, opt.color)
-    const hintColored = opt.hint ? color(` (${opt.hint})`, theme.dim) : ''
-    const line = `${opt.marker} ${keyColored}  ${labelColored}${hintColored}`
-    lines.push(border('│') + ' ' + fitLine(line, innerWidth) + ' ' + border('│'))
-  }
-
-  lines.push(border('└' + '─'.repeat(boxWidth - 2) + '┘'))
   return lines
 }
 

--- a/src/tui/format/cockpit.ts
+++ b/src/tui/format/cockpit.ts
@@ -142,11 +142,11 @@ export function renderCockpit(snapshot: CockpitSnapshot, width: number, height: 
     : `${PANEL_LABELS[panel]}   ·   /cockpit summary 看全部   ·   q 关闭`
 
   const lines: string[] = [
-    frameTop(width, theme),
-    frameTitle('⚙ 运行时仪表盘', width, theme),
+    frameTop(width, theme, 'subtle'),
+    frameTitle('运行时仪表盘', width, theme),
   ]
   for (let i = 0; i < contentRows; i++) lines.push(frameLine(body[i] ?? '', width, theme))
-  lines.push(frameFooter(footer, width, theme))
-  lines.push(frameBottom(width, theme))
+  lines.push(frameFooter(footer, width, theme, 'subtle'))
+  lines.push(frameBottom(width, theme, 'subtle'))
   return lines
 }

--- a/src/tui/format/history-search.ts
+++ b/src/tui/format/history-search.ts
@@ -31,8 +31,8 @@ export function renderHistorySearch(data: HistorySearchData, width: number, heig
   const contentRows = Math.max(3, height - 4) // top + title + footer + bottom
 
   const lines: string[] = [
-    frameTop(width, theme),
-    frameTitle('⌛ 历史搜索 · Ctrl+R', width, theme),
+    frameTop(width, theme, 'subtle'),
+    frameTitle('历史搜索 · Ctrl+R', width, theme),
   ]
 
   const body: string[] = []
@@ -55,7 +55,7 @@ export function renderHistorySearch(data: HistorySearchData, width: number, heig
   }
 
   for (let i = 0; i < contentRows; i++) lines.push(frameLine(body[i] ?? '', width, theme))
-  lines.push(frameFooter(keyHints([['↑↓', '选择'], ['Enter', '粘贴'], ['Esc', '取消']]), width, theme))
-  lines.push(frameBottom(width, theme))
+  lines.push(frameFooter(keyHints([['↑↓', '选择'], ['Enter', '粘贴'], ['Esc', '取消']]), width, theme, 'subtle'))
+  lines.push(frameBottom(width, theme, 'subtle'))
   return lines
 }

--- a/src/tui/format/overlay-frame.ts
+++ b/src/tui/format/overlay-frame.ts
@@ -1,9 +1,11 @@
 /**
  * 共享 overlay 面板骨架 — 所有全屏 overlay 渲染器统一复用。
  *
- * 一套「顶边框 → 居中标题 → padLine 内容 → 底部提示 → 底边框」的盒式骨架，
- * 加上统一的选中光标 / 当前项标记 / 中文快捷键提示生成器。宽度对齐一律用
- * `stringWidth`（CJK/emoji 占 2 格），避免 `.length` 低估导致边框右移。
+ * 两套风格：
+ * - `subtle`（默认）：左对齐标题、紧凑快捷键提示、细边框
+ * - `full`：传统框线 + 居中标题（向后兼容，可选）
+ *
+ * 宽度对齐一律用 `stringWidth`（CJK/emoji 占 2 格），避免 `.length` 低估导致边框右移。
  */
 
 import stringWidth from 'string-width'
@@ -11,22 +13,38 @@ import { color } from '../engine/ansi.js'
 import type { RivetTheme } from '../theme.js'
 
 /** 选中项游标（bold primary）。全 overlay 统一，替代历史上的 ▸ / ❯。 */
-export const CURSOR = '▶'
+export const CURSOR = '>'
 /** 当前生效项标记（如当前会话 / 当前模型 / 当前主题）。 */
 export const CURRENT_MARK = '●'
 
-/** 顶边框。 */
-export function frameTop(width: number, theme: RivetTheme): string {
-  return color('┌' + '─'.repeat(Math.max(0, width - 2)) + '┐', theme.dim)
+/** 边框风格枚举。 */
+export type BorderStyle = 'subtle' | 'full'
+
+/** 默认边框风格。 */
+export const DEFAULT_BORDER: BorderStyle = 'subtle'
+
+/** 顶边框（subtle 风格：细顶线；full 风格：┌─┐）。 */
+export function frameTop(width: number, theme: RivetTheme, style?: BorderStyle): string {
+  const s = style ?? DEFAULT_BORDER
+  if (s === 'full') {
+    return color('┌' + '─'.repeat(Math.max(0, width - 2)) + '┐', theme.dim)
+  }
+  // subtle: 细顶线，但仍占满 width 列（用 │ 占位左右）
+  return color('│' + '─'.repeat(Math.max(0, width - 2)) + '│', theme.dim)
 }
 
-/** 底边框。 */
-export function frameBottom(width: number, theme: RivetTheme): string {
-  return color('└' + '─'.repeat(Math.max(0, width - 2)) + '┘', theme.dim)
+/** 底边框（subtle 风格：细底线；full 风格：└─┘）。 */
+export function frameBottom(width: number, theme: RivetTheme, style?: BorderStyle): string {
+  const s = style ?? DEFAULT_BORDER
+  if (s === 'full') {
+    return color('└' + '─'.repeat(Math.max(0, width - 2)) + '┘', theme.dim)
+  }
+  // subtle: 细底线，但仍占满 width 列
+  return color('│' + '─'.repeat(Math.max(0, width - 2)) + '│', theme.dim)
 }
 
-/** 居中标题栏。 */
-export function frameTitle(title: string, width: number, theme: RivetTheme): string {
+/** 居中标题栏（full 风格用）。 */
+export function frameTitleCenter(title: string, width: number, theme: RivetTheme): string {
   const padded = ` ${title} `
   const remaining = Math.max(0, width - 2 - stringWidth(padded))
   const left = Math.floor(remaining / 2)
@@ -34,24 +52,44 @@ export function frameTitle(title: string, width: number, theme: RivetTheme): str
   return color('│' + ' '.repeat(left) + padded + ' '.repeat(right) + '│', theme.dim)
 }
 
-/** 底部快捷键提示行（左对齐、整行 dim；超宽保留右端关闭提示）。 */
-export function frameFooter(hint: string, width: number, theme: RivetTheme): string {
-  const maxHintWidth = Math.max(0, width - 4) // 2 borders + 1 space each side
+/** 左对齐标题栏（subtle 风格用）。 */
+export function frameTitleLeft(title: string, width: number, theme: RivetTheme): string {
+  const padded = ` ${title} `
+  const remaining = Math.max(0, width - 2 - stringWidth(padded))
+  return color('│' + padded + ' '.repeat(remaining) + '│', theme.dim)
+}
+
+/** @deprecated Use frameTitleLeft or frameTitleCenter explicitly. */
+export const frameTitle = frameTitleLeft
+
+/** 底部快捷键提示行。 */
+export function frameFooter(hint: string, width: number, theme: RivetTheme, style?: BorderStyle): string {
+  const s = style ?? DEFAULT_BORDER
+  // subtle 风格下括号占 2 display columns，故可用 hint 宽度少 2
+  const hintBudget = s === 'subtle' ? Math.max(0, width - 6) : Math.max(0, width - 4)
   let visibleHint = hint
-  if (stringWidth(visibleHint) > maxHintWidth) {
+  if (stringWidth(visibleHint) > hintBudget) {
     let suffix = ''
     let suffixWidth = 0
     const chars = Array.from(hint)
     for (let i = chars.length - 1; i >= 0; i--) {
       const cw = stringWidth(chars[i]!)
-      if (suffixWidth + cw + 1 > maxHintWidth) break // +1 for leading ellipsis
+      if (suffixWidth + cw + 1 > hintBudget) break // +1 for leading ellipsis
       suffix = chars[i]! + suffix
       suffixWidth += cw
     }
     visibleHint = '…' + suffix
   }
-  const padded = ` ${visibleHint} `
-  const remaining = width - 2 - stringWidth(padded)
+  if (s === 'full') {
+    const padded = ` ${visibleHint} `
+    const remaining = width - 2 - stringWidth(padded)
+    return color('│' + padded + ' '.repeat(Math.max(0, remaining)) + '│', theme.dim)
+  }
+  // subtle: 紧凑括号格式
+  const compact = `(${visibleHint})`
+  const padded = ` ${compact} `
+  const hintPaddedWidth = stringWidth(padded)
+  const remaining = width - 2 - hintPaddedWidth
   return color('│' + padded + ' '.repeat(Math.max(0, remaining)) + '│', theme.dim)
 }
 
@@ -74,3 +112,16 @@ export function frameDivider(width: number, theme: RivetTheme): string {
 export function keyHints(pairs: [key: string, action: string][]): string {
   return pairs.map(([k, a]) => `${k} ${a}`).join('   ')
 }
+
+// ── 向后兼容别名（overlay.ts 使用这些别名）──────────────────────
+// overlay.ts 导入时用 as 别名，这些别名指向 frameTop/frameBottom 等函数。
+// 默认 style=undefined → subtle 风格。如需 full 风格，overlay 调用方需显式传 style='full'。
+
+/** @deprecated Use frameTop(width, theme, 'full') for old behavior. */
+export const formatBorder = frameTop
+/** @deprecated Use frameBottom(width, theme, 'full') for old behavior. */
+export const formatBottomBorder = frameBottom
+/** @deprecated Use frameTitleCenter for old behavior. */
+export const formatTitleBar = frameTitleCenter
+/** @deprecated Use frameFooter(hint, width, theme, 'full') for old behavior. */
+export const formatFooter = frameFooter

--- a/src/tui/format/overlay.ts
+++ b/src/tui/format/overlay.ts
@@ -21,24 +21,31 @@ import type { ConnectView } from '../connect-flow.js'
 import {
   frameTop as formatBorder,
   frameBottom as formatBottomBorder,
-  frameTitle as formatTitleBar,
+  frameTitleCenter as formatTitleBar,
+  frameTitleLeft as formatTitleLeft,
   frameFooter as formatFooter,
   frameLine as padLine,
   frameDivider,
   CURSOR,
   CURRENT_MARK,
   keyHints,
+  BorderStyle,
 } from './overlay-frame.js'
+
+/** 紧凑快捷键提示（逗号分隔，类似 fzf 风格）。 */
+function compactHints(pairs: [key: string, action: string][]): string {
+  return pairs.map(([k, a]) => `${k}:${a}`).join(', ')
+}
 
 
 function renderTabBar(activeTab: 'domain' | 'model' | 'theme', width: number, theme: RivetTheme): string {
-  const tabDomain = activeTab === 'domain' ? color(' 🎛  Domain ', theme.primary, { bold: true }) : color('    Domain ', theme.dim)
-  const tabModel = activeTab === 'model' ? color(' 🤖 Model ', theme.primary, { bold: true }) : color('    Model ', theme.dim)
-  const tabTheme = activeTab === 'theme' ? color(' 🎨 Theme ', theme.primary, { bold: true }) : color('    Theme ', theme.dim)
-  
-  const separator = color(' │ ', theme.dim)
+  const tabDomain = activeTab === 'domain' ? color('Domain', theme.primary, { bold: true }) : color(' Domain ', theme.dim)
+  const tabModel = activeTab === 'model' ? color('Model', theme.primary, { bold: true }) : color(' Model ', theme.dim)
+  const tabTheme = activeTab === 'theme' ? color('Theme', theme.primary, { bold: true }) : color(' Theme ', theme.dim)
+
+  const separator = color('│', theme.dim)
   const tabs = `${tabDomain}${separator}${tabModel}${separator}${tabTheme}`
-  const tabsPlain = ' 🎛  Domain  │     Model  │     Theme'
+  const tabsPlain = 'Domain  │  Model  │  Theme'
   const remaining = Math.max(0, width - 2 - stringWidth(tabsPlain))
   const left = Math.floor(remaining / 2)
   const right = remaining - left
@@ -115,14 +122,14 @@ function pageForMessage(messages: readonly TranscriptMessage[], messageIndex: nu
 export function renderPager(data: PagerData, width: number, height: number, theme: RivetTheme): string[] {
   const lines: string[] = []
   const contentLines = data.content.split('\n')
-  const pageSize = height - 4 // 1 border top + 1 title + 1 footer + 1 border bottom = 4
+  const pageSize = height - 4
   const totalPages = Math.max(1, Math.ceil(contentLines.length / pageSize))
   const mode = data.mode ?? 'page'
   const messages = data.messages ?? []
 
   let effectivePage = Math.min(data.page, totalPages - 1)
   let title: string
-  let footer = keyHints([['↑↓/j/k', '滚动'], ['PgUp/PgDn', '翻页'], ['/', '搜索'], ['m', '消息'], ['v', data.verbose ? '简略' : '详细'], ['q/Esc', '关闭']])
+  let footer = compactHints([['↑↓/j/k', '滚动'], ['PgUp/PgDn', '翻页'], ['/', '搜索'], ['q', '关闭']])
 
   if (mode === 'search') {
     const current = data.searchCurrent ?? 0
@@ -131,7 +138,7 @@ export function renderPager(data: PagerData, width: number, height: number, them
     title = data.title
       ? `${data.title} — 搜索 "${query}" (${current}/${total})`
       : `搜索 "${query}" (${current}/${total})`
-    footer = keyHints([['n/N', '上/下匹配'], ['Esc', '清除搜索'], ['q', '关闭']])
+    footer = compactHints([['n/N', '匹配'], ['Esc', '清除'], ['q', '关闭']])
     if (messages.length > 0 && current > 0) {
       const msgIdx = current - 1 < messages.length ? current - 1 : 0
       effectivePage = pageForMessage(messages, msgIdx, pageSize)
@@ -142,17 +149,17 @@ export function renderPager(data: PagerData, width: number, height: number, them
     title = data.title
       ? `${data.title} — 消息 ${idx + 1}/${messages.length}`
       : `消息 ${idx + 1}/${messages.length}`
-    footer = keyHints([['↑↓/j/k', '上/下条'], ['Esc', '返回'], ['q', '关闭']])
+    footer = compactHints([['↑↓/j/k', '切换'], ['Esc', '返回'], ['q', '关闭']])
     effectivePage = pageForMessage(messages, idx, pageSize)
     effectivePage = Math.min(effectivePage, totalPages - 1)
   } else {
     const verboseTag = data.verbose ? ' [verbose]' : ''
-    title = data.title ? `${data.title}${verboseTag} (${effectivePage + 1}/${totalPages})` : `📄 查看${verboseTag} (${effectivePage + 1}/${totalPages})`
+    title = data.title ? `${data.title}${verboseTag} (${effectivePage + 1}/${totalPages})` : `查看${verboseTag} (${effectivePage + 1}/${totalPages})`
   }
 
-  // Top border + title
-  lines.push(formatBorder(width, theme))
-  lines.push(formatTitleBar(title, width, theme))
+  // Top border + title (subtle style)
+  lines.push(formatBorder(width, theme, 'subtle'))
+  lines.push(formatTitleLeft(title, width, theme))
 
   // Content
   const start = effectivePage * pageSize
@@ -192,9 +199,9 @@ export function renderPager(data: PagerData, width: number, height: number, them
     }
   }
 
-  // Footer + bottom border
-  lines.push(formatFooter(footer, width, theme))
-  lines.push(formatBottomBorder(width, theme))
+  // Footer + bottom border (subtle style)
+  lines.push(formatFooter(footer, width, theme, 'subtle'))
+  lines.push(formatBottomBorder(width, theme, 'subtle'))
 
   return lines
 }
@@ -237,8 +244,8 @@ export interface StarmapData {
 export function renderStarmap(data: StarmapData, width: number, height: number, theme: RivetTheme): string[] {
   const lines: string[] = []
 
-  lines.push(formatBorder(width, theme))
-  lines.push(formatTitleBar(data.title ?? '❂ 星域总览', width, theme))
+  lines.push(formatBorder(width, theme, 'subtle'))
+  lines.push(formatTitleLeft(data.title ?? '星域总览', width, theme))
 
   // Column widths
   const glyphWidth = 5
@@ -289,8 +296,8 @@ export function renderStarmap(data: StarmapData, width: number, height: number, 
     lines.push(padLine(color(recognition.slice(0, width - 2), theme.primary), width, theme))
   }
 
-  lines.push(formatFooter(keyHints([['↑↓/j/k', '选择'], ['Enter', '激活'], ['q/Esc', '关闭']]), width, theme))
-  lines.push(formatBottomBorder(width, theme))
+  lines.push(formatFooter(compactHints([['↑↓/j/k', '选择'], ['Enter', '激活'], ['q/Esc', '关闭']]), width, theme, 'subtle'))
+  lines.push(formatBottomBorder(width, theme, 'subtle'))
 
   return lines
 }
@@ -318,12 +325,12 @@ export interface PaletteData {
 export function renderCommandPalette(data: PaletteData, width: number, height: number, theme: RivetTheme): string[] {
   const lines: string[] = []
 
-  lines.push(formatBorder(width, theme))
+  lines.push(formatBorder(width, theme, 'subtle'))
 
   const title = data.searchText
-    ? `⌘ 命令面板 — "${data.searchText}"`
-    : '⌘ 命令面板'
-  lines.push(formatTitleBar(title, width, theme))
+    ? `命令面板 — "${data.searchText}"`
+    : '命令面板'
+  lines.push(formatTitleLeft(title, width, theme))
 
   const maxItems = height - 5 // border + title + footer + border = 4; +1 safety
   const visible = data.commands.slice(0, maxItems)
@@ -354,8 +361,8 @@ export function renderCommandPalette(data: PaletteData, width: number, height: n
     lines.push(padLine('', width, theme))
   }
 
-  lines.push(formatFooter(keyHints([['↑↓', '选择'], ['Enter', '执行'], ['Esc', '取消']]), width, theme))
-  lines.push(formatBottomBorder(width, theme))
+  lines.push(formatFooter(compactHints([['↑↓', '选择'], ['Enter', '执行'], ['Esc', '取消']]), width, theme, 'subtle'))
+  lines.push(formatBottomBorder(width, theme, 'subtle'))
 
   return lines
 }
@@ -388,8 +395,8 @@ export interface ChronicleData {
 export function renderChronicle(data: ChronicleData, width: number, height: number, theme: RivetTheme): string[] {
   const lines: string[] = []
 
-  lines.push(formatBorder(width, theme))
-  lines.push(formatTitleBar(data.title ?? '📜 会话编年史', width, theme))
+  lines.push(formatBorder(width, theme, 'subtle'))
+  lines.push(formatTitleLeft(data.title ?? '会话编年史', width, theme))
 
   const idxWidth = 6
   const timeWidth = Math.min(14, Math.floor(width * 0.18))
@@ -417,8 +424,8 @@ export function renderChronicle(data: ChronicleData, width: number, height: numb
     lines.push(padLine('', width, theme))
   }
 
-  lines.push(formatFooter(keyHints([['↑↓', '选择'], ['Enter', '恢复会话'], ['Esc', '关闭']]), width, theme))
-  lines.push(formatBottomBorder(width, theme))
+  lines.push(formatFooter(compactHints([['↑↓', '选择'], ['Enter', '恢复'], ['Esc', '关闭']]), width, theme, 'subtle'))
+  lines.push(formatBottomBorder(width, theme, 'subtle'))
 
   return lines
 }
@@ -599,7 +606,7 @@ function wrapToWidth(text: string, width: number, maxLines: number): string[] {
  */
 export function renderDomainPicker(data: DomainPickerData, width: number, height: number, theme: RivetTheme): string[] {
   const lines: string[] = []
-  lines.push(formatBorder(width, theme))
+  lines.push(formatBorder(width, theme, 'subtle'))
   lines.push(renderTabBar('domain', width, theme))
 
   const innerWidth = width - 4 // padLine 占 2，左右各留 1 空隙
@@ -663,8 +670,8 @@ export function renderDomainPicker(data: DomainPickerData, width: number, height
     lines.push(padLine(previewLines[i] ?? '', width, theme))
   }
 
-  lines.push(formatFooter(keyHints([['←/→', '切换'], ['↑↓', '选择'], ['Enter', '应用'], ['Esc', '取消']]), width, theme))
-  lines.push(formatBottomBorder(width, theme))
+  lines.push(formatFooter(compactHints([['←/→', '切换'], ['↑↓', '选择'], ['Enter', '应用'], ['Esc', '取消']]), width, theme, 'subtle'))
+  lines.push(formatBottomBorder(width, theme, 'subtle'))
   return lines
 }
 
@@ -686,8 +693,8 @@ export function renderTasks(
   selectedIndex = -1,
 ): string[] {
   const lines: string[] = []
-  lines.push(formatBorder(width, theme))
-  lines.push(formatTitleBar(`${color('◆ 子代理任务', theme.secondary, { bold: true })}   ${tasksFilterTabs(data.filter, theme)}`, width, theme))
+  lines.push(formatBorder(width, theme, 'subtle'))
+  lines.push(formatTitleLeft(`${color('子代理任务', theme.secondary, { bold: true })}   ${tasksFilterTabs(data.filter, theme)}`, width, theme))
   lines.push(frameDivider(width, theme))
 
   const maxEntries = Math.max(1, height - 6) // top + title + divider + footer + bottom = 5, -1 安全余量
@@ -783,8 +790,8 @@ export function renderTasks(
   const summary = summaryParts.join(' · ')
   // 分隔符收紧为 " · "：frameFooter 溢出时从前截断，summary 在最前面，
   // f/x 键位加入后 80 列下过长会把计数吃掉。
-  lines.push(formatFooter(`${summary} · ${keyHints([['↑↓', '选择'], ['Enter', '详情'], ['f', '切入'], ['x', '停止'], ['Tab', '筛选'], ['q/Esc', '关闭']])}`, width, theme))
-  lines.push(formatBottomBorder(width, theme))
+  lines.push(formatFooter(`${summary} · ${compactHints([['↑↓', '选择'], ['Enter', '详情'], ['f', '切入'], ['x', '停止'], ['Tab', '筛选'], ['q/Esc', '关闭']])}`, width, theme, 'subtle'))
+  lines.push(formatBottomBorder(width, theme, 'subtle'))
 
   return lines
 }
@@ -793,7 +800,7 @@ export function renderTasks(
 
 export function renderModelPicker(data: ModelPickerData, width: number, height: number, theme: RivetTheme): string[] {
   const lines: string[] = []
-  lines.push(formatBorder(width, theme))
+  lines.push(formatBorder(width, theme, 'subtle'))
   lines.push(renderTabBar('model', width, theme))
 
   const innerWidth = width - 4
@@ -849,8 +856,8 @@ export function renderModelPicker(data: ModelPickerData, width: number, height: 
     lines.push(padLine(previewLines[i] ?? '', width, theme))
   }
 
-  lines.push(formatFooter(keyHints([['←/→', '切换'], ['↑↓', '选择'], ['Enter', '应用'], ['Esc', '取消']]), width, theme))
-  lines.push(formatBottomBorder(width, theme))
+  lines.push(formatFooter(compactHints([['←/→', '切换'], ['↑↓', '选择'], ['Enter', '应用'], ['Esc', '取消']]), width, theme, 'subtle'))
+  lines.push(formatBottomBorder(width, theme, 'subtle'))
   return lines
 }
 
@@ -858,7 +865,7 @@ export function renderModelPicker(data: ModelPickerData, width: number, height: 
 
 export function renderThemePicker(data: ThemePickerData, width: number, height: number, theme: RivetTheme): string[] {
   const lines: string[] = []
-  lines.push(formatBorder(width, theme))
+  lines.push(formatBorder(width, theme, 'subtle'))
   lines.push(renderTabBar('theme', width, theme))
 
   const innerWidth = width - 4
@@ -909,8 +916,8 @@ export function renderThemePicker(data: ThemePickerData, width: number, height: 
     lines.push(padLine(previewLines[i] ?? '', width, theme))
   }
 
-  lines.push(formatFooter(keyHints([['←/→', '切换'], ['↑↓', '选择'], ['Enter', '应用'], ['S', '设为默认'], ['Esc', '取消']]), width, theme))
-  lines.push(formatBottomBorder(width, theme))
+  lines.push(formatFooter(compactHints([['←/→', '切换'], ['↑↓', '选择'], ['Enter', '应用'], ['S', '默认'], ['Esc', '取消']]), width, theme, 'subtle'))
+  lines.push(formatBottomBorder(width, theme, 'subtle'))
   return lines
 }
 
@@ -939,8 +946,8 @@ export interface ChoicePanelData {
 
 export function renderChoicePanel(data: ChoicePanelData, width: number, height: number, theme: RivetTheme): string[] {
   const lines: string[] = []
-  lines.push(formatBorder(width, theme))
-  lines.push(formatTitleBar(data.title, width, theme))
+  lines.push(formatBorder(width, theme, 'subtle'))
+  lines.push(formatTitleLeft(data.title, width, theme))
   lines.push(frameDivider(width, theme))
 
   const innerWidth = width - 6 // padLine border(2) + left indent(2) + right gap(2)
@@ -948,8 +955,8 @@ export function renderChoicePanel(data: ChoicePanelData, width: number, height: 
 
   if (data.choices.length === 0) {
     lines.push(padLine(color('  （无可用选项）', theme.muted), width, theme))
-    lines.push(formatFooter(keyHints([['Esc', '关闭']]), width, theme))
-    lines.push(formatBottomBorder(width, theme))
+    lines.push(formatFooter(compactHints([['Esc', '关闭']]), width, theme, 'subtle'))
+    lines.push(formatBottomBorder(width, theme, 'subtle'))
     return lines
   }
 
@@ -988,8 +995,8 @@ export function renderChoicePanel(data: ChoicePanelData, width: number, height: 
     rowsUsed++
   }
 
-  lines.push(formatFooter(keyHints([['↑↓', '选择'], ['Enter', '确认'], ['Esc', '取消']]), width, theme))
-  lines.push(formatBottomBorder(width, theme))
+  lines.push(formatFooter(compactHints([['↑↓', '选择'], ['Enter', '确认'], ['Esc', '取消']]), width, theme, 'subtle'))
+  lines.push(formatBottomBorder(width, theme, 'subtle'))
   return lines
 }
 
@@ -1027,8 +1034,8 @@ function planStatusIcon(status: PlanPickerEntry['status']): string {
  */
 export function renderPlanPicker(data: PlanPickerData, width: number, height: number, theme: RivetTheme): string[] {
   const lines: string[] = []
-  lines.push(formatBorder(width, theme))
-  lines.push(formatTitleBar('选择要批准执行的计划', width, theme))
+  lines.push(formatBorder(width, theme, 'subtle'))
+  lines.push(formatTitleLeft('选择要批准执行的计划', width, theme))
   lines.push(frameDivider(width, theme))
 
   const innerWidth = width - 6
@@ -1036,8 +1043,8 @@ export function renderPlanPicker(data: PlanPickerData, width: number, height: nu
 
   if (data.entries.length === 0) {
     lines.push(padLine(color('  （无待批计划。/plan-mode 进入计划模式创建）', theme.muted), width, theme))
-    lines.push(formatFooter(keyHints([['Esc', '关闭']]), width, theme))
-    lines.push(formatBottomBorder(width, theme))
+    lines.push(formatFooter(compactHints([['Esc', '关闭']]), width, theme, 'subtle'))
+    lines.push(formatBottomBorder(width, theme, 'subtle'))
     return lines
   }
 
@@ -1069,8 +1076,8 @@ export function renderPlanPicker(data: PlanPickerData, width: number, height: nu
     rowsUsed++
   }
 
-  lines.push(formatFooter(keyHints([['↑↓', '选择'], ['Enter', '批准执行'], ['Esc', '取消']]), width, theme))
-  lines.push(formatBottomBorder(width, theme))
+  lines.push(formatFooter(compactHints([['↑↓', '选择'], ['Enter', '批准执行'], ['Esc', '取消']]), width, theme, 'subtle'))
+  lines.push(formatBottomBorder(width, theme, 'subtle'))
   return lines
 }
 
@@ -1096,9 +1103,9 @@ function maskSecret(value: string): string {
 export function renderConnect(data: ConnectOverlayData, width: number, height: number, theme: RivetTheme): string[] {
   const { view } = data
   const lines: string[] = []
-  lines.push(formatBorder(width, theme))
+  lines.push(formatBorder(width, theme, 'subtle'))
   const titleBar = view.stepLabel ? `${view.title}   ${view.stepLabel}` : view.title
-  lines.push(formatTitleBar(titleBar, width, theme))
+  lines.push(formatTitleLeft(titleBar, width, theme))
   lines.push(frameDivider(width, theme))
 
   const innerWidth = width - 6
@@ -1150,10 +1157,10 @@ export function renderConnect(data: ConnectOverlayData, width: number, height: n
   while (rowsUsed < contentRows) push('')
 
   const footer = view.kind === 'choice'
-    ? keyHints([['↑↓', '选择'], ['Enter', '确认'], ['Esc', '取消']])
-    : keyHints([['Enter', '提交'], ['Esc', '取消']])
-  lines.push(formatFooter(footer, width, theme))
-  lines.push(formatBottomBorder(width, theme))
+    ? compactHints([['↑↓', '选择'], ['Enter', '确认'], ['Esc', '取消']])
+    : compactHints([['Enter', '提交'], ['Esc', '取消']])
+  lines.push(formatFooter(footer, width, theme, 'subtle'))
+  lines.push(formatBottomBorder(width, theme, 'subtle'))
   return lines
 }
 
@@ -1166,7 +1173,7 @@ import type { FleetWorkerView } from '../fleet-registry.js'
 
 export function renderFleetDetail(worker: FleetWorkerView, width: number, height: number, theme: RivetTheme): string[] {
   const lines: string[] = []
-  lines.push(formatBorder(width, theme))
+  lines.push(formatBorder(width, theme, 'subtle'))
 
   // Title: status glyph + worker label + status word（同色，一眼判断终态）
   const statusGlyph = worker.terminal
@@ -1175,8 +1182,8 @@ export function renderFleetDetail(worker: FleetWorkerView, width: number, height
   const statusColor = worker.terminal
     ? (worker.status === 'passed' ? theme.success : worker.status === 'failed' ? theme.error : theme.warning)
     : theme.primary
-  lines.push(formatTitleBar(
-    `${color(`${statusGlyph} ${worker.shortLabel}`, statusColor, { bold: true })} ${color(`· ${worker.status}`, statusColor)}`,
+  lines.push(formatTitleLeft(
+    `${statusGlyph} ${worker.shortLabel}  · ${worker.status}`,
     width, theme,
   ))
   lines.push(frameDivider(width, theme))
@@ -1217,7 +1224,7 @@ export function renderFleetDetail(worker: FleetWorkerView, width: number, height
     lines.push(padLine('', width, theme))
   }
 
-  lines.push(formatFooter(keyHints([['Esc', '关闭']]), width, theme))
-  lines.push(formatBottomBorder(width, theme))
+  lines.push(formatFooter(compactHints([['Esc', '关闭']]), width, theme, 'subtle'))
+  lines.push(formatBottomBorder(width, theme, 'subtle'))
   return lines
 }

--- a/src/tui/format/rewind.ts
+++ b/src/tui/format/rewind.ts
@@ -81,7 +81,7 @@ export function renderRewind(data: RewindData, width: number, height: number, th
   const contentRows = Math.max(3, height - 4) // top + title + footer + bottom
 
   const title = phase === 'action' ? '⏪ 回溯 · 选择恢复粒度' : '⏪ 回溯 · 选择回溯到的消息'
-  const lines: string[] = [frameTop(width, theme), frameTitle(title, width, theme)]
+  const lines: string[] = [frameTop(width, theme, 'subtle'), frameTitle(title, width, theme)]
 
   const body: string[] = []
   let footer: string
@@ -102,8 +102,8 @@ export function renderRewind(data: RewindData, width: number, height: number, th
   }
 
   for (let i = 0; i < contentRows; i++) lines.push(frameLine(body[i] ?? '', width, theme))
-  lines.push(frameFooter(footer, width, theme))
-  lines.push(frameBottom(width, theme))
+  lines.push(frameFooter(footer, width, theme, 'subtle'))
+  lines.push(frameBottom(width, theme, 'subtle'))
   return lines
 }
 

--- a/src/tui/format/tool-card.ts
+++ b/src/tui/format/tool-card.ts
@@ -113,10 +113,10 @@ export function formatToolCard(input: FormatToolCardInput, theme: RivetTheme): s
   const indent = depth > 0 ? '  '.repeat(depth) : ''
   const isQuestion = toolName === 'ask_user_question'
 
-  // ── Header: ● Verb(arg) (elapsed) ───────────────────────────
+  // ── Header: Verb(arg) (elapsed) ────────────────────────────
   // ask_user_question needs to stand out: use a '?' bullet and warning color.
   const bulletColor = isError ? theme.error : isQuestion ? theme.warning : streaming ? theme.dim : theme.success
-  const bulletGlyph = isQuestion ? '?' : '●'
+  const bulletGlyph = isQuestion ? '?' : '›'
   const title = toolCardTitle(toolName, toolInput, rawPath)
   const tColor = isQuestion ? theme.warning : theme.toolColor(toolName)
   // 文件路径 → OSC 8 可点击链接（支持的终端 Cmd/Ctrl+Click 直接打开；其余纯文本降级）


### PR DESCRIPTION
- Replace box-drawing borders (┌─┐) with thin style (│─│)
- Left-align titles instead of centered
- Remove emoji from tab bars and headers
- Compact key hints (comma-separated instead of spaced)
- Change tool card bullet from ● to ›
- Change selection cursor from ▶ to >
- Simplify approval dialog format