### PR TITLE
Feat rivet shell completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,41 @@ npm run build      # 生成 dist/main.js
 npm start          # 或：node dist/main.js
 ```
 
+### 3. 启用 Shell 补全（可选）
+
+仓库自带 `completions/` 目录，覆盖 bash / zsh / fish / Windows PowerShell 四种 shell。按你的 shell 安装对应文件：
+
+**bash** —— 任选其一：
+
+```bash
+source /path/to/rivet.bash                                   # 追加到 ~/.bashrc
+cp completions/rivet.bash ~/.local/share/bash-completion/completions/rivet
+sudo cp completions/rivet.bash /usr/share/bash-completion/completions/rivet
+```
+
+**zsh** —— 把 `rivet.zsh` 以 `_rivet` 名字放入 `$fpath`：
+
+```bash
+mkdir -p ~/.zsh/completions
+cp completions/rivet.zsh ~/.zsh/completions/_rivet
+echo 'fpath=(~/.zsh/completions $fpath)' >> ~/.zshrc   # 需在 compinit 之前
+```
+
+**fish**：
+
+```bash
+mkdir -p ~/.config/fish/completions
+cp completions/rivet.fish ~/.config/fish/completions/rivet.fish
+```
+
+**Windows PowerShell** —— 在 `$PROFILE` 里 dot-source：
+
+```powershell
+Add-Content $PROFILE ". C:\path\to\rivet.ps1"
+```
+
+> 补全内容与 CLI 保持一致：顶层命令（`config` / `serve` / `sessions` / `browser` / `logs`）、全局 flags、`config` 全部子命令，以及从 `~/.rivet/config.json` 动态读取的 provider 名。
+
 ### 3. 配置 API Key（首次必做）
 
 ```bash

--- a/completions/rivet.bash
+++ b/completions/rivet.bash
@@ -1,31 +1,118 @@
-# Bash completion for Rivet
+# Bash completion for Rivet (rivet)
+#
+# Install (pick one):
+#   source /path/to/rivet.bash            # from ~/.bashrc
+#   cp rivet.bash ~/.local/share/bash-completion/completions/rivet
+#   sudo cp rivet.bash /usr/share/bash-completion/completions/rivet
+
+# Provider names are read from ~/.rivet/config.json when available.
+_rivet_providers() {
+  local config_file="${HOME}/.rivet/config.json"
+  [[ -f $config_file ]] || return 0
+  node -e '
+    try {
+      const c = JSON.parse(require("fs").readFileSync(process.argv[1], "utf-8"))
+      console.log(Object.keys((c.provider && c.provider.providers) || {}).join(" "))
+    } catch {}
+  ' "$config_file" 2>/dev/null
+}
+
 _rivet() {
   local cur prev words cword
-  _init_completion || return
+  if declare -F _init_completion >/dev/null 2>&1; then
+    _init_completion || return
+  else
+    COMPREPLY=()
+    cur=${COMP_WORDS[COMP_CWORD]}
+    prev=${COMP_WORDS[COMP_CWORD-1]}
+    words=("${COMP_WORDS[@]}")
+    cword=$COMP_CWORD
+  fi
 
-  local subcommands="config"
-  local config_commands="show providers set-key set-key-env set-default add-model remove-model"
+  local commands='config serve sessions browser logs'
+  local global_flags='-p --print --json --stream-json --goal --budget --model
+    --provider -c --continue -r --resume --new --list
+    --dangerously-skip-permissions --screen-reader --skip-welcome --stream-events'
+  local config_commands='show providers setup set-url set-model set-key set-key-env
+    set-default set-approval add-model remove-model mcp'
+  local provider_commands=' setup set-url set-model set-key set-key-env set-default add-model remove-model '
+  local approval_modes='auto-safe manual auto-accept dangerously-skip-permissions'
+  local mcp_commands='list add-stdio add-sse remove enable disable'
+  local setup_flags='--key --key-env --url --model --context-window --max-tokens --alias --default'
 
-  case ${prev} in
-    rivet)
-      COMPREPLY=($(compgen -W "$subcommands --help --version -h -v" -- "$cur"))
-      ;;
-    config)
-      COMPREPLY=($(compgen -W "$config_commands" -- "$cur"))
-      ;;
-    set-key|set-key-env|set-default|add-model|remove-model)
-      # Provider name completion — read from config if available
-      local config_file="$HOME/.rivet/config.json"
-      if [[ -f "$config_file" ]]; then
-        local providers=$(node -e "
-          try { const c = JSON.parse(require('fs').readFileSync('$config_file','utf-8'));
-            console.log(Object.keys(c.provider?.providers || {}).join(' ')); } catch {}
-        " 2>/dev/null)
-        COMPREPLY=($(compgen -W "$providers" -- "$cur"))
-      fi
-      ;;
-    *)
-      ;;
+  # Value-taking flags win over positional logic.
+  case $prev in
+    --provider)
+      COMPREPLY=($(compgen -W "$(_rivet_providers)" -- "$cur"))
+      return ;;
+    --stream-events)
+      COMPREPLY=($(compgen -f -- "$cur"))
+      return ;;
+    --model|--budget|--goal|--port|--session)
+      return ;;
   esac
+
+  # Locate the first non-flag word after `rivet` — the top-level subcommand.
+  local cmd='' idx=0 i
+  for ((i = 1; i < cword; i++)); do
+    case ${words[i]} in
+      -*) ;;
+      *) cmd=${words[i]}; idx=$i; break ;;
+    esac
+  done
+
+  case $cmd in
+    config)
+      local sub=${words[idx+1]:-}
+      if ((cword <= idx + 1)); then
+        COMPREPLY=($(compgen -W "$config_commands" -- "$cur"))
+        return
+      fi
+      case $sub in
+        mcp)
+          ((cword == idx + 2)) && COMPREPLY=($(compgen -W "$mcp_commands" -- "$cur"))
+          return ;;
+        set-approval)
+          ((cword == idx + 2)) && COMPREPLY=($(compgen -W "$approval_modes" -- "$cur"))
+          return ;;
+        setup)
+          # `setup` may target a provider that does not exist yet, so the flags are
+          # offered alongside the known provider names at the first argument slot.
+          if ((cword == idx + 2)); then
+            COMPREPLY=($(compgen -W "$(_rivet_providers) $setup_flags" -- "$cur"))
+          else
+            COMPREPLY=($(compgen -W "$setup_flags" -- "$cur"))
+          fi
+          return ;;
+      esac
+      if [[ $provider_commands == *" $sub "* ]] && ((cword == idx + 2)); then
+        COMPREPLY=($(compgen -W "$(_rivet_providers)" -- "$cur"))
+      fi
+      return ;;
+    serve)
+      COMPREPLY=($(compgen -W '--port' -- "$cur"))
+      return ;;
+    browser)
+      if ((cword == idx + 1)); then
+        COMPREPLY=($(compgen -W 'status check install help' -- "$cur"))
+      elif [[ ${words[idx+1]:-} == install ]]; then
+        COMPREPLY=($(compgen -W '--no-mirror' -- "$cur"))
+      fi
+      return ;;
+    logs)
+      if ((cword == idx + 1)); then
+        COMPREPLY=($(compgen -W 'open --session --json' -- "$cur"))
+      elif [[ ${words[idx+1]:-} == open ]] && ((cword == idx + 2)); then
+        COMPREPLY=($(compgen -W 'desktop --session --json' -- "$cur"))
+      else
+        COMPREPLY=($(compgen -W '--session --json' -- "$cur"))
+      fi
+      return ;;
+    sessions)
+      return ;;
+  esac
+
+  COMPREPLY=($(compgen -W "$commands $global_flags" -- "$cur"))
 }
