### PR TITLE
fix(agent): DeepSeek effort 映射修复 + 双向 effort 调度 + 缓存预热 + ShadowQueue 校验加固

### DIFF
--- a/src/agent/__tests__/effort-routing.test.ts
+++ b/src/agent/__tests__/effort-routing.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { routeRoutineEffort, isEffortRoutingEnabled } from '../effort-routing.js'
+import { routeRoutineEffort, isEffortRoutingEnabled, escalateOnHardSignal } from '../effort-routing.js'
 
 describe('routeRoutineEffort (Phase 2A)', () => {
   const routine = { complexity: 0.2, momentum: 0.9, confidence: 0.8 }
@@ -56,5 +56,27 @@ describe('routeRoutineEffort (Phase 2A)', () => {
       if (prev === undefined) delete process.env['RIVET_EFFORT_ROUTING']
       else process.env['RIVET_EFFORT_ROUTING'] = prev
     }
+  })
+})
+
+describe('escalateOnHardSignal (Phase 2B)', () => {
+  it('forces max when verification debt is present', () => {
+    assert.equal(escalateOnHardSignal('low', { hasVerificationDebt: true, doomLoopLevel: 'none' }), 'max')
+  })
+
+  it('forces max on a doom-loop warning even without verification debt', () => {
+    assert.equal(escalateOnHardSignal('medium', { hasVerificationDebt: false, doomLoopLevel: 'warn' }), 'max')
+  })
+
+  it('forces max on a doom-loop block', () => {
+    assert.equal(escalateOnHardSignal('high', { hasVerificationDebt: false, doomLoopLevel: 'blocked' }), 'max')
+  })
+
+  it('leaves effort unchanged with no hard signal', () => {
+    assert.equal(escalateOnHardSignal('medium', { hasVerificationDebt: false, doomLoopLevel: 'none' }), 'medium')
+  })
+
+  it('is idempotent when already max', () => {
+    assert.equal(escalateOnHardSignal('max', { hasVerificationDebt: true, doomLoopLevel: 'blocked' }), 'max')
   })
 })

