### PR TITLE
feat(completions): add fish and Windows-shell completion scripts

### DIFF
--- a/completions/rivet.fish
+++ b/completions/rivet.fish
@@ -1,0 +1,49 @@
+# Fish completion for Rivet (rivet)
+#
+# Install: copy this file to ~/.config/fish/completions/rivet.fish
+#   (mkdir -p ~/.config/fish/completions && cp rivet.fish ~/.config/fish/completions/)
+
+# Provider names are read from ~/.rivet/config.json when available.
+function __rivet_providers
+    node -e "const os=require('os');try{const c=JSON.parse(require('fs').readFileSync(os.homedir()+'/.rivet/config.json','utf-8'));console.log(Object.keys(c.provider?.providers||{}).join('\n'));}catch{}"
+end
+
+# --- Top-level commands ---
+complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -a "config" -d "Manage API keys and model configuration"
+complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -a "serve" -d "Start the sidecar HTTP/SSE server"
+complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -a "sessions" -d "List recent sessions"
+
+# --- Top-level flags (from the user guide) ---
+complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -l help -s h -d "Show help"
+complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -l version -s v -d "Show version"
+complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -l print -s p -d "Single prompt, print and exit"
+complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -l json -d "Output a single JSON result (with -p)"
+complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -l stream-json -d "NDJSON event stream, output de-identified (CI)"
+complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -l goal -d "Headless autonomous goal mode"
+complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -l budget -d "Goal turn budget (default 100)"
+complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -l model -d "Override the model for this session"
+complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -l provider -d "Override the provider for this session"
+complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -l continue -s c -d "Resume the most recent session in cwd"
+complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -l resume -s r -d "Resume a session by id/prefix"
+complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -l new -d "Force a new session"
+complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -l list -d "List sessions and exit"
+complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -l dangerously-skip-permissions -d "Skip all approvals (YOLO)"
+complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -l screen-reader -d "Screen-reader mode"
+complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -l skip-welcome -d "Skip the welcome screen"
+complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -l stream-events -d "Mirror this run as a NDJSON SessionEvent file"
+
+# --- config subcommands ---
+complete -c rivet -n "__fish_seen_subcommand_from config" -a "show" -d "Show current configuration"
+complete -c rivet -n "__fish_seen_subcommand_from config" -a "providers" -d "List configured providers"
+complete -c rivet -n "__fish_seen_subcommand_from config" -a "set-key" -d "Set API key for a provider"
+complete -c rivet -n "__fish_seen_subcommand_from config" -a "set-key-env" -d "Set API key from an environment variable"
+complete -c rivet -n "__fish_seen_subcommand_from config" -a "set-default" -d "Set the default provider"
+complete -c rivet -n "__fish_seen_subcommand_from config" -a "add-model" -d "Add a model to a provider"
+complete -c rivet -n "__fish_seen_subcommand_from config" -a "remove-model" -d "Remove a model from a provider"
+
+# --- Provider name completion (read from ~/.rivet/config.json) ---
+complete -c rivet -n "__fish_seen_subcommand_from config set-key" -a "(__rivet_providers)" -d "Provider"
+complete -c rivet -n "__fish_seen_subcommand_from config set-key-env" -a "(__rivet_providers)" -d "Provider"
+complete -c rivet -n "__fish_seen_subcommand_from config set-default" -a "(__rivet_providers)" -d "Provider"
+complete -c rivet -n "__fish_seen_subcommand_from config add-model" -a "(__rivet_providers)" -d "Provider"
+complete -c rivet -n "__fish_seen_subcommand_from config remove-model" -a "(__rivet_providers)" -d "Provider"