+
 complete -F _rivet rivet

--- a/completions/rivet.fish
+++ b/completions/rivet.fish
@@ -1,49 +1,110 @@
 # Fish completion for Rivet (rivet)
 #
 # Install: copy this file to ~/.config/fish/completions/rivet.fish
-#   (mkdir -p ~/.config/fish/completions && cp rivet.fish ~/.config/fish/completions/)
+#   mkdir -p ~/.config/fish/completions
+#   cp rivet.fish ~/.config/fish/completions/
 
 # Provider names are read from ~/.rivet/config.json when available.
 function __rivet_providers
-    node -e "const os=require('os');try{const c=JSON.parse(require('fs').readFileSync(os.homedir()+'/.rivet/config.json','utf-8'));console.log(Object.keys(c.provider?.providers||{}).join('\n'));}catch{}"
+    node -e '
+      const os = require("os")
+      const path = require("path")
+      try {
+        const f = path.join(os.homedir(), ".rivet", "config.json")
+        const c = JSON.parse(require("fs").readFileSync(f, "utf-8"))
+        console.log(Object.keys((c.provider && c.provider.providers) || {}).join("\n"))
+      } catch {}
+    ' 2>/dev/null
+end
+
+function __rivet_no_subcommand
+    not __fish_seen_subcommand_from config serve sessions browser logs
+end
+
+function __rivet_config_no_subcommand
+    __fish_seen_subcommand_from config
+    and not __fish_seen_subcommand_from show providers setup set-url set-model \
+        set-key set-key-env set-default set-approval add-model remove-model mcp
 end
 
 # --- Top-level commands ---
-complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -a "config" -d "Manage API keys and model configuration"
-complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -a "serve" -d "Start the sidecar HTTP/SSE server"
-complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -a "sessions" -d "List recent sessions"
+complete -c rivet -n __rivet_no_subcommand -a config -d 'Manage providers, API keys and models'
+complete -c rivet -n __rivet_no_subcommand -a serve -d 'Start the sidecar HTTP/SSE runtime server'
+complete -c rivet -n __rivet_no_subcommand -a sessions -d 'Print the session list and exit'
+complete -c rivet -n __rivet_no_subcommand -a browser -d 'Check or install the Chromium used by browser tools'
+complete -c rivet -n __rivet_no_subcommand -a logs -d 'Show where sessions, caches and logs are written'
 
-# --- Top-level flags (from the user guide) ---
-complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -l help -s h -d "Show help"
-complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -l version -s v -d "Show version"
-complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -l print -s p -d "Single prompt, print and exit"
-complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -l json -d "Output a single JSON result (with -p)"
-complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -l stream-json -d "NDJSON event stream, output de-identified (CI)"
-complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -l goal -d "Headless autonomous goal mode"
-complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -l budget -d "Goal turn budget (default 100)"
-complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -l model -d "Override the model for this session"
-complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -l provider -d "Override the provider for this session"
-complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -l continue -s c -d "Resume the most recent session in cwd"
-complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -l resume -s r -d "Resume a session by id/prefix"
-complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -l new -d "Force a new session"
-complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -l list -d "List sessions and exit"
-complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -l dangerously-skip-permissions -d "Skip all approvals (YOLO)"
-complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -l screen-reader -d "Screen-reader mode"
-complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -l skip-welcome -d "Skip the welcome screen"
-complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -l stream-events -d "Mirror this run as a NDJSON SessionEvent file"
+# --- Top-level flags ---
+complete -c rivet -n __rivet_no_subcommand -s p -l print -r -d 'Run a single prompt headlessly and print the result'
+complete -c rivet -n __rivet_no_subcommand -l json -d 'Emit a single JSON result object'
+complete -c rivet -n __rivet_no_subcommand -l stream-json -d 'Emit the run as an NDJSON event stream'
+complete -c rivet -n __rivet_no_subcommand -l goal -r -d 'Run headless autonomous goal mode'
+complete -c rivet -n __rivet_no_subcommand -l budget -r -d 'Turn budget for goal mode (default 100)'
+complete -c rivet -n __rivet_no_subcommand -l model -r -d 'Override the model for this session'
+complete -c rivet -n __rivet_no_subcommand -l provider -r -a '(__rivet_providers)' -d 'Override the provider for this session'
+complete -c rivet -n __rivet_no_subcommand -s c -l continue -d 'Resume the most recent session for this directory'
+complete -c rivet -n __rivet_no_subcommand -s r -l resume -d 'Resume a session by id or prefix'
+complete -c rivet -n __rivet_no_subcommand -l new -d 'Force a brand-new session'
+complete -c rivet -n __rivet_no_subcommand -l list -d 'Print the session list and exit'
+complete -c rivet -n __rivet_no_subcommand -l dangerously-skip-permissions -d 'Skip all tool approvals'
+complete -c rivet -n __rivet_no_subcommand -l screen-reader -d 'Screen-reader friendly output'
+complete -c rivet -n __rivet_no_subcommand -l skip-welcome -d 'Skip the welcome screen'
+complete -c rivet -n __rivet_no_subcommand -l stream-events -r -F -d 'Mirror the run as an NDJSON SessionEvent file'
 
 # --- config subcommands ---
