### PR TITLE
fix(updater): 修复 /update 在非 JSON 响应下 unhandled rejection 崩溃

### DIFF
--- a/src/tui/__tests__/updater.test.ts
+++ b/src/tui/__tests__/updater.test.ts
@@ -11,6 +11,7 @@ import {
   withResumeArgs,
   checkForUpdate,
   fetchNpmLatestVersion,
+  fetchGitHubLatestVersion,
   npmPackageExists,
 } from '../updater.js'
 import { WinStreamDecoder } from '../../platform.js'
@@ -328,6 +329,49 @@ describe('fetchNpmLatestVersion proxy support', () => {
     }
     await fetchNpmLatestVersion('tianshu-tui')
     assert.equal(capturedDispatcher, undefined)
+  })
+})
+
+describe('non-JSON 200 responses (proxy interception)', () => {
+  let origFetch: typeof globalThis.fetch
+
+  before(() => {
+    origFetch = globalThis.fetch
+  })
+
+  after(() => {
+    globalThis.fetch = origFetch
+  })
+
+  // 代理/网关劫持时可能以 200 返回 GBK 编码的 HTML 错误页，
+  // res.json() 会抛 SyntaxError —— 两处 fetch 都必须吞掉并返回 null，
+  // 否则 /update 命令以 unhandled promise rejection 崩溃。
+  it('fetchNpmLatestVersion returns null on HTML body with 200', async () => {
+    globalThis.fetch = async () =>
+      new Response('<html><body>proxy error</body></html>', {
+        status: 200,
+        headers: { 'content-type': 'text/html; charset=GBK' },
+      })
+    assert.equal(await fetchNpmLatestVersion('tianshu-tui'), null)
+  })
+
+  it('fetchNpmLatestVersion returns null on non-UTF-8 bytes', async () => {
+    // GBK 编码的中文（非合法 UTF-8），复现 "Unexpected token ''" 现场。
+    globalThis.fetch = async () =>
+      new Response(Buffer.from([0xb4, 0xed, 0xce, 0xf3, 0xd2, 0xb3, 0xc3, 0xe6]), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    assert.equal(await fetchNpmLatestVersion('tianshu-tui'), null)
+  })
+
+  it('fetchGitHubLatestVersion returns null on HTML body with 200', async () => {
+    globalThis.fetch = async () =>
+      new Response('<html><body>blocked</body></html>', {
+        status: 200,
+        headers: { 'content-type': 'text/html' },
+      })
+    assert.equal(await fetchGitHubLatestVersion('owner', 'repo'), null)
   })
 })
 

--- a/src/tui/updater.ts
+++ b/src/tui/updater.ts
@@ -336,7 +336,14 @@ export async function fetchNpmLatestVersion(
   const url = `${NPM_REGISTRY_URL}/${encodeURIComponent(packageName)}/latest`
   const res = await fetchWithRetry(url, { headers: { Accept: 'application/json' } })
   if (!res || !res.ok) return null
-  const data = await res.json() as { version?: string; time?: Record<string, string> }
+  // 代理/网关可能以 200 返回非 JSON 错误页（如 GBK 编码的 HTML 拦截页），
+  // 此时 res.json() 抛 SyntaxError —— 按「任何失败返回 null」契约吞掉。
+  let data: { version?: string; time?: Record<string, string> }
+  try {
+    data = await res.json() as { version?: string; time?: Record<string, string> }
+  } catch {
+    return null
+  }
   if (typeof data.version !== 'string') return null
   return { version: data.version, publishedAt: data.time?.[data.version], source: 'npm' }
 }
@@ -382,7 +389,13 @@ export async function fetchGitHubLatestVersion(
     },
   })
   if (!res || !res.ok) return null
-  const data = await res.json() as { tag_name?: string; published_at?: string }
+  let data: { tag_name?: string; published_at?: string }
+  try {
+    data = await res.json() as { tag_name?: string; published_at?: string }
+  } catch {
+    // 同 npm 路径：200 但响应体非 JSON（代理拦截页等）→ 视为查询失败。
+    return null
+  }
   const tag = data.tag_name
   if (typeof tag !== 'string') return null
   const version = tag.replace(/^v/, '')


### PR DESCRIPTION
## 问题现象

在代理/网关劫持的网络环境下执行 `/update`，更新检查请求被以 HTTP 200 返回非 JSON 错误页（如 GBK 编码的 HTML 拦截页），终端打印：

```
[rivet] Unhandled promise rejection: SyntaxError: Unexpected token '', ""... is not valid JSON
    at JSON.parse (<anonymous>)
    at parseJSONFromBytes (node:internal/deps/undici/undici:4227:19)
```

## 根因分析

崩溃链路：`/update` → `checkForUpdate` → `fetchNpmLatestVersion` → `res.json()`

1. 代理劫持的响应 `res.ok === true`，通过了状态码检查
2. 但响应体是 GBK 编码的 HTML 而非 JSON（报错中的 `` 乱码即非法 UTF-8 字节的替换符），`res.json()` 抛出 `SyntaxError`
3. `checkForUpdate` 的注释承诺「不抛异常：任何失败都返回 null」，未防护的 `res.json()` 违反了该契约
4. `/update` 的 handler 没有 try/catch 包裹，最终以 unhandled promise rejection 崩溃

## 修复内容

- `src/tui/updater.ts`：`fetchNpmLatestVersion` 与 `fetchGitHubLatestVersion` 两处 `res.json()` 加 try/catch，解析失败返回 `null`，恢复「任何失败返回 null」的契约
- `src/tui/__tests__/updater.test.ts`：新增 `non-JSON 200 responses` 回归测试套件 3 个用例
  - 200 + HTML 错误页 body
  - 200 + GBK 编码字节（精确复现乱码现场）
  - GitHub releases 路径的 HTML body

## 测试

`npx tsx --test src/tui/__tests__/updater.test.ts`：33 个测试全部通过（含新增 3 个）。

修复后用户在代理劫持环境下会看到友好的 `⚠️ Could not check for updates right now.` 提示，而非崩溃堆栈。