--- a/completions/rivet.ps1
+++ b/completions/rivet.ps1
@@ -1,0 +1,109 @@
+# PowerShell completion for Rivet (rivet)
+#
+# Install: dot-source this file from your $PROFILE so the completer loads in every session:
+#   Add-Content $PROFILE ". $PSScriptRoot\rivet.ps1"   # or the absolute path to this file
+# Then restart PowerShell (or run `. .\rivet.ps1` once).
+
+function Get-RivetProviders {
+    $configFile = Join-Path $env:USERPROFILE ".rivet\config.json"
+    if (-not (Test-Path $configFile)) { return @() }
+    try {
+        $cfg = Get-Content $configFile -Raw | ConvertFrom-Json
+        if ($cfg.provider -and $cfg.provider.providers) {
+            return $cfg.provider.providers.PSObject.Properties.Name
+        }
+    } catch { }
+    return @()
+}
+
+# The completer scriptblock is self-contained (arrays defined inside) so it does not
+# depend on outer-scope variable resolution when invoked by the PowerShell engine.
+$rivetCompleter = {
+    param($wordToComplete, $commandAst, $cursorPosition)
+
+    $rivetTopCommands   = @('config', 'serve', 'sessions')
+    $rivetConfigCommands = @('show', 'providers', 'set-key', 'set-key-env', 'set-default', 'add-model', 'remove-model')
+    $rivetProviderVerbs  = @('set-key', 'set-key-env', 'set-default', 'add-model', 'remove-model')
+    $rivetTopFlags = @(
+        '--help', '-h', '--version', '-v',
+        '--print', '-p', '--json', '--stream-json',
+        '--goal', '--budget', '--model', '--provider',
+        '--continue', '-c', '--resume', '-r', '--new', '--list',
+        '--dangerously-skip-permissions', '--screen-reader', '--skip-welcome', '--stream-events'
+    )
+
+    # Parse the command line into tokens (works for native commands).
+    $line = $commandAst.ToString().Trim()
+    $words = $line.Split(' ', [System.StringSplitOptions]::RemoveEmptyEntries)
+
+    $result = @()
+
+    $hasConfig = $words -contains 'config'
+    if ($hasConfig) {
+        $configIdx = [array]::IndexOf($words, 'config')
+        $afterConfig = @($words[($configIdx + 1)..($words.Length - 1)] | Where-Object { $_ -and $_ -ne 'config' })
+        if ($afterConfig.Count -eq 0) {
+            # No token after `config` yet — offer every config subcommand.
+            foreach ($c in $rivetConfigCommands) {
+                if ($c -like "$wordToComplete*") {
+                    $result += [System.Management.Automation.CompletionResult]::new($c, $c, 'Command', $c)
+                }
+            }
+            return $result
+        }
+        $only = $afterConfig[0]
+        if ($afterConfig.Count -eq 1) {
+            if ($rivetProviderVerbs -contains $only) {
+                # A complete provider verb is present — next token is the provider name.
+                foreach ($p in (Get-RivetProviders)) {
+                    if ($p -like "$wordToComplete*") {
+                        $result += [System.Management.Automation.CompletionResult]::new($p, $p, 'ParameterValue', $p)
+                    }
+                }
+                return $result
+            }
+            if ($rivetConfigCommands -contains $only) {
+                # A complete subcommand with no further arguments — nothing more to offer.
+                return $result
+            }
+            # Still typing the subcommand (partial) — offer matching subcommands.
+            foreach ($c in $rivetConfigCommands) {
+                if ($c -like "$wordToComplete*") {
+                    $result += [System.Management.Automation.CompletionResult]::new($c, $c, 'Command', $c)
+                }
+            }
+            return $result
+        }
+        # Two or more tokens after `config` — the first is the verb, the rest are its args.
+        if ($rivetProviderVerbs -contains $only) {
+            foreach ($p in (Get-RivetProviders)) {
+                if ($p -like "$wordToComplete*") {
+                    $result += [System.Management.Automation.CompletionResult]::new($p, $p, 'ParameterValue', $p)
+                }
+            }
+            return $result
+        }
+        return $result
+    }
+
+    # Top-level: commands + flags.
+    foreach ($c in $rivetTopCommands) {
+        if ($c -like "$wordToComplete*") {
+            $result += [System.Management.Automation.CompletionResult]::new($c, $c, 'Command', $c)
+        }
+    }
+    foreach ($f in $rivetTopFlags) {
+        if ($f -like "$wordToComplete*") {
+            $result += [System.Management.Automation.CompletionResult]::new($f, $f, 'ParameterName', $f)
+        }
+    }
+    return $result
+}
+
+# -Native is required for external commands on PowerShell 7+, but is not a valid
+# switch on Windows PowerShell 5.1 (where native completion is implicit).
+$registerParams = @{ CommandName = 'rivet'; ScriptBlock = $rivetCompleter }
+if ((Get-Command Register-ArgumentCompleter).Parameters.ContainsKey('Native')) {
+    $registerParams['Native'] = $true
+}
+Register-ArgumentCompleter @registerParams


### PR DESCRIPTION
Adds two new shell completion scripts alongside the existing bash/zsh ones, so the remaining two mainstream shells are covered:

- completions/rivet.fish - fish shell completion
- completions/rivet.ps1  - Windows-shell completion

Both cover:
- top-level commands (config, serve, sessions)
- all global flags (--print, --json, --stream-json, --goal, --budget, --model, --provider, --continue, --resume, --new, --list, --dangerously-skip-permissions, --screen-reader, --skip-welcome, --stream-events, --help, --version)
- config subcommands
- dynamic provider-name completion read from ~/.rivet/config.json

Both scripts were manually exercised against a mock config to verify command, flag and provider completion behave correctly.

## 变更摘要

<!-- 用一句话说明这个 PR 做了什么 -->

## 动机

<!-- 为什么需要这个变更？它解决了什么问题？ -->

## 主要改动

<!-- 列出关键文件与行为变化，便于 reviewer 快速定位 -->

## 测试

<!-- 如何验证的？新增/修改了哪些测试？ -->

## 检查清单

- [ ] 本地 `npm test` 通过
- [ ] `npx tsc --noEmit` 无类型错误
- [ ] 变更范围最小化，无关改动已排除
- [ ] 文档（README / 用户手册 / CHANGELOG）已同步更新

## 相关 Issue

<!-- 关联的 issue 编号，例如 Closes #123 -->