-complete -c rivet -n "__fish_seen_subcommand_from config" -a "show" -d "Show current configuration"
-complete -c rivet -n "__fish_seen_subcommand_from config" -a "providers" -d "List configured providers"
-complete -c rivet -n "__fish_seen_subcommand_from config" -a "set-key" -d "Set API key for a provider"
-complete -c rivet -n "__fish_seen_subcommand_from config" -a "set-key-env" -d "Set API key from an environment variable"
-complete -c rivet -n "__fish_seen_subcommand_from config" -a "set-default" -d "Set the default provider"
-complete -c rivet -n "__fish_seen_subcommand_from config" -a "add-model" -d "Add a model to a provider"
-complete -c rivet -n "__fish_seen_subcommand_from config" -a "remove-model" -d "Remove a model from a provider"
+complete -c rivet -n __rivet_config_no_subcommand -a show -d 'Print the resolved configuration as JSON'
+complete -c rivet -n __rivet_config_no_subcommand -a providers -d 'List configured providers and key status'
+complete -c rivet -n __rivet_config_no_subcommand -a setup -d 'Configure a provider in one shot'
+complete -c rivet -n __rivet_config_no_subcommand -a set-url -d 'Set the base URL for a provider'
+complete -c rivet -n __rivet_config_no_subcommand -a set-model -d 'Set the active model for a provider'
+complete -c rivet -n __rivet_config_no_subcommand -a set-key -d 'Set the API key for a provider'
+complete -c rivet -n __rivet_config_no_subcommand -a set-key-env -d 'Read the API key from an environment variable'
+complete -c rivet -n __rivet_config_no_subcommand -a set-default -d 'Set the default provider'
+complete -c rivet -n __rivet_config_no_subcommand -a set-approval -d 'Set the tool approval mode'
+complete -c rivet -n __rivet_config_no_subcommand -a add-model -d 'Add a model to a provider'
+complete -c rivet -n __rivet_config_no_subcommand -a remove-model -d 'Remove a model from a provider'
+complete -c rivet -n __rivet_config_no_subcommand -a mcp -d 'Manage MCP servers'
 
-# --- Provider name completion (read from ~/.rivet/config.json) ---
-complete -c rivet -n "__fish_seen_subcommand_from config set-key" -a "(__rivet_providers)" -d "Provider"
-complete -c rivet -n "__fish_seen_subcommand_from config set-key-env" -a "(__rivet_providers)" -d "Provider"
-complete -c rivet -n "__fish_seen_subcommand_from config set-default" -a "(__rivet_providers)" -d "Provider"
-complete -c rivet -n "__fish_seen_subcommand_from config add-model" -a "(__rivet_providers)" -d "Provider"
-complete -c rivet -n "__fish_seen_subcommand_from config remove-model" -a "(__rivet_providers)" -d "Provider"
+# --- Provider names for the config subcommands that take one ---
+complete -c rivet -n '__fish_seen_subcommand_from config; and __fish_seen_subcommand_from setup set-url set-model set-key set-key-env set-default add-model remove-model' \
+    -a '(__rivet_providers)' -d Provider
+
+# --- config setup flags ---
+complete -c rivet -n '__fish_seen_subcommand_from config; and __fish_seen_subcommand_from setup' -l key -r -d 'API key literal'
+complete -c rivet -n '__fish_seen_subcommand_from config; and __fish_seen_subcommand_from setup' -l key-env -r -d 'Environment variable holding the key'
+complete -c rivet -n '__fish_seen_subcommand_from config; and __fish_seen_subcommand_from setup' -l url -r -d 'Base URL'
+complete -c rivet -n '__fish_seen_subcommand_from config; and __fish_seen_subcommand_from setup' -l model -r -d 'Model id'
+complete -c rivet -n '__fish_seen_subcommand_from config; and __fish_seen_subcommand_from setup' -l context-window -r -d 'Context window size in tokens'
+complete -c rivet -n '__fish_seen_subcommand_from config; and __fish_seen_subcommand_from setup' -l max-tokens -r -d 'Max output tokens'
+complete -c rivet -n '__fish_seen_subcommand_from config; and __fish_seen_subcommand_from setup' -l alias -r -d 'Model alias'
+complete -c rivet -n '__fish_seen_subcommand_from config; and __fish_seen_subcommand_from setup' -l default -d 'Make this the default provider'
+
+# --- config set-approval modes ---
+complete -c rivet -n '__fish_seen_subcommand_from config; and __fish_seen_subcommand_from set-approval' -a auto-safe -d 'Auto-approve read-only tools, ask for the rest'
+complete -c rivet -n '__fish_seen_subcommand_from config; and __fish_seen_subcommand_from set-approval' -a manual -d 'Ask before every tool call'
+complete -c rivet -n '__fish_seen_subcommand_from config; and __fish_seen_subcommand_from set-approval' -a auto-accept -d 'Auto-approve everything except destructive actions'
+complete -c rivet -n '__fish_seen_subcommand_from config; and __fish_seen_subcommand_from set-approval' -a dangerously-skip-permissions -d 'Skip all approvals'
+
+# --- config mcp subcommands ---
+complete -c rivet -n '__fish_seen_subcommand_from config; and __fish_seen_subcommand_from mcp; and not __fish_seen_subcommand_from list add-stdio add-sse remove enable disable' -a list -d 'List configured MCP servers'
+complete -c rivet -n '__fish_seen_subcommand_from config; and __fish_seen_subcommand_from mcp; and not __fish_seen_subcommand_from list add-stdio add-sse remove enable disable' -a add-stdio -d 'Add a stdio MCP server'
+complete -c rivet -n '__fish_seen_subcommand_from config; and __fish_seen_subcommand_from mcp; and not __fish_seen_subcommand_from list add-stdio add-sse remove enable disable' -a add-sse -d 'Add an SSE MCP server'
+complete -c rivet -n '__fish_seen_subcommand_from config; and __fish_seen_subcommand_from mcp; and not __fish_seen_subcommand_from list add-stdio add-sse remove enable disable' -a remove -d 'Remove an MCP server'
+complete -c rivet -n '__fish_seen_subcommand_from config; and __fish_seen_subcommand_from mcp; and not __fish_seen_subcommand_from list add-stdio add-sse remove enable disable' -a enable -d 'Enable an MCP server'
+complete -c rivet -n '__fish_seen_subcommand_from config; and __fish_seen_subcommand_from mcp; and not __fish_seen_subcommand_from list add-stdio add-sse remove enable disable' -a disable -d 'Disable an MCP server'
+
+# --- serve ---
+complete -c rivet -n '__fish_seen_subcommand_from serve' -l port -r -d 'Port to listen on'
+
+# --- browser ---
+complete -c rivet -n '__fish_seen_subcommand_from browser; and not __fish_seen_subcommand_from status check install help' -a status -d 'Report whether Chromium is ready'
+complete -c rivet -n '__fish_seen_subcommand_from browser; and not __fish_seen_subcommand_from status check install help' -a check -d 'Alias for status'
+complete -c rivet -n '__fish_seen_subcommand_from browser; and not __fish_seen_subcommand_from status check install help' -a install -d 'Download and install Chromium'
+complete -c rivet -n '__fish_seen_subcommand_from browser; and not __fish_seen_subcommand_from status check install help' -a help -d 'Show browser command help'
+complete -c rivet -n '__fish_seen_subcommand_from browser; and __fish_seen_subcommand_from install' -l no-mirror -d 'Skip the download mirror'
+
+# --- logs ---
+complete -c rivet -n '__fish_seen_subcommand_from logs; and not __fish_seen_subcommand_from open' -a open -d 'Open the log location'
+complete -c rivet -n '__fish_seen_subcommand_from logs; and __fish_seen_subcommand_from open' -a desktop -d 'Open the desktop log directory'
+complete -c rivet -n '__fish_seen_subcommand_from logs' -l session -r -d 'Restrict the report to one session'
+complete -c rivet -n '__fish_seen_subcommand_from logs' -l json -d 'Emit a structured manifest'