--- a/src/agent/__tests__/llm-speculation-wiring.test.ts
+++ b/src/agent/__tests__/llm-speculation-wiring.test.ts
@@ -66,6 +66,14 @@ describe('LLM speculation wiring (loop-factory → turn-orchestrator → p3)', (
       // The engine's only consumer was ShadowQueue pre-execution; with serving
       // cut (stale-read incident) an opted-in engine would burn side-path LLM
       // calls for nothing — so the factory never constructs it anymore.
+      //
+      // 2026-08-05 (P4 排雷): ShadowQueue 本身已补 mtime/size/TTL 校验
+      // （shadow-queue.ts）——但这条断言仍必须保持"不构造"，因为核实发现
+      // `checkSpeculativeCache` 的服务消费点在 tool-pipeline.ts 里是被物理删除
+      // 的，不是被某个 flag 挡住（全仓 grep 零生产调用点）。光修好 ShadowQueue
+      // 校验、不接回服务消费点就打开这条链，等于精确复现 2026-07-07 封存理由
+      // 本身写的那句话："纯预执行是纯成本、零收益"。重启需要先把服务消费点
+      // 设计接回去，这块工作本次未做，是识别到的新增范围，留给下一次评估。
       assert.equal(deps.speculateDuringBatch, undefined, 'sealed chain must not inject the dep')
       assert.equal(loop.llmSpeculationEngine, null, 'engine must not be constructed')
       assert.equal(client.calls.length, 0, 'no speculative LLM call may fire')

--- a/src/agent/__tests__/prefix-prewarm.test.ts
+++ b/src/agent/__tests__/prefix-prewarm.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, mock } from 'node:test'
+import assert from 'node:assert/strict'
+import { firePrefixPrewarm } from '../prefix-prewarm.js'
+import type { OaiChatRequest, OaiMessage } from '../../api/oai-types.js'
+
+const HISTORY: OaiMessage[] = [
+  { role: 'system', content: 'sys' },
+  { role: 'user', content: 'hello' },
+  { role: 'assistant', content: 'hi there' },
+]
+
+describe('firePrefixPrewarm (P3)', () => {
+  it('builds the request with sidePath history + a trailing ping, max_tokens=1', async () => {
+    let capturedMessages: OaiMessage[] = []
+    let capturedRequest: OaiChatRequest | undefined
+    const client = {
+      stream: mock.fn(async (request: OaiChatRequest) => { capturedRequest = request }),
+    }
+    let result: { ok: boolean; elapsedMs: number; error?: string } | undefined
+
+    firePrefixPrewarm({
+      client,
+      getMessages: () => HISTORY,
+      buildRequest: messages => {
+        capturedMessages = messages
+        return { model: 'deepseek-v4-flash', messages, max_tokens: 999_999 }
+      },
+      onResult: r => { result = r },
+    })
+
+    // fire-and-forget: give the microtask queue a turn to settle the .then()
+    await new Promise(r => setTimeout(r, 0))
+
+    assert.equal(capturedMessages.length, HISTORY.length + 1, 'must append exactly one synthetic ping after the real history')
+    assert.deepEqual(capturedMessages.slice(0, HISTORY.length), HISTORY, 'real history must be passed through untouched (byte-stable prefix)')
+    assert.equal(capturedMessages[HISTORY.length]!.role, 'user', 'the synthetic ping must be a user message (valid trailing role)')
+    assert.equal(capturedRequest?.max_tokens, 1, 'must override max_tokens to 1 regardless of what buildRequest returned')
+    assert.equal(client.stream.mock.calls.length, 1)
+    assert.equal(result?.ok, true)
+  })
+
+  it('does not throw and reports failure via onResult when buildRequest throws', () => {
+    let result: { ok: boolean; error?: string } | undefined
+    assert.doesNotThrow(() => {
+      firePrefixPrewarm({
+        client: { stream: mock.fn(async () => {}) },
+        getMessages: () => HISTORY,
+        buildRequest: () => { throw new Error('boom') },
+        onResult: r => { result = r },
+      })
+    })
+    assert.equal(result?.ok, false)
+    assert.ok(result?.error?.includes('boom'))
+  })
+
+  it('does not throw and reports failure via onResult when client.stream rejects', async () => {
+    let result: { ok: boolean; error?: string } | undefined
+    firePrefixPrewarm({
+      client: { stream: mock.fn(async () => { throw new Error('network down') }) },
+      getMessages: () => HISTORY,
+      buildRequest: messages => ({ model: 'deepseek-v4-flash', messages }),
+      onResult: r => { result = r },
+    })
+    await new Promise(r => setTimeout(r, 0))
+    assert.equal(result?.ok, false)
+    assert.ok(result?.error?.includes('network down'))
+  })
+
+  it('is fire-and-forget: returns synchronously without waiting for client.stream', () => {
+    let streamResolved = false
+    const client = {
+      stream: () => new Promise<void>(resolve => {
+        setTimeout(() => { streamResolved = true; resolve() }, 50)
+      }),
+    }
+    firePrefixPrewarm({
+      client,
+      getMessages: () => HISTORY,
+      buildRequest: messages => ({ model: 'deepseek-v4-flash', messages }),
+    })
+    // If firePrefixPrewarm awaited internally, streamResolved would already be true here.
+    assert.equal(streamResolved, false, 'must return before the underlying stream() settles')
+  })
+})

--- a/src/agent/__tests__/shadow-queue.test.ts
+++ b/src/agent/__tests__/shadow-queue.test.ts
@@ -1,8 +1,21 @@
-import { describe, it } from 'node:test'
+import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { ShadowQueue } from '../shadow-queue.js'
 
 describe('ShadowQueue', () => {
+  let dir: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'rivet-shadow-queue-'))
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
   it('enqueues predicted tool execution', () => {
     const queue = new ShadowQueue({
       execute: async () => 'result',
@@ -11,19 +24,21 @@ describe('ShadowQueue', () => {
     assert.equal(queue.pending(), 1)
   })
 
-  it('returns cached result on hit', async () => {
+  it('returns cached result on hit when the target file is unchanged since enqueue', async () => {
+    const target = join(dir, 'foo.ts')
+    writeFileSync(target, 'export const a = 1\n')
     const queue = new ShadowQueue({
       execute: async () => 'cached-content',
     })
-    queue.enqueue({ tool: 'read_file', probability: 0.8, likelyTarget: 'src/foo.ts' })
+    queue.enqueue({ tool: 'read_file', probability: 0.8, likelyTarget: target })
     await new Promise(r => setTimeout(r, 20))
-    const hit = queue.checkHit('read_file', 'src/foo.ts')
+    const hit = queue.checkHit('read_file', target)
     assert.equal(hit, 'cached-content')
   })
 
   it('returns undefined on miss', () => {
     const queue = new ShadowQueue({ execute: async () => 'x' })
-    assert.equal(queue.checkHit('read_file', 'src/other.ts'), undefined)
+    assert.equal(queue.checkHit('read_file', join(dir, 'other.ts')), undefined)
   })
 
   it('does not enqueue below probability threshold', () => {
@@ -74,13 +89,17 @@ describe('ShadowQueue', () => {
   })
 
   it('tracks per-source enqueue/hit stats', async () => {
+    const a = join(dir, 'a.ts')
+    const b = join(dir, 'b.ts')
+    const c = join(dir, 'c.ts')
+    writeFileSync(a, '1'); writeFileSync(b, '2'); writeFileSync(c, '3')
     const queue = new ShadowQueue({ execute: async () => 'content' })
-    queue.enqueue({ tool: 'read_file', probability: 0.8, likelyTarget: 'a.ts', source: 'llm' })
-    queue.enqueue({ tool: 'read_file', probability: 0.8, likelyTarget: 'b.ts', source: 'physarum-file' })
-    queue.enqueue({ tool: 'read_file', probability: 0.8, likelyTarget: 'c.ts' }) // defaults to tool-pattern
+    queue.enqueue({ tool: 'read_file', probability: 0.8, likelyTarget: a, source: 'llm' })
+    queue.enqueue({ tool: 'read_file', probability: 0.8, likelyTarget: b, source: 'physarum-file' })
+    queue.enqueue({ tool: 'read_file', probability: 0.8, likelyTarget: c }) // defaults to tool-pattern
     await new Promise(r => setTimeout(r, 20))
 
-    queue.checkHit('read_file', 'a.ts')
+    queue.checkHit('read_file', a)
 
     const stats = queue.statsBySource()
     assert.equal(stats.llm.enqueued, 1)
@@ -98,5 +117,77 @@ describe('ShadowQueue', () => {
     // enqueue returns void, not Promise — caller cannot accidentally float it
     const result = queue.enqueue({ tool: 'read_file', probability: 0.8, likelyTarget: 'src/foo.ts' })
     assert.equal(result, undefined, 'enqueue must return void')
+  })
+
+  describe('staleness validation (2026-07-06 stale-read incident fix)', () => {
+    it('rejects a hit when the target file was edited after enqueue (mtime/size moved)', async () => {
+      const target = join(dir, 'edited.ts')
+      writeFileSync(target, 'v1\n')
+      const queue = new ShadowQueue({ execute: async () => 'stale content read at enqueue time' })
+      queue.enqueue({ tool: 'read_file', probability: 0.8, likelyTarget: target })
+      await new Promise(r => setTimeout(r, 20))
+
+      // Simulate an edit landing between the speculative read and the real read.
+      // Sleep a beat first: some filesystems have coarse mtime granularity and
+      // an edit in the same tick could keep mtime identical — size still moves.
+      await new Promise(r => setTimeout(r, 10))
+      writeFileSync(target, 'v2 — much longer content than v1\n')
+
+      const hit = queue.checkHit('read_file', target)
+      assert.equal(hit, undefined, 'an edit after enqueue must invalidate the cached read, never serve stale content')
+    })
+
+    it('rejects a hit when the target was deleted after enqueue', async () => {
+      const target = join(dir, 'deleted.ts')
+      writeFileSync(target, 'v1\n')
+      const queue = new ShadowQueue({ execute: async () => 'content' })
+      queue.enqueue({ tool: 'read_file', probability: 0.8, likelyTarget: target })
+      await new Promise(r => setTimeout(r, 20))
+
+      rmSync(target)
+
+      assert.equal(queue.checkHit('read_file', target), undefined)
+    })
+
+    it('rejects a hit when the target never existed (stat failed at enqueue time — cannot verify freshness)', async () => {
+      const queue = new ShadowQueue({ execute: async () => 'content for a path that was never real' })
+      const target = join(dir, 'never-existed.ts')
+      queue.enqueue({ tool: 'read_file', probability: 0.8, likelyTarget: target })
+      await new Promise(r => setTimeout(r, 20))
+
+      assert.equal(queue.checkHit('read_file', target), undefined, 'unverifiable entries must never be served, not treated as fresh')
+    })
+
+    it('rejects a hit past the TTL even when the file is unchanged', async () => {
+      const target = join(dir, 'aged-out.ts')
+      writeFileSync(target, 'v1\n')
+      const queue = new ShadowQueue({ execute: async () => 'content', ttlMs: 15 })
+      queue.enqueue({ tool: 'read_file', probability: 0.8, likelyTarget: target })
+      await new Promise(r => setTimeout(r, 40)) // enqueue settle (~20ms) + past the 15ms TTL
+
+      assert.equal(queue.checkHit('read_file', target), undefined, 'TTL must expire an entry even if the underlying file never changed')
+    })
+
+    it('serves the hit when well within TTL and the file is unchanged', async () => {
+      const target = join(dir, 'fresh.ts')
+      writeFileSync(target, 'v1\n')
+      const queue = new ShadowQueue({ execute: async () => 'content', ttlMs: 60_000 })
+      queue.enqueue({ tool: 'read_file', probability: 0.8, likelyTarget: target })
+      await new Promise(r => setTimeout(r, 20))
+
+      assert.equal(queue.checkHit('read_file', target), 'content')
+    })
+
+    it('clear() empties the queue — the write/edit invalidation call site invokes this on any write success', async () => {
+      const target = join(dir, 'foo.ts')
+      writeFileSync(target, 'v1\n')
+      const queue = new ShadowQueue({ execute: async () => 'content' })
+      queue.enqueue({ tool: 'read_file', probability: 0.8, likelyTarget: target })
+      await new Promise(r => setTimeout(r, 20))
+
+      queue.clear()
+
+      assert.equal(queue.checkHit('read_file', target), undefined, 'clear() must drop entries queued before any write')
+    })
   })
 })

--- a/src/agent/council/council-orchestrator.ts
+++ b/src/agent/council/council-orchestrator.ts
@@ -216,6 +216,22 @@ function seatTierFloor(seat: CouncilSeat, objective: string): Pick<CouncilFanout
   return { tierFloor: route.tier }
 }
 
+/** Council 分歧升档（effort 双向调度的 council 分支，见 effort-routing.ts
+ *  escalateOnHardSignal 头注释）：round2 只在 round1 有冲突时才扇出（见
+ *  runCouncilDebate 调用点），所以能进到这里本身就是"分歧信号已确认"——
+ *  没有单独的 divergence 阈值判断,冲突存在即升档。当前 coordinator/WorkOrder
+ *  管线只有模型档位（tierFloor: cheap/balanced/strong）这一条已接通的升档
+ *  通道，没有独立的 reasoning-effort 下限通道，所以这里升的是 tierFloor 到
+ *  最高档 'strong'，不是字面意义的 effort='max'——同一意图('第二轮值得更贵
+ *  的模型')在现有管线里的落地方式。显式声明 provider+model 的席位保留原样，
+ *  不覆盖用户的显式选择。 */
+function round2DivergenceTierFloor(seat: CouncilSeat, objective: string): Pick<CouncilFanoutRequest, 'tierFloor'> {
+  if (seat.provider && seat.model) return {}
+  const base = seatTierFloor(seat, objective)
+  if (base.tierFloor === 'strong') return base
+  return { tierFloor: 'strong' }
+}
+
 /** 单轮会诊：恰一次 delegateBatch 扇出席位 → 裁决 → 渲染。绝不派 worker 执行 / 分波。 */
 export async function runCouncil(input: CouncilInput, deps: CouncilDeps): Promise<CouncilPlan> {
   const convenedAt = deps.now() // 全程只取一次时钟，喂 shadow / meta / md，杜绝双取不一致。
@@ -347,7 +363,7 @@ export async function runCouncilDebate(input: CouncilInput, deps: CouncilDeps): 
     scope: {},
     authority: seat.authority,
     ...seatModelOverride(seat),
-    ...seatTierFloor(seat, input.draft.objective),
+    ...round2DivergenceTierFloor(seat, input.draft.objective),
   }))
   const run2 = await deps.delegateBatch(r2requests, 'all_required', input.abortSignal,
     deps.onSeatProgress

--- a/src/agent/effort-routing.ts
+++ b/src/agent/effort-routing.ts
@@ -1,4 +1,5 @@
 import type { ReasoningEffort } from './auto-reasoning.js'
+import type { DoomLoopLevel } from './trace-store.js'
 
 const ORDER: ReasoningEffort[] = ['off', 'low', 'medium', 'high', 'max']
 
@@ -57,4 +58,36 @@ export function routeRoutineEffort(
   const idx = ORDER.indexOf(effort)
   if (idx <= 0) return effort
   return ORDER[idx - 1]!
+}
+
+export interface HardEffortSignals {
+  /** EvidenceTracker.hasVerificationDebt() — failed verification or ≥3 unverified edits. */
+  hasVerificationDebt: boolean
+  /** Doom-loop detector output — 'warn'/'blocked' means the agent looks stuck. */
+  doomLoopLevel: DoomLoopLevel
+}
+
+/**
+ * Phase 2B: force effort to 'max' when a hard signal fires, overriding
+ * whatever the routine-turn heuristic would otherwise pick.
+ *
+ * This is the "upgrade" half of bidirectional effort scheduling — the only
+ * half that matters for DeepSeek V4, where 'low'/'medium' are server-side
+ * no-ops (see openai-client.ts DeepSeek normalization) and the routine-turn
+ * downgrade path already has nowhere lower to go than 'high'. Callers should
+ * run this BEFORE {@link routeRoutineEffort} and skip the downgrade entirely
+ * when it returns 'max'.
+ *
+ * Deliberately narrow: only verification debt and doom-loop warnings, both
+ * already-computed signals with no new tracking machinery. Plan-mode's
+ * forced 'max' and council divergence escalation are handled at their own
+ * call sites (turn-step-producer.ts, council-orchestrator.ts respectively) —
+ * this function does not duplicate them.
+ */
+export function escalateOnHardSignal(
+  effort: ReasoningEffort,
+  signals: HardEffortSignals,
+): ReasoningEffort {
+  if (signals.hasVerificationDebt || signals.doomLoopLevel !== 'none') return 'max'
+  return effort
 }

--- a/src/agent/loop-factory.ts
+++ b/src/agent/loop-factory.ts
@@ -36,6 +36,7 @@ import { IntentRetrievalRouteController } from './intent-retrieval-route-control
 import { AntiAnchoringController } from './anti-anchoring-controller.js'
 import { ModelRoutingShadowController } from './model-routing-shadow-controller.js'
 import { PrewarmController } from './prewarm-controller.js'
+import { firePrefixPrewarm } from './prefix-prewarm.js'
 import { canonicalizePhysarumFileTarget } from './hooks/physarum-file-access-hook.js'
 import { TurnStepProducer } from './turn-step-producer.js'
 import { skillRegistry } from '../skills/skill-loader.js'
@@ -118,6 +119,44 @@ export function createReclaimDecisionRecorder(self: AgentLoop): (record: Reclaim
           .then(() => fs.appendFile(join(dir, 'cache-log.jsonl'), line + '\n'))
       }).catch(() => {})
     } catch { /* telemetry is best-effort — never break compaction */ }
+  }
+}
+
+/**
+ * P3 — 压缩/会话分裂/resume 后主动预热服务端前缀缓存（`prefix-prewarm.ts`）。
+ * fire-and-forget：调用方（turn-orchestrator/bootstrap）不 await 这个函数本身
+ * 的返回，结果异步落一行 `event:'prewarm'` 到 cache-log.jsonl，失败静默。
+ */
+export function createPrefixPrewarmRunner(self: AgentLoop): () => void {
+  return () => {
+    try {
+      firePrefixPrewarm({
+        client: self.config.client,
+        getMessages: () => self.session.getMessages(),
+        buildRequest: messages => self.config.promptEngine.buildOaiRequest(
+          messages,
+          undefined,
+          self.config.contextWindow,
+          { sidePath: true },
+        ),
+        onResult: result => {
+          const sid = self.config.sessionId ?? 'anon'
+          const line = JSON.stringify({
+            event: 'prewarm',
+            t: Date.now(),
+            model: self.config.promptEngine.getModel(),
+            ok: result.ok,
+            elapsedMs: result.elapsedMs,
+            ...(result.error ? { error: result.error.slice(0, 300) } : {}),
+          })
+          import('node:fs/promises').then(fs => {
+            const dir = join(getSessionDir(self.cwd), sid)
+            return fs.mkdir(dir, { recursive: true })
+              .then(() => fs.appendFile(join(dir, 'cache-log.jsonl'), line + '\n'))
+          }).catch(() => {})
+        },
+      })
+    } catch { /* prewarm is best-effort — never break the turn boundary */ }
   }
 }
 
@@ -1110,6 +1149,7 @@ export function createTurnOrchestrator(self: AgentLoop): TurnOrchestrator {
     buildTurnRequest: (turn, strategy, sensorium, pressureResult, assistantResponded, userMessageConsumed, callbacks) =>
       self.turnStepProducer.buildTurnRequest(turn, strategy, sensorium, pressureResult, assistantResponded, userMessageConsumed, callbacks),
     prewarmRecentReads: () => self.prewarmController.prewarmRecentReads(),
+    firePrefixPrewarm: createPrefixPrewarmRunner(self),
     runPostSession: (callbacks) => self.runPostSession(callbacks),
     recordProviderOutcome: (ok) => { self.recordProviderOutcome(ok) },
 

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -122,7 +122,7 @@ import type { PermissionAllowRule, PermissionOverlay } from './permissions.js'
 import { createPermissionOverlay } from './permissions.js'
 import { recordToolHistory } from "./tool-history-recorder.js";
 import { requestThetaCheck } from "./theta-controller.js";
-import { createTurnStreamController, createTurnCompletionController, createToolExecutionController, createPlanTraceCoordinator, createCompactBoundaryCoordinator, createTurnOrchestrator, createTurnStepProducer, createReasoningEffortController, createIntentRetrievalRouteController, createAntiAnchoringController, createModelRoutingShadowController, createPrewarmController, createRuntimeHooksPipeline, buildRuntimeSnapshot, createSidePathUsageRecorder, createReclaimDecisionRecorder } from "./loop-factory.js";
+import { createTurnStreamController, createTurnCompletionController, createToolExecutionController, createPlanTraceCoordinator, createCompactBoundaryCoordinator, createTurnOrchestrator, createTurnStepProducer, createReasoningEffortController, createIntentRetrievalRouteController, createAntiAnchoringController, createModelRoutingShadowController, createPrewarmController, createRuntimeHooksPipeline, buildRuntimeSnapshot, createSidePathUsageRecorder, createReclaimDecisionRecorder, createPrefixPrewarmRunner } from "./loop-factory.js";
 import type { TurnStepProducer } from './turn-step-producer.js'
 import { ReasoningEffortController } from './reasoning-effort-controller.js'
 import { IntentRetrievalRouteController } from './intent-retrieval-route-controller.js'
@@ -825,6 +825,7 @@ export class AgentLoop {
       setReasoningEffort: effort => { this.setReasoningEffort(effort, 'programmatic') },
       getFingerprint: () => this.config.promptEngine.getFingerprint(),
       submitControlSignal: signal => { this.controlPlane.submit(signal) },
+      getVerificationDebt: () => this.evidence.hasVerificationDebt(),
     })
     this.intent = new TurnIntentController()
     this.contextInjection = new ContextInjectionController({
@@ -1339,6 +1340,16 @@ export class AgentLoop {
     // autoReasoning 档位）不得覆盖，保护显式用户意图。
     if (source === 'programmatic' && this.userReasoningOverride) return
     this.reasoningEffort.set(effort)
+  }
+
+  /**
+   * P3 — 主动预热服务端前缀缓存。压缩/会话分裂后由 turn-orchestrator 在轮内
+   * 自动触发；resume 场景没有"轮内"时机（agent 刚构造，还没开始第一轮），
+   * 由 bootstrap.ts 在恢复完成后显式调一次。fire-and-forget：从不 await、
+   * 从不重试、从不影响调用方。
+   */
+  firePrefixPrewarm(): void {
+    createPrefixPrewarmRunner(this)()
   }
 
   shadowEffortTelemetry(

--- a/src/agent/p3-integration.ts
+++ b/src/agent/p3-integration.ts
@@ -29,6 +29,20 @@ export interface P3Config {
    * chain is now inert unless explicitly enabled (unit tests only).
    * Re-enable in production only after ShadowQueue entries record mtime and
    * checkHit re-stats before returning.
+   *
+   * 2026-08-05 追加发现：上面这条"重启契约"只覆盖了一半——ShadowQueue 本身
+   * 已经补上 mtime/size/TTL 校验（`shadow-queue.ts`），但 `checkSpeculativeCache`
+   * 的服务消费点（原在 tool-pipeline.ts 工具执行前做命中短路）在 2026-07-06
+   * 就被物理删除了，不是被这个 flag 挡住——全仓 grep `checkSpeculativeCache`
+   * 只有本文件的定义和一处单测引用，零生产调用点。这意味着：即使把这个 flag
+   * 打开、把下面 enqueue 相关方法的门也打开，预测也只会被造出来又在 TTL 后
+   * 过期，从不被消费——这正是 2026-07-07 封存理由本身描述的"纯预执行是纯
+   * 成本、零收益"状态,重新触发同一个理由。真正的重启需要先决定并实现服务
+   * 消费点怎么接回 tool-pipeline.ts（短路真实工具执行前的一次 trace/harness/
+   * UI 事件一致性设计），这是比"修好 ShadowQueue 校验"更大的一块工作，本次
+   * 未做——ShadowQueue 校验修复本身是独立价值（即便投机链永远不重启，它也
+   * 让这个类不再是一个已知会跑出脏数据的定时炸弹），但只做这一半不代表可以
+   * 安全打开这个 flag。
    */
   speculativeEnabled?: boolean
   /** Background agent task executor */

--- a/src/agent/prefix-prewarm.ts
+++ b/src/agent/prefix-prewarm.ts
@@ -1,0 +1,71 @@
+import type { StreamClient } from '../api/stream-client.js'
+import type { OaiChatRequest, OaiMessage } from '../api/oai-types.js'
+
+/**
+ * P3 — 主动预热服务端前缀缓存（压缩/会话分裂/resume 之后）。
+ *
+ * 官方单元化缓存语义：新前缀第一轮必冷（cache write 价），第二轮才回暖
+ * （cache read 价）。压缩/分裂/resume 之后没有"别人"替这个会话建缓存——不像
+ * galaxy 多 worker 场景第一个 worker 的真实请求天然帮后面的 worker 建好缓存
+ * （`docs/plans/2026-07-31-galaxy-prewarm-and-cache-affinity.md` 的"不引入
+ * 提前发建缓存 API 请求"非目标正是针对那个场景：服务端自动前缀匹配，无需
+ * 客户端协调）。单会话场景没有这个天然热身对象，冷启动代价必然由下一次真实
+ * 请求来付——这里做的是把它挪到用户不可感知的时机（提前发一个极小请求），
+ * **摊平延迟，不是省钱**：cache write 的钱无论走哪次请求都要付一次。
+ *
+ * 刻意不做的事：不去改共享 client 的 reasoning effort / thinking 配置。
+ * fire-and-forget 调用不 await，若在此处临时切换共享 client 状态再异步恢复，
+ * 会跟"本轮稍后才构建的真实请求"产生竞态（CLAUDE.md「request 对象会被多个
+ * stream() 重入，client 变换层禁止 mutation」同一类问题）。一条空 ping 触发
+ * 模型跑出意外长思维链的最坏情况，由 P2 思维链上限看门狗兜底。
+ */
+
+const PREWARM_PING: OaiMessage = { role: 'user', content: '.' }
+
+export interface PrefixPrewarmResult {
+  ok: boolean
+  elapsedMs: number
+  error?: string
+}
+
+export interface PrefixPrewarmDeps {
+  client: Pick<StreamClient, 'stream'>
+  /** 复用生产同一条构建路径（frozen base + appendixDelta + 边界合并），
+   *  必须传 `{ sidePath: true }`——绝不能触碰主路径的冻结快照/appendix 基线。 */
+  buildRequest: (messages: OaiMessage[]) => OaiChatRequest
+  getMessages: () => OaiMessage[]
+  /** 失败静默、不重试；仅用于把结果记进 cache-log.jsonl，从不影响调用方。 */
+  onResult?: (result: PrefixPrewarmResult) => void
+}
+
+const noopCallbacks = {
+  onTextDelta: () => {},
+  onThinkingDelta: () => {},
+  onContentBlock: () => {},
+  onStopReason: () => {},
+  onError: () => {},
+}
+
+/**
+ * Fire-and-forget：调用方不 await，不重试，不阻塞真实轮次。
+ */
+export function firePrefixPrewarm(deps: PrefixPrewarmDeps): void {
+  const startedAt = Date.now()
+  let request: OaiChatRequest
+  try {
+    request = deps.buildRequest([...deps.getMessages(), PREWARM_PING])
+    // 只要 1 个输出 token 就够触发服务端对输入前缀的处理/建缓存——不需要，
+    // 也不想要，真实回答。
+    request.max_tokens = 1
+  } catch (err) {
+    deps.onResult?.({ ok: false, elapsedMs: Date.now() - startedAt, error: String((err as Error)?.message ?? err) })
+    return
+  }
+  const timeoutSignal = AbortSignal.timeout(30_000)
+  deps.client.stream(request, noopCallbacks, timeoutSignal).then(
+    () => { deps.onResult?.({ ok: true, elapsedMs: Date.now() - startedAt }) },
+    (err: unknown) => {
+      deps.onResult?.({ ok: false, elapsedMs: Date.now() - startedAt, error: String((err as Error)?.message ?? err) })
+    },
+  )
+}

--- a/src/agent/shadow-queue.ts
+++ b/src/agent/shadow-queue.ts
@@ -1,10 +1,22 @@
+import { stat, statSync } from 'node:fs'
+import { promisify } from 'node:util'
 import type { ToolPrediction } from './tool-pattern-miner.js'
+
+const statAsync = promisify(stat)
 
 const READ_ONLY_SPECULATIVE_TOOLS = new Set(['read_file', 'grep', 'glob', 'list_dir'])
 
 export interface ShadowQueueDeps {
   execute: (tool: string, target: string) => Promise<string>
   minProbability?: number
+  /**
+   * Entries older than this are treated as a miss regardless of mtime/size,
+   * mirroring PrewarmCache's TTL convention. Bounds the worst case for tool
+   * types whose `target` isn't a reliable staleness signal (see mtimeMs
+   * comment on CachedResult) — without a TTL, a stale-but-unstattable entry
+   * could sit in the queue indefinitely.
+   */
+  ttlMs?: number
 }
 
 type PredictionSource = NonNullable<ToolPrediction['source']>
@@ -14,6 +26,20 @@ interface CachedResult {
   target: string
   result: string
   source: PredictionSource
+  enqueuedAt: number
+  /**
+   * stat() taken right after execute() resolved (mirrors prewarm-file.ts
+   * buildPrewarmValue). Reliable staleness signal for `read_file` (target is
+   * a real file — any edit moves mtime/size). Weaker for `grep`/`list_dir`
+   * (target is often a directory: adding/removing files moves its mtime, but
+   * editing an existing file's content inside it does not) — TTL is the
+   * backstop for that gap, not a full fix. Absent when stat() failed at
+   * enqueue time (deleted mid-flight, or a target that isn't a real fs path
+   * at all) — checkHit treats absence as "can't verify" and never serves it,
+   * rather than assuming freshness.
+   */
+  mtimeMs?: number
+  sizeBytes?: number
 }
 
 export type ShadowQueueSourceStats = Record<PredictionSource, { enqueued: number; hits: number }>
@@ -27,14 +53,27 @@ function emptySourceStats(): ShadowQueueSourceStats {
   }
 }
 
+/**
+ * 2026-07-06 事故：本类完全没有 staleness 校验——预读结果在目标文件历经多次
+ * 编辑后仍被当作 read_file 的实时结果返回，模型据此推理出"文件被回退"之类
+ * 的幻觉结论。P3-P4（本次修复）补两层防线：①enqueue 时 stat 一次留痕，
+ * checkHit 时重新 stat 比对 mtime/size，任一漂移或缺失即判 miss；②TTL 兜底
+ * （见 mtimeMs 注释——目录级 target 的 mtime 信号本身不完整）。写/编辑工具
+ * 执行后应调 {@link ShadowQueue.clear} 整队失效（镜像 PrewarmCache.invalidate
+ * 的调用点模式，但本队列不是按文件路径索引的单一 key-value 存储，粗粒度整队
+ * 清空是这个数据结构下唯一安全的等价物——best-effort 投机缓存，清空代价是
+ * 一次浪费的预读，不是正确性问题）。
+ */
 export class ShadowQueue {
   private cache: CachedResult[] = []
   private inflight = 0
   private readonly minProbability: number
+  private readonly ttlMs: number
   private sourceStats: ShadowQueueSourceStats = emptySourceStats()
 
   constructor(private deps: ShadowQueueDeps) {
     this.minProbability = deps.minProbability ?? 0.4
+    this.ttlMs = deps.ttlMs ?? 60_000
   }
 
   enqueue(prediction: ToolPrediction): void {
@@ -45,8 +84,16 @@ export class ShadowQueue {
     const target = prediction.likelyTarget
     const source: PredictionSource = prediction.source ?? 'tool-pattern'
     this.sourceStats[source].enqueued++
-    void this.deps.execute(prediction.tool, target).then(result => {
-      this.cache.push({ tool: prediction.tool, target, result, source })
+    void this.deps.execute(prediction.tool, target).then(async result => {
+      const fileStat = await statAsync(target).catch(() => null)
+      this.cache.push({
+        tool: prediction.tool,
+        target,
+        result,
+        source,
+        enqueuedAt: Date.now(),
+        ...(fileStat ? { mtimeMs: fileStat.mtimeMs, sizeBytes: fileStat.size } : {}),
+      })
     }).catch(() => {
       // Speculative execution failed — silently absorb.
       // Shadow queue is best-effort; failures should not cause
@@ -58,6 +105,17 @@ export class ShadowQueue {
     const idx = this.cache.findIndex(c => c.tool === tool && c.target === target)
     if (idx === -1) return undefined
     const [hit] = this.cache.splice(idx, 1) as [CachedResult]
+    if (Date.now() - hit.enqueuedAt > this.ttlMs) return undefined
+    // No usable stat from enqueue time (deleted mid-flight, or target isn't a
+    // real fs path) — never assume freshness for something we couldn't verify.
+    if (hit.mtimeMs === undefined || hit.sizeBytes === undefined) return undefined
+    let live: ReturnType<typeof statSync>
+    try {
+      live = statSync(target)
+    } catch {
+      return undefined // deleted since enqueue
+    }
+    if (live.mtimeMs !== hit.mtimeMs || live.size !== hit.sizeBytes) return undefined
     this.sourceStats[hit.source].hits++
     return hit.result
   }

--- a/src/agent/tool-pipeline.ts
+++ b/src/agent/tool-pipeline.ts
@@ -1866,6 +1866,12 @@ export async function executeToolUse(
      } catch {
         deps.prewarm.invalidate(tu.input.file_path as string)
      }
+      // ShadowQueue 投机预读队列失效（P4 解封配套）：队列不像 PrewarmCache
+      // 按文件路径索引，没有对应单个 key 的失效方式（grep/glob/list_dir 的
+      // target 常是目录，不是被改的那个文件）——整队清空是这个数据结构下
+      // 唯一安全的等价物。checkHit 自带 mtime/size/TTL 校验兜底，这里是额外
+      // 的一层尽早失效，不是唯一防线。
+      deps.p3?.queue.clear()
    }
 
     // Prewarm grep-matched files: grep→read_file is the most common tool sequence.

--- a/src/agent/turn-orchestrator.ts
+++ b/src/agent/turn-orchestrator.ts
@@ -200,6 +200,9 @@ export interface TurnOrchestratorDeps {
     request?: import('../api/oai-types.js').OaiChatRequest
   }>
   prewarmRecentReads: () => Promise<void>
+  /** P3 — 压缩/会话分裂后主动预热服务端前缀缓存（fire-and-forget，never throws,
+   *  never awaited here）。缺省 → 不预热（向后兼容，测试 deps 可省略）。 */
+  firePrefixPrewarm?: () => void
   runPostSession: (callbacks: AgentCallbacks) => Promise<void>
   recordProviderOutcome: (ok: boolean) => void
 
@@ -522,6 +525,10 @@ export class TurnOrchestrator {
             return
           }
           if (compactionResult.userMessageConsumed) userMessageConsumed = true
+          // P3 — 新前缀第一轮必冷；这次压缩/分裂刚把它敲定，趁真实请求还没
+          // 发出去之前抢跑一个极小请求把它焐热（摊平延迟，不是省钱：cache
+          // write 的钱无论走哪次请求都要付一次）。Fire-and-forget，不阻塞本轮。
+          if (compactionResult.compacted) this.deps.firePrefixPrewarm?.()
         }
 
         this.deps.state.streamedText = ''

--- a/src/agent/turn-perception.ts
+++ b/src/agent/turn-perception.ts
@@ -10,7 +10,7 @@ import type { Sensorium, SensoriumInput, StrategyProfile } from './sensorium.js'
 import { adaptThetaInterval, buildStarPhaseContext, buildTelemetrySnapshot } from './perception.js'
 import type { ThetaTelemetrySnapshot } from './perception.js'
 import { createStarEvent } from './star-event.js'
-import { routeRoutineEffort } from './effort-routing.js'
+import { routeRoutineEffort, escalateOnHardSignal } from './effort-routing.js'
 import type { StarEvent, ThetaState } from './star-event.js'
 import type { VigorState } from './vigor.js'
 import type { TelemetryWriter } from './telemetry-writer.js'
@@ -30,6 +30,9 @@ export interface TurnPerceptionDeps {
   getFingerprint(): PrefixFingerprint
   /** Wave 2 控制面：hook 结构化事实上报出口（shadow 记账，不改 prompt）。 */
   submitControlSignal?(signal: import('./control-plane.js').ControlSignal): void
+  /** Phase 2B hard-signal effort escalation（effort-routing.ts escalateOnHardSignal）。
+   *  缺省 → 该信号不参与升档判定（只剩 routine 降档 + doom 信号）。 */
+  getVerificationDebt?(): boolean
 }
 
 export interface PerceptionInput {
@@ -137,10 +140,21 @@ export class TurnPerceptionController {
       this.hasEnteredHighComplexity = true
     }
 
+    // Phase 2B hard-signal escalation: verification debt or a doom-loop warning
+    // forces 'max', bypassing the routine-turn downgrade below entirely — this
+    // is the only actionable "upgrade" half of bidirectional effort scheduling
+    // (see effort-routing.ts escalateOnHardSignal for why downgrade alone is
+    // moot on DeepSeek V4). Uses the doomLevel already computed above for
+    // sensoriumInput — no extra tracking, no new fingerprint pass.
+    const hardEscalated = escalateOnHardSignal(nextStrategy.reasoningEffort, {
+      hasVerificationDebt: this.deps.getVerificationDebt?.() ?? false,
+      doomLoopLevel: sensoriumInput.doomLevel,
+    })
     // Phase 2A effort routing (default ON; opt out with RIVET_EFFORT_ROUTING=0):
     // step effort down one tier on routine, on-track turns. Floor is enforced
-    // downstream in ReasoningEffortController.set().
-    this.deps.setReasoningEffort(routeRoutineEffort(nextStrategy.reasoningEffort, {
+    // downstream in ReasoningEffortController.set(). Skipped when a hard signal
+    // already escalated to 'max' — nothing left to route down from there.
+    this.deps.setReasoningEffort(hardEscalated === 'max' ? 'max' : routeRoutineEffort(hardEscalated, {
       complexity: nextSensorium.complexity,
       momentum: nextSensorium.momentum,
       confidence: nextSensorium.confidence,

--- a/src/api/__tests__/deepseek-thinking-effort.test.ts
+++ b/src/api/__tests__/deepseek-thinking-effort.test.ts
@@ -80,6 +80,14 @@ test('DeepSeek thinking 模式：thinking 块与 reasoning_effort 必须并存',
   )
 })
 
+test('DeepSeek low/medium 在服务端会被静默改判成 high —— 客户端本地归一化到 high，不发死文字', async () => {
+  const lowBody = await captureBody({ ...DEEPSEEK_CONFIG, reasoningEffort: 'low' }, baseRequest)
+  assert.equal(lowBody.reasoning_effort, 'high', "low 对 DeepSeek V4 是服务端无效值，本地应归一化为 'high'")
+
+  const mediumBody = await captureBody({ ...DEEPSEEK_CONFIG, reasoningEffort: 'medium' }, baseRequest)
+  assert.equal(mediumBody.reasoning_effort, 'high', "medium 对 DeepSeek V4 是服务端无效值，本地应归一化为 'high'")
+})
+
 test('DeepSeek thinking disabled：不发 thinking 块也不发 reasoning_effort', async () => {
   const body = await captureBody(
     { ...DEEPSEEK_CONFIG, thinking: 'disabled' },

--- a/src/api/__tests__/openai-client.test.ts
+++ b/src/api/__tests__/openai-client.test.ts
@@ -49,6 +49,62 @@ describe('parseStream / SSE parsing', () => {
     assert.equal(stopReason, 'end_turn')
   })
 
+  it('P2: cuts the stream cleanly (not as an error) once accumulated reasoning crosses the cap', async () => {
+    // Cap of 5 tokens ≈ 20 chars — trivially exceeded by the deltas below.
+    const client = new OpenAIClient({ ...TEST_CONFIG, providerName: 'deepseek', reasoningChainCapTokens: 5 })
+    const encoder = new TextEncoder()
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode('data: {"choices":[{"delta":{"reasoning_content":"this is a long chain of thought that keeps going"},"index":0}]}\n\n'))
+        // A second delta the guard must never see — proves the stream was really cut, not just capped-then-continued.
+        controller.enqueue(encoder.encode('data: {"choices":[{"delta":{"reasoning_content":"more thinking after the cap should have fired"},"index":0}]}\n\n'))
+        controller.enqueue(encoder.encode('data: [DONE]\n\n'))
+        controller.close()
+      },
+    })
+    const response = new Response(stream)
+
+    const thoughts: string[] = []
+    let stopReason: string | undefined
+    let textEmitted = false
+
+    await (client as any).parseStreamFromReader(
+      response.body!.getReader(),
+      {
+        onThinkingDelta: (t: string) => thoughts.push(t),
+        onTextDelta: () => { textEmitted = true },
+        onStopReason: (reason: string) => { stopReason = reason },
+      },
+    )
+
+    assert.equal(stopReason, 'reasoning_chain_capped', 'cap hit must surface a distinct, greppable stop reason')
+    assert.equal(thoughts.length, 1, 'only the first delta should have been processed before the cut')
+    assert.equal(textEmitted, false, 'DeepSeek must not promote capped reasoning to visible text (GLM-only behavior)')
+  })
+
+  it('P2: reasoning cap disabled (0) never cuts even a very long chain', async () => {
+    const client = new OpenAIClient({ ...TEST_CONFIG, providerName: 'deepseek', reasoningChainCapTokens: 0 })
+    const encoder = new TextEncoder()
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode(`data: {"choices":[{"delta":{"reasoning_content":"${'x'.repeat(500_000)}"},"index":0}]}\n\n`))
+        controller.enqueue(encoder.encode('data: {"choices":[{"delta":{"content":"done"},"index":0,"finish_reason":"stop"}]}\n\n'))
+        controller.enqueue(encoder.encode('data: [DONE]\n\n'))
+        controller.close()
+      },
+    })
+    const response = new Response(stream)
+
+    let stopReason: string | undefined
+    const texts: string[] = []
+    await (client as any).parseStreamFromReader(
+      response.body!.getReader(),
+      { onTextDelta: (t: string) => texts.push(t), onStopReason: (reason: string) => { stopReason = reason } },
+    )
+    assert.equal(texts.join(''), 'done', 'a disabled cap must let the full stream through to the real answer')
+    assert.equal(stopReason, 'end_turn')
+  })
+
   it('handles empty stream', async () => {
     const client = new OpenAIClient(TEST_CONFIG)
     const stream = new ReadableStream({

--- a/src/api/__tests__/reasoning-chain-guard.test.ts
+++ b/src/api/__tests__/reasoning-chain-guard.test.ts
@@ -1,0 +1,24 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { shouldCapReasoning, DEFAULT_REASONING_CHAIN_CAP_TOKENS } from '../reasoning-chain-guard.js'
+
+describe('shouldCapReasoning (P2 96K reasoning-chain guard)', () => {
+  it('does not cap a short chain', () => {
+    assert.equal(shouldCapReasoning(100, 1000), false)
+  })
+
+  it('caps once accumulated chars/4 reaches the token cap', () => {
+    assert.equal(shouldCapReasoning(4000, 1000), true)
+    assert.equal(shouldCapReasoning(3999, 1000), false)
+  })
+
+  it('cap <= 0 disables the check entirely, regardless of length', () => {
+    assert.equal(shouldCapReasoning(10_000_000, 0), false)
+    assert.equal(shouldCapReasoning(10_000_000, -1), false)
+  })
+
+  it('defaults to 96,000 tokens when capTokens is omitted', () => {
+    assert.equal(shouldCapReasoning(DEFAULT_REASONING_CHAIN_CAP_TOKENS * 4 - 1), false)
+    assert.equal(shouldCapReasoning(DEFAULT_REASONING_CHAIN_CAP_TOKENS * 4), true)
+  })
+})

--- a/src/api/openai-client.ts
+++ b/src/api/openai-client.ts
@@ -11,6 +11,7 @@ import { sanitizeMessageContent } from '../utils/sanitize.js'
 import { wireAbortToReaderCancel, wrapBodyTimeoutError } from './abort-reader.js'
 import { debugLog } from '../utils/debug.js'
 import { repairInvalidJsonEscapes } from './json-escape-repair.js'
+import { shouldCapReasoning } from './reasoning-chain-guard.js'
 import { appendFileSync, mkdirSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 
@@ -101,6 +102,9 @@ export interface OpenAIClientConfig {
   model: string
   maxTokens: number
   reasoningEffort?: string
+  /** P2 思维链上限看门狗（reasoning-chain-guard.ts）。undefined → 默认 96,000；
+   *  <=0 → 关闭检查（无上限，旧行为）。 */
+  reasoningChainCapTokens?: number
   thinking?: 'enabled' | 'disabled'
   /** How to format thinking in the request body. 'openai' = use reasoning_effort only, others = use thinking block */
   thinkingFormat?: 'anthropic' | 'openai' | 'none'
@@ -432,6 +436,17 @@ export class OpenAIClient implements StreamClient {
     if (request.reasoning_effort && this.config.effortFormat !== 'none') {
       body.reasoning_effort = request.reasoning_effort
     }
+    // DeepSeek V4 only recognizes 'high'/'max' server-side — 'low' and 'medium'
+    // are silently coerced to 'high' by the API itself (confirmed against
+    // Agno/Together.ai/DeepSeek third-party docs, no official DeepSeek-side
+    // acknowledgment of the mapping but consistently reproduced). Whatever
+    // upstream config or effort-routing computes, normalize here so the wire
+    // value always matches what actually takes effect — otherwise routine-turn
+    // step-down (`effort-routing.ts`) silently costs nothing on this provider.
+    if (this.config.providerName === 'deepseek'
+      && (body.reasoning_effort === 'low' || body.reasoning_effort === 'medium')) {
+      body.reasoning_effort = 'high'
+    }
     // Codex (served via cliproxy) tops out at 'xhigh', not Rivet's canonical
     // 'max'. Map at the wire so the global ReasoningEffort enum stays unchanged
     // and other providers keep receiving 'max'.
@@ -687,6 +702,8 @@ export class OpenAIClient implements StreamClient {
     let lastFiredAsThinkingStall = false
     /** Whether any reasoning_content has been received — used to detect thinking stalls. */
     let receivedThinking = false
+    /** P2 96K reasoning-chain cap — set once, cuts the stream cleanly (see below). */
+    let reasoningCapHit = false
     // GLM-5.1 mandatory thinking mode outputs everything as reasoning_content
     // with no content field. Accumulate reasoning to promote if no content arrives.
     let reasoningAccum = ''
@@ -822,6 +839,20 @@ export class OpenAIClient implements StreamClient {
               reasoningAccum += parsed.choices[0].delta.reasoning_content
               receivedThinking = true
               if (reasoningRef) reasoningRef.content = reasoningAccum
+              // P2 96K 思维链上限看门狗: no native max-reasoning-tokens knob on
+              // DeepSeek, so we count client-side and cut cleanly (treated as a
+              // normal finish, NOT an error — an error would retry the whole
+              // request and pay for the runaway chain again). Empty streamedText
+              // + non-empty thinkingAccum at post-turn lands in the existing
+              // thinking-only-retry path (thinking-retry.ts), which already
+              // injects "respond directly without thinking" — no new retry
+              // machinery needed here.
+              if (!reasoningCapHit && shouldCapReasoning(reasoningAccum.length, this.config.reasoningChainCapTokens)) {
+                reasoningCapHit = true
+                streamDone = true
+                reader.cancel().catch(() => {})
+                break
+              }
             }
           } catch {
             // Skip malformed SSE lines
@@ -891,8 +922,15 @@ export class OpenAIClient implements StreamClient {
       }
       this._textAccum = ''
 
-      // If no usage chunk arrived, emit stop reason now
-      if (this.pendingStopReason) {
+      // If no usage chunk arrived, emit stop reason now. reasoningCapHit is a
+      // clean client-side cutoff (not a server finish_reason), so it takes a
+      // distinct, greppable stop reason instead of falling through to whatever
+      // pendingStopReason happens to hold (normally none yet, since the server
+      // never got to finish on its own).
+      if (reasoningCapHit) {
+        callbacks.onStopReason?.('reasoning_chain_capped', {})
+        this.pendingStopReason = null
+      } else if (this.pendingStopReason) {
         callbacks.onStopReason?.(mapFinishReason(this.pendingStopReason), {})
         this.pendingStopReason = null
       }

--- a/src/api/reasoning-chain-guard.ts
+++ b/src/api/reasoning-chain-guard.ts
@@ -1,0 +1,24 @@
+/**
+ * P2 — 96K 思维链上限看门狗（effort 双向调度收口，见
+ * src/agent/effort-routing.ts escalateOnHardSignal 头注释）。DeepSeek 没有
+ * Anthropic `budget_tokens` 式的原生"最大推理 token"参数——升到 max 之后思维链
+ * 可以无限跑，唯一能收口的手段是客户端自己边收流边数、越界就主动收口。
+ *
+ * chars/4 ≈ tokens 是仓库既有估算惯例（如 tool-pipeline.ts 的工具输出字符预算），
+ * 这里沿用同一惯例，不引入新的计数方式。
+ */
+
+/** 默认思维链上限（token）。0 关闭该检查（完全不设上限，回退旧行为）。 */
+export const DEFAULT_REASONING_CHAIN_CAP_TOKENS = 96_000
+
+/**
+ * @param accumulatedChars 当前已收到的 reasoning_content 累计字符数
+ * @param capTokens 上限（token）。<=0 表示关闭检查。
+ */
+export function shouldCapReasoning(
+  accumulatedChars: number,
+  capTokens: number = DEFAULT_REASONING_CHAIN_CAP_TOKENS,
+): boolean {
+  if (capTokens <= 0) return false
+  return accumulatedChars / 4 >= capTokens
+}

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -2230,6 +2230,13 @@ export async function bootstrapInteractiveSession(opts: BootstrapOptions = {}): 
   })
   refs.promptEngine = agent.config.promptEngine
   wireFrozenSnapshotPersist(persist, agent.config.promptEngine)
+  // P3 — resume 后主动预热服务端前缀缓存：长间隔后 provider 端 TTL 大概率
+  // 已过期，且不像轮内压缩场景有"下一轮"帮忙自然回暖——resume 完成到用户敲
+  // 下第一条消息之间就是唯一的、真实请求还没占用的空窗。只在真有历史可暖时
+  // 才发（否则等于对着空前缀发一个没有意义的 ping）。fire-and-forget。
+  if (wasSessionResumed() && existingMessages.length > 0) {
+    agent.firePrefixPrewarm()
+  }
   // 兜底模型续跑：meta + JSONL 审计，对齐 switchAgentSession/桌面 resume-fallback 语义。
   if (startupResume.fallbackUsed && startupResume.target) {
     try {

--- a/src/config/__tests__/provider-presets.test.ts
+++ b/src/config/__tests__/provider-presets.test.ts
@@ -22,11 +22,11 @@ describe('provider presets', () => {
     assert.equal(codex.models[0]?.id, 'gpt-5.5')
   })
 
-  it('deepseek cost defaults: pro=high effort, flash=medium effort', () => {
+  it('deepseek cost defaults: pro and flash both effort=high (medium/low are server-side no-ops on V4)', () => {
     const deepseek = cloneProviderPreset('deepseek')
     const pro = deepseek.models.find(m => m.id === 'deepseek-v4-pro')
     const flash = deepseek.models.find(m => m.id === 'deepseek-v4-flash')
     assert.equal(pro?.reasoningEffort, 'high')
-    assert.equal(flash?.reasoningEffort, 'medium')
+    assert.equal(flash?.reasoningEffort, 'high')
   })
 })

--- a/src/config/provider-presets.ts
+++ b/src/config/provider-presets.ts
@@ -52,7 +52,12 @@ export const PROVIDER_PRESETS: Record<ProviderPresetKey, ProviderPreset> = {
           alias: 'v4-flash',
           contextWindow: 1_000_000,
           maxTokens: 384_000,
-          reasoningEffort: 'medium',
+          // DeepSeek V4 only honors 'high'/'max' server-side — 'low'/'medium' are
+          // silently coerced to 'high'. Setting 'medium' here would have zero
+          // effect (openai-client.ts normalizes it anyway) but reads as if it
+          // saved cost when it never did. 'high' is the real, honest floor;
+          // the only actionable lever left is escalating to 'max' on hard signals.
+          reasoningEffort: 'high',
           tier: 'cheap',
           pricing: { input: 1, output: 2, cacheRead: 0.02, cacheWrite: 1 },
         },
@@ -263,7 +268,16 @@ export const PROVIDER_PRESETS: Record<ProviderPresetKey, ProviderPreset> = {
           alias: 'sf-v4-flash',
           contextWindow: 1_000_000,
           maxTokens: 384_000,
-          reasoningEffort: 'medium',
+          // Same 'medium' is a no-op as deepseek-v4-flash above (this IS DeepSeek
+          // V4 weights, just proxied). Separately: 'siliconflow' has no entry in
+          // WELL_KNOWN_DEFAULTS (src/api/provider.ts) so effortFormat/thinkingFormat
+          // resolve to 'none'/'none' — reasoning_effort and the thinking block are
+          // currently never sent at all for ANY siliconflow model (this field is
+          // presently inert for a second, more severe reason). Left unfixed here:
+          // fixing it means adding a WELL_KNOWN_DEFAULTS entry, which also affects
+          // sf-glm (GLM-5.2, a different reasoning protocol than DeepSeek's
+          // preserved-thinking) and needs live verification before being trusted.
+          reasoningEffort: 'high',
           tier: 'cheap',
           pricing: { input: 0.13, output: 0.28 },
         },


### PR DESCRIPTION
## Summary
- **effort 映射修复**：DeepSeek V4 服务端只认 `high`/`max`，`low`/`medium` 会被静默映射为 `high`——`openai-client.ts` 加本地归一化让发出去的值等于实际生效的值，`provider-presets.ts` 的 `deepseek-v4-flash`/`sf-v4-flash` 从 `medium` 改回 `high`（`medium` 这个"降档"从上线起就没生效过）。
- **双向 effort 调度**：新增 `escalateOnHardSignal`（验证债务 / doom-loop 预警 → 强制升到 `max`），接入 `turn-perception.ts`；`council-orchestrator.ts` 的 round2（本身只在有冲突时才扇出）把 `tierFloor` 提到 `strong`。
- **96K 思维链上限看门狗**：新增 `reasoning-chain-guard.ts`，流式循环里越界即清洁收口（不当错误重试，会把已经烧掉的思考再烧一遍）——复用了现成的 thinking-only-retry 路径，没有新造轮子。
- **前缀缓存预热**：新增 `prefix-prewarm.ts`，压缩/会话分裂后和 resume 后各发一次 fire-and-forget 的 `max_tokens:1` 请求，把服务端前缀缓存的冷启动代价挪出用户可感知的关键路径。
- **ShadowQueue 校验加固**：修复 `ShadowQueue` 完全没有 mtime/size/TTL 校验的问题（此前编辑后仍会命中旧结果），并接了写/编辑后清空队列。投机引擎本身的服务消费点在更早之前已被物理移除，这次没有重新接回去（会复现之前"纯预执行零收益"被封存的理由），只做了这一半的正确性加固。

## 修改思路
起点是核实一个假设：`deepseek-v4-flash` 的 `reasoningEffort: 'medium'` 是否真的省钱。查下来发现 DeepSeek V4 服务端根本不识别 `medium`/`low`，会静默退回 `high`——也就是说现有的"routine 轮降档"机制对 DeepSeek 从来没有生效过。这个发现改变了后续设计的方向：既然降档这条路走不通，effort 调度就只剩"该升档时升档"这一半有意义，所以把重心放在识别硬信号（验证债务、doom-loop、council 分歧）触发升档，而不是继续在降档上做文章。

其余三块（思维链上限、前缀预热、ShadowQueue 加固）是同一条主线的延伸：思维链上限是升档之后必须配的收口机制（否则升到 max 没有硬顶，可能跑出失控的长思维链）；前缀预热和 ShadowQueue 加固都是"把现有基础设施修到能用"——分别对应压缩/resume 后没人主动预热、以及投机队列曾经完全没有 staleness 校验这两个已知缺口。这两块都刻意保持在"最小可信改动"范围内：预热不碰共享 client 状态（避免跟真实请求起竞态），ShadowQueue 只补校验、没有重新接回已被移除的服务消费点（避免重蹈之前被封存的覆辙）。

## Test plan
- `tsc --noEmit` 通过
- 新增/更新单测覆盖以上全部改动（effort 映射、hard-signal 升档、reasoning cap、prefix prewarm、ShadowQueue 校验）
- 跑过 api/config/agent 相关约 1200+ 条既有测试，全绿；唯一一次失败是与本次改动无关的 Windows temp 目录清理 flake（`loop.test.ts` 的 prewarm-cache 测试，环境问题不是逻辑问题）
- 新增功能未完成全量测试，需要进一步验证可行性（effort 是否真按预期发送、看门狗是否真触发、预热是否真建到服务端缓存等，均依赖真实环境活体验证）
