### PR TITLE
fix(tui): 打开推理强度选择器前重置面板类型

### DIFF
--- a/src/tui/__tests__/slash-commands.test.ts
+++ b/src/tui/__tests__/slash-commands.test.ts
@@ -903,6 +903,31 @@ describe('/skill review|approve|reject — auto-distill drafts', () => {
   })
 })
 
+describe('/effort', () => {
+  it('resets stale choice-panel kind before opening the picker', async () => {
+    let kind = 'ask-user-question'
+    const events: string[] = []
+
+    const handled = await handleSlashCommand(makeCtx({
+      parts: ['/effort'],
+      setChoicePanelKind: (next) => {
+        kind = next
+        events.push(`kind:${next}`)
+      },
+      surfacePush: (id) => {
+        events.push(`push:${id}`)
+      },
+    }))
+
+    assert.equal(handled, true)
+    assert.equal(kind, 'effort')
+    assert.deepEqual(events, [
+      'kind:effort',
+      'push:choice-panel',
+    ])
+  })
+})
+
 describe('/permission', () => {
   // Isolate real config writes (setCheckpointConfig / any persist) to a temp file.
   let prevConfigPath: string | undefined

--- a/src/tui/slash-commands.ts
+++ b/src/tui/slash-commands.ts
@@ -3247,7 +3247,8 @@ const TUI_SLASH_COMMANDS: readonly TuiSlashCommandDef[] = [
       const level = parts[1]?.toLowerCase() as 'off' | 'low' | 'medium' | 'high' | 'max' | 'auto' | undefined
       const valid: Array<'off' | 'low' | 'medium' | 'high' | 'max' | 'auto'> = ['off', 'low', 'medium', 'high', 'max', 'auto']
       if (!level) {
-        // 无参数 → 打开交互式选择面板（上下选、回车确认）。
+        // 无参数 → 重置面板类型后打开交互式选择面板（上下选、回车确认）。
+        ctx.setChoicePanelKind?.('effort')
         surfacePush?.('choice-panel')
         setIsStreaming(false)
         return true


### PR DESCRIPTION
## 变更摘要

修复无参数 `/effort` 打开推理强度选择器时，可能继续显示上一个 choice-panel 类型的问题。

## 动机

`/effort`、计划审批和 ask-user-question 共用 `choice-panel` overlay。

计划审批和 ask-user-question 面板会修改 `choicePanelKind`，但无参数 `/effort` 此前只执行 `surfacePush('choice-panel')`，没有先将 `choicePanelKind` 恢复为 `effort`。

当用户关闭之前的 choice-panel 后直接执行 `/effort`，面板可能继续按照旧的 `choicePanelKind` 渲染，而不是显示 Reasoning Effort 选项。

## 主要改动

- 在无参数 `/effort` 打开 `choice-panel` 前调用 `setChoicePanelKind('effort')`
- 增加回归测试，验证旧面板状态会被重置
- 验证状态重置发生在 overlay 打开之前
- 保持 `/effort auto|max|high|medium|low|off` 原有行为不变

修改文件：

- `src/tui/slash-commands.ts`
- `src/tui/__tests__/slash-commands.test.ts`

## 复现步骤

1. 打开计划审批或 ask-user-question 选择面板
2. 不做选择，按 `Esc` 或 `q` 关闭
3. 执行无参数 `/effort`
4. 修复前可能继续显示上一个面板的选项
5. 修复后始终显示 Auto / Max / High / Medium / Low / Off

## 测试

已通过：

```bash
node --import tsx --test src/tui/__tests__/slash-commands.test.ts
# 91 passed / 0 failed

npm run typecheck
npm run build
git diff --check
```

已完整运行：

```bash
npm test
```

全量测试未全绿，发现两个失败，并在未修改的 `main` 基线 `36467795` 上单独复跑，两个失败均可复现：

1. `src/tui/__tests__/unified-shell-bracket.test.ts`
   - `main` 基线同样不能满足 `(main)` 断言
   - 本 PR 未修改 shell bracket、GlanceBar 或 Git 分支显示

2. `src/tui/engine/__tests__/app-clipboard-image.test.ts`
   - 测试读取到当前系统剪贴板文本
   - `main` 基线同样失败
   - 本 PR 未修改 clipboard、Ctrl+V 或输入框逻辑

基线和修复分支单独复跑结果均为 `7 passed / 2 failed`，因此这两个失败不是本 PR 引入的回归。

## 检查清单

- [x] 本地 `npm test` 全绿：已完整执行，存在 2 项可在未修改 `main` 基线上复现的失败
- [x] `npx tsc --noEmit` 无类型错误
- [x] 变更范围最小化，无关改动已排除
- [x] 文档无需更新：README 已准确描述 `/effort` 无参数会打开选择面板

## 相关 Issue

无（直接修复已定位的 TUI 状态残留问题）。

## 非目标

本 PR 不处理 `/permission` 的重复注册问题。该问题需要单独确认产品预期。