--- a/completions/rivet.fish
+++ b/completions/rivet.fish
@@ -1,0 +1,49 @@
+# Fish completion for Rivet (rivet)
+#
+# Install: copy this file to ~/.config/fish/completions/rivet.fish
+#   (mkdir -p ~/.config/fish/completions && cp rivet.fish ~/.config/fish/completions/)
+
+# Provider names are read from ~/.rivet/config.json when available.
+function __rivet_providers
+    node -e "const os=require('os');try{const c=JSON.parse(require('fs').readFileSync(os.homedir()+'/.rivet/config.json','utf-8'));console.log(Object.keys(c.provider?.providers||{}).join('\n'));}catch{}"
+end
+
+# --- Top-level commands ---
+complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -a "config" -d "Manage API keys and model configuration"
+complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -a "serve" -d "Start the sidecar HTTP/SSE server"
+complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -a "sessions" -d "List recent sessions"
+
+# --- Top-level flags (from the user guide) ---
+complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -l help -s h -d "Show help"
+complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -l version -s v -d "Show version"
+complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -l print -s p -d "Single prompt, print and exit"
+complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -l json -d "Output a single JSON result (with -p)"
+complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -l stream-json -d "NDJSON event stream, output de-identified (CI)"
+complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -l goal -d "Headless autonomous goal mode"
+complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -l budget -d "Goal turn budget (default 100)"
+complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -l model -d "Override the model for this session"
+complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -l provider -d "Override the provider for this session"
+complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -l continue -s c -d "Resume the most recent session in cwd"
+complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -l resume -s r -d "Resume a session by id/prefix"
+complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -l new -d "Force a new session"
+complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -l list -d "List sessions and exit"
+complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -l dangerously-skip-permissions -d "Skip all approvals (YOLO)"
+complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -l screen-reader -d "Screen-reader mode"
+complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -l skip-welcome -d "Skip the welcome screen"
+complete -c rivet -n "not __fish_seen_subcommand_from config serve sessions" -l stream-events -d "Mirror this run as a NDJSON SessionEvent file"
+
+# --- config subcommands ---
+complete -c rivet -n "__fish_seen_subcommand_from config" -a "show" -d "Show current configuration"
+complete -c rivet -n "__fish_seen_subcommand_from config" -a "providers" -d "List configured providers"
+complete -c rivet -n "__fish_seen_subcommand_from config" -a "set-key" -d "Set API key for a provider"
+complete -c rivet -n "__fish_seen_subcommand_from config" -a "set-key-env" -d "Set API key from an environment variable"
+complete -c rivet -n "__fish_seen_subcommand_from config" -a "set-default" -d "Set the default provider"
+complete -c rivet -n "__fish_seen_subcommand_from config" -a "add-model" -d "Add a model to a provider"
+complete -c rivet -n "__fish_seen_subcommand_from config" -a "remove-model" -d "Remove a model from a provider"
+
+# --- Provider name completion (read from ~/.rivet/config.json) ---
+complete -c rivet -n "__fish_seen_subcommand_from config set-key" -a "(__rivet_providers)" -d "Provider"
+complete -c rivet -n "__fish_seen_subcommand_from config set-key-env" -a "(__rivet_providers)" -d "Provider"
+complete -c rivet -n "__fish_seen_subcommand_from config set-default" -a "(__rivet_providers)" -d "Provider"
+complete -c rivet -n "__fish_seen_subcommand_from config add-model" -a "(__rivet_providers)" -d "Provider"
+complete -c rivet -n "__fish_seen_subcommand_from config remove-model" -a "(__rivet_providers)" -d "Provider"

--- a/completions/rivet.ps1
+++ b/completions/rivet.ps1
@@ -1,0 +1,109 @@
+# PowerShell completion for Rivet (rivet)
+#
+# Install: dot-source this file from your $PROFILE so the completer loads in every session:
+#   Add-Content $PROFILE ". $PSScriptRoot\rivet.ps1"   # or the absolute path to this file
+# Then restart PowerShell (or run `. .\rivet.ps1` once).
+
+function Get-RivetProviders {
+    $configFile = Join-Path $env:USERPROFILE ".rivet\config.json"
+    if (-not (Test-Path $configFile)) { return @() }
+    try {
+        $cfg = Get-Content $configFile -Raw | ConvertFrom-Json
+        if ($cfg.provider -and $cfg.provider.providers) {
+            return $cfg.provider.providers.PSObject.Properties.Name
+        }
+    } catch { }
+    return @()
+}
+
+# The completer scriptblock is self-contained (arrays defined inside) so it does not
+# depend on outer-scope variable resolution when invoked by the PowerShell engine.
+$rivetCompleter = {
+    param($wordToComplete, $commandAst, $cursorPosition)
+
+    $rivetTopCommands   = @('config', 'serve', 'sessions')
+    $rivetConfigCommands = @('show', 'providers', 'set-key', 'set-key-env', 'set-default', 'add-model', 'remove-model')
+    $rivetProviderVerbs  = @('set-key', 'set-key-env', 'set-default', 'add-model', 'remove-model')
+    $rivetTopFlags = @(
+        '--help', '-h', '--version', '-v',
+        '--print', '-p', '--json', '--stream-json',
+        '--goal', '--budget', '--model', '--provider',
+        '--continue', '-c', '--resume', '-r', '--new', '--list',
+        '--dangerously-skip-permissions', '--screen-reader', '--skip-welcome', '--stream-events'
+    )
+
+    # Parse the command line into tokens (works for native commands).
+    $line = $commandAst.ToString().Trim()
+    $words = $line.Split(' ', [System.StringSplitOptions]::RemoveEmptyEntries)
+
+    $result = @()
+
+    $hasConfig = $words -contains 'config'
+    if ($hasConfig) {
+        $configIdx = [array]::IndexOf($words, 'config')
+        $afterConfig = @($words[($configIdx + 1)..($words.Length - 1)] | Where-Object { $_ -and $_ -ne 'config' })
+        if ($afterConfig.Count -eq 0) {
+            # No token after `config` yet — offer every config subcommand.
+            foreach ($c in $rivetConfigCommands) {
+                if ($c -like "$wordToComplete*") {
+                    $result += [System.Management.Automation.CompletionResult]::new($c, $c, 'Command', $c)
+                }
+            }
+            return $result
+        }
+        $only = $afterConfig[0]
+        if ($afterConfig.Count -eq 1) {
+            if ($rivetProviderVerbs -contains $only) {
+                # A complete provider verb is present — next token is the provider name.
+                foreach ($p in (Get-RivetProviders)) {
+                    if ($p -like "$wordToComplete*") {
+                        $result += [System.Management.Automation.CompletionResult]::new($p, $p, 'ParameterValue', $p)
+                    }
+                }
+                return $result
+            }
+            if ($rivetConfigCommands -contains $only) {
+                # A complete subcommand with no further arguments — nothing more to offer.
+                return $result
+            }
+            # Still typing the subcommand (partial) — offer matching subcommands.
+            foreach ($c in $rivetConfigCommands) {
+                if ($c -like "$wordToComplete*") {
+                    $result += [System.Management.Automation.CompletionResult]::new($c, $c, 'Command', $c)
+                }
+            }
+            return $result
+        }
+        # Two or more tokens after `config` — the first is the verb, the rest are its args.
+        if ($rivetProviderVerbs -contains $only) {
+            foreach ($p in (Get-RivetProviders)) {
+                if ($p -like "$wordToComplete*") {
+                    $result += [System.Management.Automation.CompletionResult]::new($p, $p, 'ParameterValue', $p)
+                }
+            }
+            return $result
+        }
+        return $result
+    }
+
+    # Top-level: commands + flags.
+    foreach ($c in $rivetTopCommands) {
+        if ($c -like "$wordToComplete*") {
+            $result += [System.Management.Automation.CompletionResult]::new($c, $c, 'Command', $c)
+        }
+    }
+    foreach ($f in $rivetTopFlags) {
+        if ($f -like "$wordToComplete*") {
+            $result += [System.Management.Automation.CompletionResult]::new($f, $f, 'ParameterName', $f)
+        }
+    }
+    return $result
+}
+
+# -Native is required for external commands on PowerShell 7+, but is not a valid
+# switch on Windows PowerShell 5.1 (where native completion is implicit).
+$registerParams = @{ CommandName = 'rivet'; ScriptBlock = $rivetCompleter }
+if ((Get-Command Register-ArgumentCompleter).Parameters.ContainsKey('Native')) {
+    $registerParams['Native'] = $true
+}
+Register-ArgumentCompleter @registerParams

