### PR TITLE
docs(readme): renumber sections to fix duplicate '### 3.' heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Add-Content $PROFILE ". C:\path\to\rivet.ps1"
 
 > 补全内容与 CLI 保持一致：顶层命令（`config` / `serve` / `sessions` / `browser` / `logs`）、全局 flags、`config` 全部子命令，以及从 `~/.rivet/config.json` 动态读取的 provider 名。
 
-### 3. 配置 API Key（首次必做）
+### 4. 配置 API Key（首次必做）
 
 ```bash
 # A. 环境变量（首次试用最简单）
@@ -108,7 +108,7 @@ rivet config set-key deepseek sk-xxx
 
 > 其他提供商（Claude、GLM、Codex、MiniMax、MiMo）用法相同，详见 [模型配置](docs/user-guide-provider-config.md)。
 
-### 4. 启动
+### 5. 启动
 
 ```bash
 rivet            # 或：npm start / node dist/main.js


### PR DESCRIPTION
## 变更摘要

为 `rivet` CLI 新增 bash / zsh / fish / powershell 四套 Shell 补全脚本与安装说明；并修正 README 中因新增「启用 Shell 补全」小节导致的重复 `### 3.` 章节编号。

## 动机

终端用户希望 `rivet` 具备命令补全能力。新增的「启用 Shell 补全」小节最初与「配置 API Key」同为 `### 3.`，造成章节编号重复、阅读混乱，需要把后续章节顺延重排。

## 主要改动

- `completions/`（**新增 4 个文件**）：`rivet.bash`、`rivet.zsh`、`rivet.fish`、`rivet.ps1`，与真实 CLI 子命令对齐（对应提交 `fix(completions): align all four shell completions with the real CLI`）。
- `README.md`
  - 新增 `### 3. 启用 Shell 补全（可选）` 安装说明。
  - 原 `### 3. 配置 API Key` → `### 4.`，`### 4. 启动` → `### 5.`（修复重复编号，对应提交 `docs(readme): renumber sections to fix duplicate '### 3.' heading`）。

## 测试

补全脚本为 Shell 脚本，无单测；已在本地按各 Shell 手动验证补全可加载。其余改动仅为文档与脚本，不影响既有 TS 测试套件。

## 检查清单

- [x] 文档（README）已同步更新
- [x] 变更范围最小化（仅补全脚本 + README）
- [ ] `npm test` 通过（本分支不含 TS 源码逻辑改动，CI 应全绿；合入前以 CI 为准）
- [ ] `npx tsc --noEmit` 无类型错误（本分支不含 TS 源码改动）

## 相关 Issue

无。