### PR TITLE
fix: improve git detection on Windows for non-standard install paths

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1601,11 +1601,11 @@ async function main() {
   if (ctx.templatesPendingAgents && !args.includes('--dangerously-skip-permissions')) {
     // Detect git availability to advise first-run users. Git is optional (the
     // agent runs in-place without it), but unlocks worktree isolation, commit,
-    // diff review, and checkpoints. Mirrors the inline try/catch probe pattern
-    // used at main.ts:396 (gitBranch detection).
+    // diff review, and checkpoints. Use `git --version` — `git rev-parse
+    // --is-inside-work-tree` fails outside a repo even when git is installed.
     const gitAvailable = (() => {
       try {
-        execSync('git rev-parse --is-inside-work-tree', { cwd: process.cwd(), stdio: 'pipe' })
+        execSync('git --version', { cwd: process.cwd(), stdio: 'pipe' })
         return true
       } catch {
         return false

--- a/src/tools/env-check.ts
+++ b/src/tools/env-check.ts
@@ -124,9 +124,19 @@ export async function resolveGitExePath(deps: GitExeProbeDeps): Promise<string |
   const override = deps.env['RIVET_GIT_PATH']
   if (override && deps.exists(override)) return override
 
+  // 2. where git (Electron's PATH — may be truncated)
   const path = await deps.whichGit()
   if (path) return path
 
+  // 3. cmd /c where git — cmd.exe inherits the full system PATH, unlike Electron
+  //    which may miss entries only in Machine-level PATH (e.g. D:\App\Git\cmd).
+  try {
+    const { stdout } = await execFileAsync('cmd', ['/c', 'where', 'git'], { timeout: 5000 })
+    const first = stdout.split('\n')[0]?.trim()
+    if (first && deps.exists(first)) return first
+  } catch { /* fall through */ }
+
+  // 4. Common install locations (Program Files / LOCALAPPDATA)
   const candidates = [
     'C:\\Program Files\\Git\\cmd\\git.exe',
     'C:\\Program Files (x86)\\Git\\cmd\\git.exe',
@@ -137,6 +147,25 @@ export async function resolveGitExePath(deps: GitExeProbeDeps): Promise<string |
   for (const c of candidates) {
     if (deps.exists(c)) return c
   }
+
+  // 5. Scan system (Machine) PATH for git.exe — covers non-standard install
+  //    drives like D:\App\Git that aren't in the per-process PATH Electron sees.
+  try {
+    const { stdout } = await execFileAsync('cmd', ['/c', 'reg', 'query',
+      'HKLM\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment',
+      '/v', 'Path'], { timeout: 5000 })
+    const match = stdout.match(/REG_(?:EXPAND_)?SZ\s+(.+)/i)
+    if (match?.[1]) {
+      const sysPath = match[1].trim()
+      for (const dir of sysPath.split(';')) {
+        const trimmed = dir.trim()
+        if (!trimmed) continue
+        const candidate = winPath.join(trimmed, 'git.exe')
+        if (deps.exists(candidate)) return candidate
+      }
+    }
+  } catch { /* fall through */ }
+
   return undefined
 }
 


### PR DESCRIPTION
- resolveGitExePath: add cmd.exe 'where git' fallback (cmd inherits full system PATH unlike Electron) and scan Machine PATH registry for git.exe to cover non-standard install drives (e.g. D:\App\Git)
- main.ts first-run check: use 'git --version' instead of 'git rev-parse --is-inside-work-tree' which fails outside a git repo even when git is installed

## 变更摘要

<!-- 用一句话说明这个 PR 做了什么 -->

## 动机

<!-- 为什么需要这个变更？它解决了什么问题？ -->

## 主要改动

<!-- 列出关键文件与行为变化，便于 reviewer 快速定位 -->

## 测试

<!-- 如何验证的？新增/修改了哪些测试？ -->

## 检查清单

- [ ] 本地 `npm test` 通过
- [ ] `npx tsc --noEmit` 无类型错误
- [ ] 变更范围最小化，无关改动已排除
- [ ] 文档（README / 用户手册 / CHANGELOG）已同步更新

## 相关 Issue

<!-- 关联的 issue 编号，例如 Closes #123 -->