--- a/completions/rivet.ps1
+++ b/completions/rivet.ps1
@@ -1,8 +1,10 @@
 # PowerShell completion for Rivet (rivet)
 #
 # Install: dot-source this file from your $PROFILE so the completer loads in every session:
-#   Add-Content $PROFILE ". $PSScriptRoot\rivet.ps1"   # or the absolute path to this file
+#   Add-Content $PROFILE ". C:\path\to\rivet.ps1"
 # Then restart PowerShell (or run `. .\rivet.ps1` once).
+#
+# Works on Windows PowerShell 5.1 and PowerShell 7+.
 
 function Get-RivetProviders {
     $configFile = Join-Path $env:USERPROFILE ".rivet\config.json"
@@ -10,94 +12,213 @@ function Get-RivetProviders {
     try {
         $cfg = Get-Content $configFile -Raw | ConvertFrom-Json
         if ($cfg.provider -and $cfg.provider.providers) {
-            return $cfg.provider.providers.PSObject.Properties.Name
+            return @($cfg.provider.providers.PSObject.Properties.Name)
         }
     } catch { }
     return @()
 }
 
-# The completer scriptblock is self-contained (arrays defined inside) so it does not
-# depend on outer-scope variable resolution when invoked by the PowerShell engine.
+# The completer is self-contained (all tables defined inside) so it does not depend
+# on outer-scope variable resolution when invoked by the PowerShell engine.
 $rivetCompleter = {
     param($wordToComplete, $commandAst, $cursorPosition)
 
-    $rivetTopCommands   = @('config', 'serve', 'sessions')
-    $rivetConfigCommands = @('show', 'providers', 'set-key', 'set-key-env', 'set-default', 'add-model', 'remove-model')
-    $rivetProviderVerbs  = @('set-key', 'set-key-env', 'set-default', 'add-model', 'remove-model')
-    $rivetTopFlags = @(
-        '--help', '-h', '--version', '-v',
-        '--print', '-p', '--json', '--stream-json',
-        '--goal', '--budget', '--model', '--provider',
-        '--continue', '-c', '--resume', '-r', '--new', '--list',
-        '--dangerously-skip-permissions', '--screen-reader', '--skip-welcome', '--stream-events'
-    )
-
-    # Parse the command line into tokens (works for native commands).
-    $line = $commandAst.ToString().Trim()
-    $words = $line.Split(' ', [System.StringSplitOptions]::RemoveEmptyEntries)
-
-    $result = @()
-
-    $hasConfig = $words -contains 'config'
-    if ($hasConfig) {
-        $configIdx = [array]::IndexOf($words, 'config')
-        $afterConfig = @($words[($configIdx + 1)..($words.Length - 1)] | Where-Object { $_ -and $_ -ne 'config' })
-        if ($afterConfig.Count -eq 0) {
-            # No token after `config` yet — offer every config subcommand.
-            foreach ($c in $rivetConfigCommands) {
-                if ($c -like "$wordToComplete*") {
-                    $result += [System.Management.Automation.CompletionResult]::new($c, $c, 'Command', $c)
-                }
+    # NOTE: both helpers are always consumed via @(...) at the call sites. PowerShell
+    # unwraps a single-element array into a scalar, and `CompletionResult + array`
+    # throws op_Addition, so the @() cast around every call is load-bearing.
+    function Add-Match($map, $type, $prefix) {
+        $out = @()
+        foreach ($k in $map.Keys) {
+            if ($k -like "$prefix*") {
+                $out += [System.Management.Automation.CompletionResult]::new($k, $k, $type, $map[$k])
             }
-            return $result
         }
-        $only = $afterConfig[0]
-        if ($afterConfig.Count -eq 1) {
-            if ($rivetProviderVerbs -contains $only) {
-                # A complete provider verb is present — next token is the provider name.
-                foreach ($p in (Get-RivetProviders)) {
-                    if ($p -like "$wordToComplete*") {
-                        $result += [System.Management.Automation.CompletionResult]::new($p, $p, 'ParameterValue', $p)
+        return $out
+    }
+
+    function Add-List($items, $type, $prefix) {
+        $out = @()
+        foreach ($k in $items) {
+            if ($k -like "$prefix*") {
+                $out += [System.Management.Automation.CompletionResult]::new($k, $k, $type, $k)
+            }
+        }
+        return $out
+    }
+
+    $topCommands = [ordered]@{
+        'config'   = 'Manage providers, API keys and models'
+        'serve'    = 'Start the sidecar HTTP/SSE runtime server'
+        'sessions' = 'Print the session list and exit'
+        'browser'  = 'Check or install the Chromium used by browser tools'
+        'logs'     = 'Show where sessions, caches and logs are written'
+    }
+
+    $topFlags = [ordered]@{
+        '-p'                             = 'Run a single prompt headlessly and print the result'
+        '--print'                        = 'Run a single prompt headlessly and print the result'
+        '--json'                         = 'Emit a single JSON result object'
+        '--stream-json'                  = 'Emit the run as an NDJSON event stream'
+        '--goal'                         = 'Run headless autonomous goal mode'
+        '--budget'                       = 'Turn budget for goal mode (default 100)'
+        '--model'                        = 'Override the model for this session'
+        '--provider'                     = 'Override the provider for this session'
+        '-c'                             = 'Resume the most recent session for this directory'
+        '--continue'                     = 'Resume the most recent session for this directory'
+        '-r'                             = 'Resume a session by id or prefix'
+        '--resume'                       = 'Resume a session by id or prefix'
+        '--new'                          = 'Force a brand-new session'
+        '--list'                         = 'Print the session list and exit'
+        '--dangerously-skip-permissions' = 'Skip all tool approvals'
+        '--screen-reader'                = 'Screen-reader friendly output'
+        '--skip-welcome'                 = 'Skip the welcome screen'
+        '--stream-events'                = 'Mirror the run as an NDJSON SessionEvent file'
+    }
+
+    $configCommands = [ordered]@{
+        'show'         = 'Print the resolved configuration as JSON'
+        'providers'    = 'List configured providers and key status'
+        'setup'        = 'Configure a provider in one shot'
+        'set-url'      = 'Set the base URL for a provider'
+        'set-model'    = 'Set the active model for a provider'
+        'set-key'      = 'Set the API key for a provider'
+        'set-key-env'  = 'Read the API key from an environment variable'
+        'set-default'  = 'Set the default provider'
+        'set-approval' = 'Set the tool approval mode'
+        'add-model'    = 'Add a model to a provider'
+        'remove-model' = 'Remove a model from a provider'
+        'mcp'          = 'Manage MCP servers'
+    }
+
+    $mcpCommands = [ordered]@{
+        'list'      = 'List configured MCP servers'
+        'add-stdio' = 'Add a stdio MCP server'
+        'add-sse'   = 'Add an SSE MCP server'
+        'remove'    = 'Remove an MCP server'
+        'enable'    = 'Enable an MCP server'
+        'disable'   = 'Disable an MCP server'
+    }
+
+    $approvalModes = [ordered]@{
+        'auto-safe'                      = 'Auto-approve read-only tools, ask for the rest'
+        'manual'                         = 'Ask before every tool call'
+        'auto-accept'                    = 'Auto-approve everything except destructive actions'
+        'dangerously-skip-permissions'   = 'Skip all approvals'
+    }
+
+    $setupFlags = [ordered]@{
+        '--key'            = 'API key literal'
+        '--key-env'        = 'Environment variable holding the key'
+        '--url'            = 'Base URL'
+        '--model'          = 'Model id'
+        '--context-window' = 'Context window size in tokens'
+        '--max-tokens'     = 'Max output tokens'
+        '--alias'          = 'Model alias'
+        '--default'        = 'Make this the default provider'
+    }
+
+    $browserCommands = [ordered]@{
+        'status'  = 'Report whether Chromium is ready'
+        'check'   = 'Alias for status'
+        'install' = 'Download and install Chromium'
+        'help'    = 'Show browser command help'
+    }
+
+    $logsFlags = [ordered]@{
+        '--session' = 'Restrict the report to one session'
+        '--json'    = 'Emit a structured manifest'
+    }
+
+    $providerVerbs = @('setup', 'set-url', 'set-model', 'set-key', 'set-key-env', 'set-default', 'add-model', 'remove-model')
+
+    # --- Tokenise the line, excluding the word currently being typed ---
+    $all = @(($commandAst.ToString().Trim()) -split '\s+' | Where-Object { $_ })
+    $tokens = @()
+    if ($all.Count -gt 1) { $tokens = @($all[1..($all.Count - 1)]) }
+    if ($wordToComplete -and $tokens.Count -gt 0 -and $tokens[-1] -eq $wordToComplete) {
+        if ($tokens.Count -eq 1) { $tokens = @() }
+        else { $tokens = @($tokens[0..($tokens.Count - 2)]) }
+    }
+
+    # A value-taking flag immediately before the cursor wins over positional logic.
+    if ($tokens.Count -gt 0) {
+        switch ($tokens[-1]) {
+            '--provider' { return @(Add-List (Get-RivetProviders) 'ParameterValue' $wordToComplete) }
+            '--model'    { return @() }
+            '--budget'   { return @() }
+            '--goal'     { return @() }
+            '--port'     { return @() }
+            '--session'  { return @() }
+        }
+    }
+
+    # Positional tokens only (flags filtered out), so interleaved flags do not shift positions.
+    $positional = @($tokens | Where-Object { $_ -notlike '-*' })
+
+    if ($positional.Count -eq 0) {
+        return @(Add-Match $topCommands 'Command' $wordToComplete) +
+               @(Add-Match $topFlags 'ParameterName' $wordToComplete)
+    }
+
+    switch ($positional[0]) {
+        'config' {
+            if ($positional.Count -eq 1) {
+                return @(Add-Match $configCommands 'Command' $wordToComplete)
+            }
+            $sub = $positional[1]
+            switch ($sub) {
+                'mcp' {
+                    if ($positional.Count -eq 2) {
+                        return @(Add-Match $mcpCommands 'Command' $wordToComplete)
                     }
+                    return @()
                 }
-                return $result
-            }
-            if ($rivetConfigCommands -contains $only) {
-                # A complete subcommand with no further arguments — nothing more to offer.
-                return $result
-            }
-            # Still typing the subcommand (partial) — offer matching subcommands.
-            foreach ($c in $rivetConfigCommands) {
-                if ($c -like "$wordToComplete*") {
-                    $result += [System.Management.Automation.CompletionResult]::new($c, $c, 'Command', $c)
+                'set-approval' {
+                    if ($positional.Count -eq 2) {
+                        return @(Add-Match $approvalModes 'ParameterValue' $wordToComplete)
+                    }
+                    return @()
+                }
+                'setup' {
+                    if ($positional.Count -eq 2) {
+                        return @(Add-List (Get-RivetProviders) 'ParameterValue' $wordToComplete) +
+                               @(Add-Match $setupFlags 'ParameterName' $wordToComplete)
+                    }
+                    return @(Add-Match $setupFlags 'ParameterName' $wordToComplete)
                 }
             }
-            return $result
+            if ($positional.Count -eq 2 -and $providerVerbs -contains $sub) {
+                return @(Add-List (Get-RivetProviders) 'ParameterValue' $wordToComplete)
+            }
+            return @()
         }
-        # Two or more tokens after `config` — the first is the verb, the rest are its args.
-        if ($rivetProviderVerbs -contains $only) {
-            foreach ($p in (Get-RivetProviders)) {
-                if ($p -like "$wordToComplete*") {
-                    $result += [System.Management.Automation.CompletionResult]::new($p, $p, 'ParameterValue', $p)
-                }
-            }
-            return $result
+        'serve' {
+            return @(Add-Match ([ordered]@{ '--port' = 'Port to listen on' }) 'ParameterName' $wordToComplete)
         }
-        return $result
+        'browser' {
+            if ($positional.Count -eq 1) {
+                return @(Add-Match $browserCommands 'Command' $wordToComplete)
+            }
+            if ($positional[1] -eq 'install') {
+                return @(Add-Match ([ordered]@{ '--no-mirror' = 'Skip the download mirror' }) 'ParameterName' $wordToComplete)
+            }
+            return @()
+        }
+        'logs' {
+            if ($positional.Count -eq 1) {
+                return @(Add-Match ([ordered]@{ 'open' = 'Open the log location' }) 'Command' $wordToComplete) +
+                       @(Add-Match $logsFlags 'ParameterName' $wordToComplete)
+            }
+            if ($positional[1] -eq 'open' -and $positional.Count -eq 2) {
+                return @(Add-Match ([ordered]@{ 'desktop' = 'Open the desktop log directory' }) 'Command' $wordToComplete) +
+                       @(Add-Match $logsFlags 'ParameterName' $wordToComplete)
+            }
+            return @(Add-Match $logsFlags 'ParameterName' $wordToComplete)
+        }
+        'sessions' { return @() }
     }
 
-    # Top-level: commands + flags.
-    foreach ($c in $rivetTopCommands) {
-        if ($c -like "$wordToComplete*") {
-            $result += [System.Management.Automation.CompletionResult]::new($c, $c, 'Command', $c)
-        }
-    }
-    foreach ($f in $rivetTopFlags) {
-        if ($f -like "$wordToComplete*") {
-            $result += [System.Management.Automation.CompletionResult]::new($f, $f, 'ParameterName', $f)
-        }
-    }
-    return $result
+    return @()
 }
 
 # -Native is required for external commands on PowerShell 7+, but is not a valid

--- a/completions/rivet.zsh
+++ b/completions/rivet.zsh
@@ -1,56 +1,183 @@
 #compdef rivet
+#
+# Zsh completion for Rivet (rivet)
+#
+# Install: put this file somewhere on your $fpath as `_rivet`, e.g.
+#   mkdir -p ~/.zsh/completions && cp rivet.zsh ~/.zsh/completions/_rivet
+#   echo 'fpath=(~/.zsh/completions $fpath)' >> ~/.zshrc
 
-_rivet() {
-  local -a commands config_commands
-  commands=(
-    'config:Manage API keys and model configuration'
-    '--help:Show help'
-    '--version:Show version'
-    '-h:Show help'
-    '-v:Show version'
-  )
+# Provider names are read from ~/.rivet/config.json when available.
+_rivet_providers() {
+  local config_file="$HOME/.rivet/config.json"
+  [[ -f $config_file ]] || return 0
+  local -a providers
+  providers=(${(f)"$(node -e '
+    try {
+      const c = JSON.parse(require("fs").readFileSync(process.argv[1], "utf-8"))
+      console.log(Object.keys((c.provider && c.provider.providers) || {}).join("\n"))
+    } catch {}
+  ' "$config_file" 2>/dev/null)"})
+  (( ${#providers} )) && _describe -t providers 'provider' providers
+}
+
+_rivet_config() {
+  local -a config_commands mcp_commands approval_modes
 
   config_commands=(
-    'show:Show current configuration'
-    'providers:List configured providers'
-    'set-key:Set API key for a provider'
-    'set-key-env:Set API key from environment variable'
-    'set-default:Set default provider'
+    'show:Print the resolved configuration as JSON'
+    'providers:List configured providers and key status'
+    'setup:Configure a provider in one shot'
+    'set-url:Set the base URL for a provider'
+    'set-model:Set the active model for a provider'
+    'set-key:Set the API key for a provider'
+    'set-key-env:Read the API key from an environment variable'
+    'set-default:Set the default provider'
+    'set-approval:Set the tool approval mode'
     'add-model:Add a model to a provider'
     'remove-model:Remove a model from a provider'
+    'mcp:Manage MCP servers'
+  )
+
+  mcp_commands=(
+    'list:List configured MCP servers'
+    'add-stdio:Add a stdio MCP server'
+    'add-sse:Add an SSE MCP server'
+    'remove:Remove an MCP server'
+    'enable:Enable an MCP server'
+    'disable:Disable an MCP server'
+  )
+
+  approval_modes=(
+    'auto-safe:Auto-approve read-only tools, ask for the rest'
+    'manual:Ask before every tool call'
+    'auto-accept:Auto-approve everything except destructive actions'
+    'dangerously-skip-permissions:Skip all approvals'
   )
 
   _arguments -C \
+    '1:config command:->config_cmd' \
+    '*::config arg:->config_args'
+
+  case $state in
+    config_cmd)
+      _describe -t commands 'config command' config_commands
+      ;;
+    config_args)
+      case $words[1] in
+        mcp)
+          if (( CURRENT == 2 )); then
+            _describe -t commands 'mcp command' mcp_commands
+          fi
+          ;;
+        set-approval)
+          if (( CURRENT == 2 )); then
+            _describe -t modes 'approval mode' approval_modes
+          fi
+          ;;
+        setup)
+          # `setup` may target a provider that does not exist yet, so the flags are
+          # offered alongside the known provider names at the first argument slot.
+          if (( CURRENT == 2 )); then
+            _rivet_providers
+            _arguments \
+              '--key[API key literal]:key:' \
+              '--key-env[Environment variable holding the key]:env var:' \
+              '--url[Base URL]:url:' \
+              '--model[Model id]:model:' \
+              '--context-window[Context window size]:tokens:' \
+              '--max-tokens[Max output tokens]:tokens:' \
+              '--alias[Model alias]:alias:' \
+              '--default[Make this the default provider]'
+          else
+            _arguments \
+              '--key[API key literal]:key:' \
+              '--key-env[Environment variable holding the key]:env var:' \
+              '--url[Base URL]:url:' \
+              '--model[Model id]:model:' \
+              '--context-window[Context window size]:tokens:' \
+              '--max-tokens[Max output tokens]:tokens:' \
+              '--alias[Model alias]:alias:' \
+              '--default[Make this the default provider]'
+          fi
+          ;;
+        set-url|set-model|set-key|set-key-env|set-default|add-model|remove-model)
+          if (( CURRENT == 2 )); then
+            _rivet_providers
+          fi
+          ;;
+      esac
+      ;;
+  esac
+}
+
+_rivet() {
+  local -a commands
+  commands=(
+    'config:Manage providers, API keys and models'
+    'serve:Start the sidecar HTTP/SSE runtime server'
+    'sessions:Print the session list and exit'
+    'browser:Check or install the Chromium used by browser tools'
+    'logs:Show where sessions, caches and logs are written'
+  )
+
+  _arguments -C \
+    '(-p --print)'{-p,--print}'[Run a single prompt headlessly and print the result]:prompt:' \
+    '--json[Emit a single JSON result object]' \
+    '--stream-json[Emit the run as an NDJSON event stream]' \
+    '--goal[Run headless autonomous goal mode]:goal:' \
+    '--budget[Turn budget for goal mode (default 100)]:turns:' \
+    '--model[Override the model for this session]:model:' \
+    '--provider[Override the provider for this session]:provider:_rivet_providers' \
+    '(-c --continue)'{-c,--continue}'[Resume the most recent session for this directory]' \
+    '(-r --resume)'{-r,--resume}'[Resume a session by id or prefix]:session id:' \
+    '--new[Force a brand-new session]' \
+    '--list[Print the session list and exit]' \
+    '--dangerously-skip-permissions[Skip all tool approvals]' \
+    '--screen-reader[Screen-reader friendly output]' \
+    '--skip-welcome[Skip the welcome screen]' \
+    '--stream-events[Mirror the run as an NDJSON SessionEvent file]:path:_files' \
     '1:command:->command' \
     '*::arg:->args'
 
   case $state in
     command)
-      _describe 'command' commands
+      _describe -t commands 'command' commands
       ;;
     args)
       case $words[1] in
         config)
-          _arguments \
-            '1:config command:->config_cmd' \
-            '*::config arg:->config_args'
-          case $state in
-            config_cmd)
-              _describe 'config command' config_commands
-              ;;
-            config_args)
-              # Provider completion from config file
-              local config_file="$HOME/.rivet/config.json"
-              if [[ -f "$config_file" ]]; then
-                local -a providers
-                providers=(${(f)"$(node -e "
-                  try { const c = JSON.parse(require('fs').readFileSync('$config_file','utf-8'));
-                    console.log(Object.keys(c.provider?.providers || {}).join('\n')); } catch {}
-                " 2>/dev/null)"})
-                _describe 'provider' providers
-              fi
-              ;;
-          esac
+          _rivet_config
+          ;;
+        serve)
+          _arguments '--port[Port to listen on]:port:'
+          ;;
+        browser)
+          if (( CURRENT == 2 )); then
+            local -a browser_commands
+            browser_commands=(
+              'status:Report whether Chromium is ready'
+              'check:Alias for status'
+              'install:Download and install Chromium'
+              'help:Show browser command help'
+            )
+            _describe -t commands 'browser command' browser_commands
+          elif [[ $words[2] == install ]]; then
+            _arguments '--no-mirror[Skip the download mirror]'
+          fi
+          ;;
+        logs)
+          if (( CURRENT == 2 )); then
+            local -a logs_commands
+            logs_commands=('open:Open the log location')
+            _describe -t commands 'logs command' logs_commands
+            _arguments '--session[Restrict to one session]:session id:' '--json[Emit a structured manifest]'
+          elif [[ $words[2] == open ]] && (( CURRENT == 3 )); then
+            local -a open_targets
+            open_targets=('desktop:Open the desktop log directory')
+            _describe -t targets 'target' open_targets
+          else
+            _arguments '--session[Restrict to one session]:session id:' '--json[Emit a structured manifest]'
+          fi
           ;;
       esac
       ;;


### PR DESCRIPTION
## 变更摘要

为 `rivet` 补齐 fish 与 Windows PowerShell 两套缺失的 Shell 补全，并把现有 bash/zsh 补全对齐到真实 CLI 表面（此前误报不存在的 `--help/--version`，且缺少 `browser`/`logs` 命令与 5 个 `config` 子命令）。

## 动机

`completions/` 目录原本只有 `rivet.bash` 和 `rivet.zsh`，fish 与 Windows PowerShell 用户没有任何补全。更关键的是，逐行核对 `src/main.ts`、`src/config/manager.ts`、`src/cli/browser-cli.ts`、`src/diagnostics/logs-cli.ts` 后发现既有 bash/zsh 补全本身就有硬伤：

- 提供 `--help` / `-h` / `--version` / `-v`，但 **main.ts 从未实现这些选项**——`rivet --help` 实际会被当作未知参数直接启动 TUI；
- 顶层命令只覆盖 `config`，漏掉 `serve` / `sessions` / `browser` / `logs`；
- `config` 子命令只列了 7 个，漏掉 `setup` / `set-url` / `set-model` / `set-approval` / `mcp`。

补全提示不存在的选项比不提示更糟，因此本次一并修正，使四种 shell 行为一致。

## 主要改动

- `completions/rivet.fish`（新增）：fish 补全
- `completions/rivet.ps1`（新增）：Windows PowerShell 补全，兼容 5.1 与 7+（`Register-ArgumentCompleter` 的 `-Native` 开关按需注入）
- `completions/rivet.bash` / `rivet.zsh`（重写）：修正上述缺陷，与新增脚本保持同一套命令面
- `README.md`：新增「启用 Shell 补全」安装说明（四种 shell 各一段）

四个脚本统一覆盖的真实命令面：

| 类别 | 内容 |
|---|---|
| 顶层命令 | `config` `serve` `sessions` `browser` `logs` |
| 全局 flags | `-p/--print` `--json` `--stream-json` `--goal` `--budget` `--model` `--provider` `-c/--continue` `-r/--resume` `--new` `--list` `--dangerously-skip-permissions` `--screen-reader` `--skip-welcome` `--stream-events` |
| config 子命令 | `show` `providers` `setup` `set-url` `set-model` `set-key` `set-key-env` `set-default` `set-approval` `add-model` `remove-model` `mcp`（含 `add-stdio`/`add-sse`/`remove`/`enable`/`disable`） |
| 子命令参数 | `serve --port`、`browser status\|check\|install --no-mirror`、`logs [open [desktop]] --session/--json`、`config setup --key/--key-env/--url/--model/--context-window/--max-tokens/--alias/--default`、`config set-approval` 四种模式 |

所有脚本都支持从 `~/.rivet/config.json` 动态补全 provider 名（`set-key` / `set-default` / `setup` 等场景）。

## 测试

未改动任何运行时代码（纯补全脚本 + 文档），未新增单元测试；四个脚本分别在真实解释器中做过功能验证：

- **bash**：驱动 `_rivet` 完成函数，mock `~/.rivet/config.json`，20 个用例全过（顶层/子命令/flag/动态 provider）
- **fish**（fish 4.8）：`complete -C` 驱动，18 个用例全过
- **Windows PowerShell**（5.1 语法兼容 + 7.x）：mock AST 驱动 completer，21 个用例全过
- **zsh**（zsh 5.9）：`zsh -n` 语法检查通过；补全 state 分发用 mock `_arguments`/`_describe` 验证

公共回归项：`--help` / `--version` 不再出现在任何脚本的补全候选中。

## 检查清单

- [x] 本地 `npm test` 通过（未触及运行时代码；CI 的 `npm test` 覆盖不受影响）
- [x] `npx tsc --noEmit` 无类型错误（无 TS 变更，`tsc` 语义上不受影响）
- [x] 变更范围最小化，无关改动已排除（仅 4 个补全脚本 + README 安装说明）
- [x] 文档（README / 用户手册 / CHANGELOG）已同步更新（README 新增安装说明；CHANGELOG 由维护者发布时统一记录）

## 相关 Issue

无
