### PR TITLE
fix(pointer-guard): 拦截 apply-patch 指针交叉 echo 到写入工具（前缀入列 + 渲染补机器 tag）

### DIFF
--- a/src/tools/__tests__/pointer-guard.test.ts
+++ b/src/tools/__tests__/pointer-guard.test.ts
@@ -33,6 +33,7 @@ describe('detectPointerPlaceholder', () => {
       '[hash_edit applied to': '[hash_edit applied to /x/y.md — new block 5 lines, 100 chars. #RIVET-POINTER-DISPLAY-ONLY# Display placeholder — never emit this as content; use read_file to review.]',
       '[new block': '[new block 100 chars — #RIVET-POINTER-DISPLAY-ONLY# placeholder, never emit as content]',
       '[plan persisted to': '[plan persisted to .rivet/plans/x.md — 5 lines, 100 chars. #RIVET-POINTER-DISPLAY-ONLY# Use read_file to review.]',
+      '[patch applied to': '[patch applied to 2 file(s): a.ts, b.ts — 3 hunks, 1520 chars. 已成功应用，勿重放——历史正常截断，查看用 read_file / git diff。#RIVET-POINTER-DISPLAY-ONLY# display-only pointer]',
     }
     for (const prefix of POINTER_PLACEHOLDER_PREFIXES) {
       const sample = samples[prefix]
@@ -50,12 +51,20 @@ describe('detectPointerPlaceholder', () => {
       '[hash_edit applied to': '[hash_edit applied to /x/y.md — new block 5 lines, 100 chars. 已成功落盘，勿重做——历史正常截断，查看用 read_file。#RIVET-POINTER-DISPLAY-ONLY# display-only pointer]',
       '[new block': '[new block 100 chars — 已落盘，勿重做。#RIVET-POINTER-DISPLAY-ONLY# display-only pointer]',
       '[plan persisted to': '[plan persisted to .rivet/plans/x.md — 5 lines, 100 chars. 已成功落盘，勿重贴——历史正常截断，查看用 read_file。#RIVET-POINTER-DISPLAY-ONLY# display-only pointer]',
+      '[patch applied to': '[patch applied to 2 file(s): a.ts, b.ts — 3 hunks, 1520 chars. 已成功应用，勿重放——历史正常截断，查看用 read_file / git diff。#RIVET-POINTER-DISPLAY-ONLY# display-only pointer]',
     }
     for (const prefix of POINTER_PLACEHOLDER_PREFIXES) {
       const sample = samples[prefix]
       assert.ok(sample, `missing test sample for prefix ${prefix}`)
       assert.equal(detectPointerPlaceholder(sample), prefix, prefix)
     }
+  })
+
+  it('detects an apply_patch pointer echoed into write_file content (cross-tool)', () => {
+    // apply-patch 的大 diff 在历史中被折叠为 [patch applied to …] 指针；
+    // 模型可能把它 echo 成 write_file 的 content —— 守卫必须识别（前缀 + tag 双条件）。
+    const apPtr = '[patch applied to 2 file(s): a.ts, b.ts — 3 hunks, 1520 chars. 已成功应用，勿重放——历史正常截断，查看用 read_file / git diff。#RIVET-POINTER-DISPLAY-ONLY# display-only pointer]'
+    assert.equal(detectPointerPlaceholder(apPtr), '[patch applied to')
   })
 
   it('detects a pointer behind leading whitespace', () => {

--- a/src/tools/apply-patch-arg-processor.ts
+++ b/src/tools/apply-patch-arg-processor.ts
@@ -18,6 +18,7 @@
  */
 
 import type { ToolArgProcessor } from '../agent/tool-arg-post-processor.js'
+import { POINTER_INTERNAL_TAG } from './pointer-tag.js'
 
 export const APPLY_PATCH_POINTER_PREFIX = '[patch applied to'
 
@@ -68,7 +69,7 @@ export const applyPatchArgProcessor: ToolArgProcessor = {
 
     return JSON.stringify({
       ...parsed,
-      diff: `${APPLY_PATCH_POINTER_PREFIX} ${files.length} file(s): ${shown}${more} — ${hunks} hunks, ${diff.length} chars. 已成功应用，勿重放——历史正常截断，查看用 read_file / git diff。]`,
+      diff: `${APPLY_PATCH_POINTER_PREFIX} ${files.length} file(s): ${shown}${more} — ${hunks} hunks, ${diff.length} chars. 已成功应用，勿重放——历史正常截断，查看用 read_file / git diff。${POINTER_INTERNAL_TAG} display-only pointer]`,
     })
   },
 }

--- a/src/tools/pointer-guard.ts
+++ b/src/tools/pointer-guard.ts
@@ -18,6 +18,7 @@
 import { WRITE_FILE_POINTER_PREFIX } from './write-file-arg-processor.js'
 import { EDIT_FILE_POINTER_PREFIX } from './edit-file-arg-processor.js'
 import { HASH_EDIT_POINTER_PREFIX } from './hash-edit-arg-processor.js'
+import { APPLY_PATCH_POINTER_PREFIX } from './apply-patch-arg-processor.js'
 import { POINTER_INTERNAL_TAG } from './pointer-tag.js'
 import { readFile } from 'node:fs/promises'
 import { toPosixPath } from '../path-format.js'
@@ -32,6 +33,7 @@ export const POINTER_PLACEHOLDER_PREFIXES: readonly string[] = [
   WRITE_FILE_POINTER_PREFIX,
   EDIT_FILE_POINTER_PREFIX,
   HASH_EDIT_POINTER_PREFIX,
+  APPLY_PATCH_POINTER_PREFIX,
   EDIT_NEW_BLOCK_POINTER_PREFIX,
   PLAN_POINTER_PREFIX,
 ]


### PR DESCRIPTION
   变更摘要

   把 apply-patch 的大 diff 折叠指针 [patch applied to …] 纳入 pointer-guard 识别范围，并补齐其渲染机器
   tag——堵住"模型把该指针 echo 成 write_file / hash_edit / edit_file 内容时守卫不拦截"的交叉 echo 漏洞。

   动机

   apply-patch-arg-processor 会把超大 diff 折叠成 [patch applied to …] 摘要指针（历史压缩机制）。但该前缀不在
   pointer-guard 的 POINTER_PLACEHOLDER_PREFIXES 中，且渲染时缺少机器
   tag（#RIVET-POINTER-DISPLAY-ONLY#）。模型在长会话中看到历史里的指针后，可能把它当作真实内容 echo
   给其他写入工具（write_file 的 content / hash_edit 的 new_string / edit_file 的
   old_string）——守卫因前缀不识别而放行，占位符会被当真实内容落盘。该缺口在 v2.28.0 线上构建同样存在。

   主要改动

   - src/tools/pointer-guard.ts：POINTER_PLACEHOLDER_PREFIXES 增加 APPLY_PATCH_POINTER_PREFIX（'[patch applied
   to'），交叉 echo 被 detectPointerPlaceholder 命中后走既有的幂等化解 / 拦截错误流程
   - src/tools/apply-patch-arg-processor.ts：折叠指针渲染补 POINTER_INTERNAL_TAG，与 write_file / plan
   指针格式统一——守卫的 marker 检查依赖该 tag，缺它即使前缀命中也会放行
   - src/tools/__tests__/pointer-guard.test.ts：新增 cross-tool 用例（apply-patch 指针 echo 成 write_file content
   必须识别），samples 补对应条目

   测试

   相关 4 套件合计 50/50 通过（基于 v2.28.0 基线实测）：pointer-guard 25/25、apply-patch-arg-processor
   10/10、apply-patch 10/10、write-file-pointer-idempotent 5/5（RED→GREEN：新用例修复前失败、修复后通过）

   守卫原有行为不变：真实内容仍放行（前缀 + 单行 + marker 三重字面条件，多行正文与文中提及指针不受影响）

   检查清单

   - 变更范围最小化：仅 3 个文件 +13/-1，无无关改动
   - 相关测试 50/50 通过（pointer-guard / apply-patch 相关 4 套件，v2.28.0 基线）
   - 本地 npm test 通过（runner 存在已知的子进程泄漏问题，与本次改动无关——详见 CLAUDE.md「测试挂死会污染归因」纪律）
   - npx tsc --noEmit 无类型错误