### PR TITLE
feat(tui): 终端内联图片渲染（kitty/iTerm2 协议 + 统一 main commit 队列）

### DIFF
--- a/src/tui/engine/__tests__/image-attach.test.ts
+++ b/src/tui/engine/__tests__/image-attach.test.ts
@@ -27,15 +27,18 @@ test('detectImageMime recognizes PNG', () => {
   assert.equal(detectImageMime(buf, '/foo/bar.png'), 'image/png')
 })
 
-test('detectImageMime falls back to extension', () => {
+test('detectImageMime returns null when magic is unrecognized (no extension fallback)', () => {
   const buf = Buffer.from('not a real image')
-  assert.equal(detectImageMime(buf, '/foo/bar.jpg'), 'image/jpeg')
+  assert.equal(detectImageMime(buf, '/foo/bar.jpg'), null)
 })
 
 test('looksLikeImagePath recognizes supported extensions', () => {
   assert.equal(looksLikeImagePath('/tmp/shot.png'), true)
   assert.equal(looksLikeImagePath('/tmp/shot.JPG'), true)
   assert.equal(looksLikeImagePath('/tmp/shot.webp'), true)
+  assert.equal(looksLikeImagePath('/tmp/scan.tiff'), true)
+  assert.equal(looksLikeImagePath('/tmp/scan.TIF'), true)
+  assert.equal(looksLikeImagePath('/tmp/scan.BMP'), true)
   assert.equal(looksLikeImagePath('/tmp/shot.txt'), false)
 })
 

--- a/src/tui/engine/__tests__/image-tool.test.ts
+++ b/src/tui/engine/__tests__/image-tool.test.ts
@@ -1,0 +1,121 @@
+/**
+ * image-tool.ts tests：isCompletePng 完整性校验 + runImageTool 截断 PNG fallback
+ * + 全失败时 RIVET_DEBUG 调试输出可观测性。
+ */
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { isCompletePng, runImageTool } from '../image-tool.js'
+
+// 1x1 transparent PNG（含完整 IHDR + IEND）
+const PNG_1X1 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=='
+const PNG_BUF = Buffer.from(PNG_1X1, 'base64')
+
+/** 用 node -e 构造假命令，不依赖 sips/ImageMagick 真实存在。 */
+function fakeCmd(script: string, ...extraArgs: string[]): { bin: string; args: string[] } {
+  return { bin: process.execPath, args: ['-e', script, ...extraArgs] }
+}
+
+/** 写出指定字节的假命令脚本。 */
+function writeBytesScript(buf: Buffer): string {
+  return `require('node:fs').writeFileSync(process.argv[1], Buffer.from('${buf.toString('base64')}','base64'))`
+}
+
+function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = mkdtempSync(join(tmpdir(), 'rivet-imgtool-test-'))
+  return fn(dir).finally(() => { rmSync(dir, { recursive: true, force: true }) })
+}
+
+// ── isCompletePng ────────────────────────────────────────────────────────────
+
+test('isCompletePng：仅 signature（8 字节）不算完整 PNG', () => {
+  assert.equal(isCompletePng(PNG_BUF.subarray(0, 8)), false)
+})
+
+test('isCompletePng：截断 IHDR 不算完整 PNG', () => {
+  // 截到 IHDR 数据中间（signature + length/type + 部分 data）
+  assert.equal(isCompletePng(PNG_BUF.subarray(0, 20)), false)
+  // IHDR 宽度为 0 的伪造 chunk
+  const zeroWidth = Buffer.from(PNG_BUF)
+  zeroWidth.writeUInt32BE(0, 16)
+  assert.equal(isCompletePng(zeroWidth), false)
+})
+
+test('isCompletePng：缺 IEND 不算完整 PNG', () => {
+  assert.equal(isCompletePng(PNG_BUF.subarray(0, PNG_BUF.length - 12)), false)
+})
+
+test('isCompletePng：完整 PNG（PNG_1X1）通过', () => {
+  assert.equal(isCompletePng(PNG_BUF), true)
+})
+
+test('isCompletePng：非 PNG 内容不通过', () => {
+  assert.equal(isCompletePng(Buffer.from('not a real image at all, definitely long enough to pass length gate........')), false)
+})
+
+// ── runImageTool：截断 PNG → fallback 下一候选 ───────────────────────────────
+
+test('runImageTool：产出截断 PNG 时 fallback 到下一候选', async () => {
+  await withTempDir(async (dir) => {
+    const out = join(dir, 'out.png')
+    // 第一个候选 exit 0 但只写出 signature + 截断 IHDR；第二个产出完整 PNG
+    const result = await runImageTool([
+      fakeCmd(writeBytesScript(PNG_BUF.subarray(0, 20)), out),
+      fakeCmd(writeBytesScript(PNG_BUF), out),
+    ], out)
+    assert.deepEqual(result, PNG_BUF)
+  })
+})
+
+// ── RIVET_DEBUG 失败可观测性 ─────────────────────────────────────────────────
+
+async function captureConsoleError(fn: () => Promise<void>): Promise<string[]> {
+  const origError = console.error
+  const lines: string[] = []
+  console.error = (...args: unknown[]) => { lines.push(args.map(String).join(' ')) }
+  try {
+    await fn()
+  } finally {
+    console.error = origError
+  }
+  return lines
+}
+
+test('runImageTool：全部失败且 RIVET_DEBUG 非空时输出一行调试信息', async () => {
+  const origDebug = process.env.RIVET_DEBUG
+  process.env.RIVET_DEBUG = '1'
+  try {
+    await withTempDir(async (dir) => {
+      const out = join(dir, 'out.png')
+      const lines = await captureConsoleError(async () => {
+        const result = await runImageTool([fakeCmd('process.exit(1)', out)], out)
+        assert.equal(result, null)
+      })
+      assert.equal(lines.length, 1)
+      assert.ok(lines[0]?.includes('[image-tool]'))
+    })
+  } finally {
+    if (origDebug === undefined) delete process.env.RIVET_DEBUG
+    else process.env.RIVET_DEBUG = origDebug
+  }
+})
+
+test('runImageTool：全部失败但无 RIVET_DEBUG 时保持静默', async () => {
+  const origDebug = process.env.RIVET_DEBUG
+  delete process.env.RIVET_DEBUG
+  try {
+    await withTempDir(async (dir) => {
+      const out = join(dir, 'out.png')
+      const lines = await captureConsoleError(async () => {
+        const result = await runImageTool([fakeCmd('process.exit(1)', out)], out)
+        assert.equal(result, null)
+      })
+      assert.equal(lines.length, 0)
+    })
+  } finally {
+    if (origDebug !== undefined) process.env.RIVET_DEBUG = origDebug
+  }
+})

--- a/src/tui/engine/__tests__/orchestration-live.test.ts
+++ b/src/tui/engine/__tests__/orchestration-live.test.ts
@@ -48,6 +48,11 @@ function makeApp() {
 
 const stripAnsi = (s: string) => s.replace(/\x1B\[[0-9;?]*[a-zA-Z]/g, '')
 
+// ask 面板提交经 submitText → commitUserPrompt，overlay 激活时
+// 返回完成 Promise（不再同步直写）——onSubmit 在面板关闭、队列回放后才触发，
+// 断言前需让出一个 tick。
+const tick = (ms = 20) => new Promise<void>(r => setTimeout(r, ms))
+
 const act = (workOrderId: string, status: DelegationActivity['status'], extra: Partial<DelegationActivity> = {}): DelegationActivity => ({
   workOrderId,
   parentToolId: 'tool-1',
@@ -110,7 +115,7 @@ test('team wave 推进：提交时间线行且重复推送去重', () => {
   assert.ok(!stripAnsi(out.chunks.join('')).includes('wave 1/2 完成'), '重复推送被去重')
 })
 
-test('ask 面板：单选数字键快选 → 提交页 → Enter 显式提交', () => {
+test('ask 面板：单选数字键快选 → 提交页 → Enter 显式提交', async () => {
   const { app, stdin } = makeApp()
   app.registerOverlays({ choicePanelData: () => ({ title: '', choices: [], selectedIndex: 0 }) })
   let submitted: string | undefined
@@ -125,11 +130,12 @@ test('ask 面板：单选数字键快选 → 提交页 → Enter 显式提交', 
   assert.ok(app.pendingAskFlow, '面板仍在（等待显式提交）')
 
   stdin.dataHandler!('\r') // 提交页光标默认在「提交回答」
+  await tick() // commitUserPrompt 返回 Promise，回放后才触发 onSubmit
   assert.equal(submitted, 'Beta', '提交页 Enter 发出答案')
   assert.equal(app.pendingAskFlow, undefined, '提交后流清理')
 })
 
-test('ask 面板：多选数字键切换 + Enter 确认 + 提交页提交', () => {
+test('ask 面板：多选数字键切换 + Enter 确认 + 提交页提交', async () => {
   const { app, stdin } = makeApp()
   app.registerOverlays({ choicePanelData: () => ({ title: '', choices: [], selectedIndex: 0 }) })
   const submitted: string[] = []
@@ -145,12 +151,13 @@ test('ask 面板：多选数字键切换 + Enter 确认 + 提交页提交', () =
   stdin.dataHandler!('\r') // Enter 确认多选 → 提交页
   assert.equal(submitted.length, 0, '确认多选只进提交页，不直接提交')
   stdin.dataHandler!('\r') // 提交页 Enter → 提交
+  await tick() // 等待队列回放后 onSubmit 才触发
   assert.equal(submitted.length, 1, '提交页 Enter 后提交一次')
   assert.ok(submitted[0]!.includes('X') && submitted[0]!.includes('Z'), `多选答案含 X 与 Z: ${submitted[0]}`)
   assert.ok(!submitted[0]!.includes('Y'), '未选 Y')
 })
 
-test('ask 面板：←→ 切 Tab 乱序答题，提交页确认后按题组串', () => {
+test('ask 面板：←→ 切 Tab 乱序答题，提交页确认后按题组串', async () => {
   const { app, stdin } = makeApp()
   app.registerOverlays({ choicePanelData: () => ({ title: '', choices: [], selectedIndex: 0 }) })
   let submitted: string | undefined
@@ -170,6 +177,7 @@ test('ask 面板：←→ 切 Tab 乱序答题，提交页确认后按题组串'
   assert.equal(submitted, undefined, '答完两题仍待显式提交')
 
   stdin.dataHandler!('\r') // 提交页 Enter
+  await tick() // 等待队列回放后 onSubmit 才触发
   assert.equal(submitted, '第一题 → A2\n第二题 → B1', 'composeAnswers 按题组串')
   assert.equal(app.pendingAskFlow, undefined)
 })

--- a/src/tui/engine/__tests__/term-image-commit.test.ts
+++ b/src/tui/engine/__tests__/term-image-commit.test.ts
@@ -1,0 +1,730 @@
+/**
+ * app 级集成测试 — commitUserPrompt 的带图异步提交路径 + 统一 main commit 队列。
+ *
+ * 覆盖的回归面（纯编码层单测无法触及）：
+ * - 顺序：慢转码不得让图片/后续提交越过所属气泡；连续两次提交不得倒序；
+ *   overlay 激活时带图提交在调用当刻预订队列位置，回放不被后排 commit 越过
+ * - 队列：唯一有序 main commit 队列（enqueueMainCommit + 单实例 pump）——
+ *   async barrier 后同步项严格 FIFO；pump await 期间 overlay 重激活不写主屏内容
+ *   进 alt screen；prepare 完成后重新检查 overlay；单条目异常不丢剩余队列
+ * - 异常：prepare 抛错/拒绝必须静默降级为纯文本气泡，无 unhandled rejection
+ * - resize：转码期间终端宽度变化，编码必须用写入当刻的最新列数
+ * - 混排：带图提交还在转码时，无图提交也必须排队尾，气泡不倒序
+ * - worker 视图：steer 回调在气泡+图片落地之后才调用
+ * - 回调异常：onSubmitCallback 抛错不产生 unhandled rejection
+ * - 规范化：超量/非法图片在入口过滤，气泡与回调看到同一份数组
+ */
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { setImageProtocol } from '../ansi.js'
+import { setTermImagePreparer } from '../term-image.js'
+import { makeApp } from './_harness.js'
+
+const tick = (ms = 50) => new Promise<void>(r => setTimeout(r, ms))
+
+function withImageEnv(protocol: 'kitty' | 'iterm2' | 'none', fn: () => Promise<void>): Promise<void> {
+  setImageProtocol(protocol)
+  return fn().finally(() => {
+    setImageProtocol(null)
+    setTermImagePreparer(null)
+  })
+}
+
+test('慢转码的带图提交与后续提交保持顺序——气泡+图片原子有序，连续提交不倒序', async () => {
+  await withImageEnv('iterm2', async () => {
+    const { app, out } = makeApp({ cols: 80, rows: 24 })
+    // 第一张图慢（手动释放），第二张立即就绪
+    let releaseSlow!: () => void
+    const slow = new Promise<void>(r => { releaseSlow = r })
+    setTermImagePreparer(async (dataUrl) => {
+      if (dataUrl.endsWith('slow')) await slow
+      return { b64: dataUrl.endsWith('slow') ? 'U0xPVw==' : 'RkFTVA==' }
+    })
+
+    app.submitText('first', ['data:image/png;base64,slow'])
+    app.submitText('second', ['data:image/png;base64,fast'])
+    await tick(20)
+    releaseSlow()
+    await tick()
+
+    const joined = out.chunks.join('')
+    const iFirst = joined.indexOf('first')
+    const iSlow = joined.indexOf('U0xPVw==')
+    const iSecond = joined.indexOf('second')
+    const iFast = joined.indexOf('RkFTVA==')
+    assert.ok(iFirst !== -1, 'first 气泡已写出')
+    assert.ok(iSlow !== -1, '第一张图片序列已写出')
+    assert.ok(iSecond !== -1, 'second 气泡已写出')
+    assert.ok(iFast !== -1, '第二张图片序列已写出')
+    assert.ok(iFirst < iSlow, '图片在所属气泡之后')
+    assert.ok(iSlow < iSecond, '慢转码的第一次提交不被第二次越过')
+    assert.ok(iSecond < iFast, '第二张图片在 second 气泡之后')
+  })
+})
+
+test('prepare 抛错静默降级为纯文本气泡，无 unhandled rejection', async () => {
+  await withImageEnv('iterm2', async () => {
+    const { app, out } = makeApp({ cols: 80, rows: 24 })
+    const rejections: unknown[] = []
+    const onRejection = (reason: unknown) => { rejections.push(reason) }
+    process.on('unhandledRejection', onRejection)
+    try {
+      setTermImagePreparer(async () => { throw new Error('converter exploded') })
+      app.submitText('boom', ['data:image/jpeg;base64,/9j/4AA='])
+      await tick()
+      const joined = out.chunks.join('')
+      assert.ok(joined.includes('boom'), '气泡仍写出')
+      assert.ok(joined.includes('📎 1 image attached'), '保留文本占位')
+      await tick(20)
+      assert.deepEqual(rejections, [], '不得产生 unhandled rejection')
+    } finally {
+      process.removeListener('unhandledRejection', onRejection)
+    }
+  })
+})
+
+test('转码期间 resize，编码用写入当刻的最新列数', async () => {
+  await withImageEnv('iterm2', async () => {
+    const { app, out } = makeApp({ cols: 80, rows: 24 })
+    let release!: () => void
+    const gate = new Promise<void>(r => { release = r })
+    setTermImagePreparer(async () => {
+      await gate
+      return { b64: 'QUJD' }
+    })
+    app.submitText('resize-me', ['data:image/png;base64,QUJD'])
+    await tick(20)
+    // 转码未完成时终端缩窄（真实路径经 resize watcher 更新 app.columns）
+    ;(app as unknown as { columns: number }).columns = 60
+    release()
+    await tick()
+    const joined = out.chunks.join('')
+    assert.ok(joined.includes('width=56'), `应用最新宽度 60-4=56，实际输出: ${joined.slice(-400)}`)
+    assert.ok(!joined.includes('width=76'), '不得使用提交时的过期宽度')
+  })
+})
+
+test('协议 none：带图提交同步完成（无异步链）', async () => {
+  await withImageEnv('none', async () => {
+    const { app, out } = makeApp({ cols: 80, rows: 24 })
+    app.submitText('plain', ['data:image/png;base64,QUJD'])
+    // 不等任何 tick：同步路径必须已经写出气泡
+    assert.ok(out.chunks.join('').includes('plain'))
+  })
+})
+
+test('慢带图提交后立即无图提交，无图排链尾、气泡不倒序', async () => {
+  await withImageEnv('iterm2', async () => {
+    const { app, out } = makeApp({ cols: 80, rows: 24 })
+    let release!: () => void
+    const gate = new Promise<void>(r => { release = r })
+    setTermImagePreparer(async () => {
+      await gate
+      return { b64: 'SU1H' }
+    })
+
+    app.submitText('img-first', ['data:image/png;base64,QUJD'])
+    app.submitText('plain-second') // 无图：链上有 pending，必须排在带图提交之后
+    await tick(20)
+    release()
+    await tick()
+
+    const joined = out.chunks.join('')
+    const iFirst = joined.indexOf('img-first')
+    const iImg = joined.indexOf('SU1H')
+    const iSecond = joined.indexOf('plain-second')
+    assert.ok(iFirst !== -1 && iImg !== -1 && iSecond !== -1, '两个气泡与图片都已写出')
+    assert.ok(iFirst < iImg, '图片在所属气泡之后')
+    assert.ok(iImg < iSecond, '无图提交不得越过还在转码的带图提交')
+  })
+})
+
+test('worker 视图 steer 在气泡+图片落地之后才调用', async () => {
+  await withImageEnv('iterm2', async () => {
+    const { app, out } = makeApp({ cols: 80, rows: 24 })
+    let release!: () => void
+    const gate = new Promise<void>(r => { release = r })
+    setTermImagePreparer(async () => {
+      await gate
+      return { b64: 'SU1H' }
+    })
+    const steerCalls: Array<{ id: string; text: string; bubbleVisible: boolean }> = []
+    app.setWorkerSteer((id, text) => {
+      steerCalls.push({ id, text, bubbleVisible: out.chunks.join('').includes('hello worker') })
+      return true
+    })
+    app.enterWorkerView('w-1')
+
+    const submit = (app as unknown as {
+      handleInputSubmit(t: string, images?: string[]): Promise<void>
+    }).handleInputSubmit('hello worker', ['data:image/png;base64,QUJD'])
+    await tick(20)
+    assert.equal(steerCalls.length, 0, '带图提交未落地前不得 steer（worker 输出会先于用户气泡）')
+    release()
+    await submit
+    assert.equal(steerCalls.length, 1, 'steer 被调用一次')
+    assert.equal(steerCalls[0]!.id, 'w-1')
+    assert.equal(steerCalls[0]!.text, 'hello worker')
+    assert.ok(steerCalls[0]!.bubbleVisible, 'steer 时用户气泡已落 scrollback')
+  })
+})
+
+test('prepare 成功但 onSubmitCallback 抛错，无 unhandled rejection', async () => {
+  await withImageEnv('iterm2', async () => {
+    const { app, out } = makeApp({ cols: 80, rows: 24 })
+    const rejections: unknown[] = []
+    const onRejection = (reason: unknown) => { rejections.push(reason) }
+    process.on('unhandledRejection', onRejection)
+    try {
+      setTermImagePreparer(async () => ({ b64: 'SU1H' }))
+      app.onSubmit(() => { throw new Error('callback exploded') })
+      app.submitText('cb-boom', ['data:image/png;base64,QUJD'])
+      await tick()
+      assert.ok(out.chunks.join('').includes('cb-boom'), '气泡仍写出')
+      await tick(20)
+      assert.deepEqual(rejections, [], 'start 回调异常不得成为 unhandled rejection')
+    } finally {
+      process.removeListener('unhandledRejection', onRejection)
+    }
+  })
+})
+
+test('入口规范化——超量/非法图片被过滤，气泡与回调看到同一份数组', async () => {
+  await withImageEnv('none', async () => {
+    const { app, out } = makeApp({ cols: 80, rows: 24 })
+    let got: string[] | undefined
+    app.onSubmit((_t, images) => { got = images })
+    const images = [
+      'data:image/png;base64,QUJD',
+      'data:image/png;base64,QUJF',
+      'data:image/png;base64,QUJG',
+      'data:image/png;base64,QUJH',
+      'data:image/png;base64,!!!!', // 非法 base64 → 过滤
+      'data:image/png;base64,QUJJ', // 第 5 张合法 → 超 MAX_IMAGES 截断
+    ]
+    app.submitText('multi', images)
+    assert.ok(out.chunks.join('').includes('📎 4 images attached'), '气泡写 4 images')
+    assert.deepEqual(got, images.slice(0, 4), 'onSubmitCallback 收到同一规范化数组')
+  })
+})
+
+test('视觉模型支持的 TIFF/BMP 附件不会被 inline MIME 过滤丢弃', async () => {
+  await withImageEnv('none', async () => {
+    const { app, out } = makeApp({ cols: 80, rows: 24 })
+    const images = [
+      'data:image/tiff;base64,QUJD',
+      'data:image/bmp;base64,QUJF',
+    ]
+    let callbackImages: string[] | undefined
+    app.onSubmit((_text, submitted) => { callbackImages = submitted })
+    app.submitText('legacy-formats', images)
+    assert.deepEqual(callbackImages, images, '回调保留视觉服务支持的 TIFF/BMP data URL')
+    assert.ok(out.chunks.join('').includes('📎 2 images attached'), '终端不 inline 时保留文本占位')
+  })
+})
+
+test('overlay 激活期间带图提交用占位项预订逻辑位，回放不被后排 commit 越过', async () => {
+  await withImageEnv('iterm2', async () => {
+    const { app, out } = makeApp({ cols: 80, rows: 24 })
+    app.registerOverlays({})
+    let release!: () => void
+    const gate = new Promise<void>(r => { release = r })
+    setTermImagePreparer(async () => {
+      await gate
+      return { b64: 'SU1HR0VE' }
+    })
+
+    app.activateOverlay('choice-panel')
+    app.commitStatic('ASSISTANT_BEFORE')   // 预排的 assistant commit
+    app.submitText('img-msg', ['data:image/png;base64,QUJD']) // 慢转码带图提交
+    app.commitStatic('ASSISTANT_AFTER')    // prepare 期间后排的 assistant commit
+    release()
+    await tick()
+    assert.ok(
+      !out.chunks.join('').includes('ASSISTANT_BEFORE'),
+      'overlay 激活期间主屏 commit 仍排队（含已兑现的占位项）',
+    )
+
+    out.clear()
+    app.deactivateOverlay()
+    await tick()
+    const text = out.chunks.join('')
+    const iBefore = text.indexOf('ASSISTANT_BEFORE')
+    const iBubble = text.indexOf('img-msg')
+    const iImg = text.indexOf('SU1HR0VE')
+    const iAfter = text.indexOf('ASSISTANT_AFTER')
+    assert.ok(iBefore !== -1 && iBubble !== -1 && iImg !== -1 && iAfter !== -1, '回放内容完整')
+    assert.ok(iBefore < iBubble, '预排 assistant commit 先于用户气泡')
+    assert.ok(iBubble < iImg, '图片在所属气泡之后')
+    assert.ok(iImg < iAfter, '占位项保证图片提交不被 prepare 期间后排的 commit 越过')
+  })
+})
+
+// ── 统一 main commit 队列回归 ─────────────────────────────
+
+test('overlay 退出回放已就绪的带图提交：clear→write→render 连续，中间无 live 帧', async () => {
+  await withImageEnv('iterm2', async () => {
+    const { app, out } = makeApp({ cols: 80, rows: 24 })
+    app.registerOverlays({})
+    let release!: () => void
+    const gate = new Promise<void>(r => { release = r })
+    setTermImagePreparer(async () => {
+      await gate
+      return { b64: 'UkVBRFk=' }
+    })
+
+    app.activateOverlay('choice-panel')
+    app.submitText('ready-bubble', ['data:image/png;base64,QUJD'])
+    release()
+    await tick() // prepare 完成时 overlay 仍激活——队列保留，一个字节都不写
+    assert.ok(!out.chunks.join('').includes('ready-bubble'), 'overlay 激活期间不得写主屏')
+
+    out.clear()
+    app.deactivateOverlay()
+    await tick()
+
+    const chunks = out.chunks
+    const bubbleIdx = chunks.findIndex(c => c.includes('ready-bubble'))
+    assert.ok(bubbleIdx > 0, '退出 overlay 后气泡落 scrollback')
+    // 原子提交窗口：擦除 live region（ERASE_SCREEN_END）与气泡必须相邻，
+    // 中间不得夹 live 帧（❯）——否则原子窗口被掏空。
+    assert.ok(
+      chunks[bubbleIdx - 1]!.includes('\x1B[0J'),
+      '擦除与气泡相邻——原子窗口内无 live 帧插入',
+    )
+    const renderIdx = chunks.findIndex((c, i) => i > bubbleIdx && c.includes('❯'))
+    assert.ok(renderIdx > bubbleIdx, '写入之后重绘 live region')
+  })
+})
+
+test('慢 prepare 未完成时退出 overlay：prepare 完成后原子写入主屏', async () => {
+  await withImageEnv('iterm2', async () => {
+    const { app, out } = makeApp({ cols: 80, rows: 24 })
+    app.registerOverlays({})
+    let release!: () => void
+    const gate = new Promise<void>(r => { release = r })
+    setTermImagePreparer(async () => {
+      await gate
+      return { b64: 'U0xPV0lNRw==' }
+    })
+
+    app.activateOverlay('choice-panel')
+    app.submitText('slow-bubble', ['data:image/png;base64,QUJD'])
+    app.deactivateOverlay()
+    await tick()
+    assert.ok(
+      !out.chunks.join('').includes('slow-bubble'),
+      'prepare 未完成：退出 overlay 也不得先擦后等',
+    )
+
+    release()
+    await tick()
+    const joined = out.chunks.join('')
+    assert.ok(joined.includes('slow-bubble'), 'prepare 完成后气泡落 scrollback')
+    assert.ok(joined.includes('U0xPV0lNRw=='), '图片序列随之写出')
+    assert.ok(
+      joined.indexOf('\x1B[?1049l') < joined.indexOf('slow-bubble'),
+      '写入发生在退出 alt screen 之后',
+    )
+    // 原子性：气泡前一 chunk 是擦除（clear→write 连续）
+    const chunks = out.chunks
+    const bubbleIdx = chunks.findIndex(c => c.includes('slow-bubble'))
+    assert.ok(chunks[bubbleIdx - 1]!.includes('\x1B[0J'), 'prepare 完成后仍是原子提交窗口')
+  })
+})
+
+test('pump await 期间 overlay 重激活：ALT_SCREEN_ON→OFF 之间无气泡/图片字节', async () => {
+  await withImageEnv('iterm2', async () => {
+    const { app, out } = makeApp({ cols: 80, rows: 24 })
+    app.registerOverlays({})
+    let release!: () => void
+    const gate = new Promise<void>(r => { release = r })
+    setTermImagePreparer(async () => {
+      await gate
+      return { b64: 'TEFURQ==' }
+    })
+
+    // 主屏提交慢图：pump 启动并停在 await ready 上
+    app.submitText('late-bubble', ['data:image/png;base64,QUJD'])
+    await tick(20)
+    // pump 等待期间打开 overlay，随后 prepare 完成——pump 唤醒必须看到
+    // overlay 激活并保留队首退出，而不是把主屏内容写进 alt screen。
+    app.activateOverlay('choice-panel')
+    release()
+    await tick()
+    assert.ok(!out.chunks.join('').includes('late-bubble'), 'overlay 激活期间气泡不得写入')
+    assert.ok(!out.chunks.join('').includes('TEFURQ=='), '图片序列不得写进 alt screen')
+
+    app.deactivateOverlay()
+    await tick()
+    const full = out.chunks.join('')
+    const iOn = full.indexOf('\x1B[?1049h')
+    const iOff = full.indexOf('\x1B[?1049l', iOn)
+    assert.ok(iOn !== -1 && iOff !== -1, 'alt screen 进出序列完整')
+    const between = full.slice(iOn, iOff)
+    assert.ok(!between.includes('late-bubble') && !between.includes('TEFURQ=='), 'alt screen 内零主屏字节')
+    assert.ok(full.indexOf('late-bubble') > iOff, '退出 alt screen 后泵出气泡')
+    assert.ok(full.indexOf('TEFURQ==') > full.indexOf('late-bubble'), '图片在所属气泡之后')
+  })
+})
+
+test('主屏 prepare 期间开 overlay 再提交第二条：回放顺序不倒', async () => {
+  await withImageEnv('iterm2', async () => {
+    const { app, out } = makeApp({ cols: 80, rows: 24 })
+    app.registerOverlays({})
+    let release1!: () => void
+    let release2!: () => void
+    const gate1 = new Promise<void>(r => { release1 = r })
+    const gate2 = new Promise<void>(r => { release2 = r })
+    setTermImagePreparer(async (dataUrl) => {
+      if (dataUrl.endsWith('b25l')) { await gate1; return { b64: 'SU1HXzE=' } }
+      await gate2
+      return { b64: 'SU1HXzI=' }
+    })
+
+    // 第一条在主屏 prepare（pump await 中）；期间打开 overlay 并提交第二条。
+    // 旧实现第一条 prepare 完成后会直写主屏、越过第二条的占位 → 物理倒序。
+    app.submitText('img-one', ['data:image/png;base64,b25l'])
+    await tick(20)
+    app.activateOverlay('choice-panel')
+    app.submitText('img-two', ['data:image/png;base64,dHdv'])
+    // 第二条先 ready、第一条后 ready（overlay 仍激活）——队列位置在调用当刻
+    // 已预订，ready 早晚不影响物理顺序。
+    release2()
+    await tick(20)
+    release1()
+    await tick(20)
+    assert.ok(!out.chunks.join('').includes('img-one'), 'overlay 激活期间不得写主屏')
+
+    app.deactivateOverlay()
+    await tick()
+    const joined = out.chunks.join('')
+    const iOne = joined.indexOf('img-one')
+    const iImg1 = joined.indexOf('SU1HXzE=')
+    const iTwo = joined.indexOf('img-two')
+    const iImg2 = joined.indexOf('SU1HXzI=')
+    assert.ok(iOne !== -1 && iImg1 !== -1 && iTwo !== -1 && iImg2 !== -1, '回放内容完整')
+    assert.ok(iOne < iImg1, '第一张图片在所属气泡之后')
+    assert.ok(iImg1 < iTwo, '第一条提交不被第二条越过（调用顺序即物理顺序）')
+    assert.ok(iTwo < iImg2, '第二张图片在所属气泡之后')
+  })
+})
+
+test('一轮 pump 等待期间第二轮 overlay 退出：只有一个 pump 实例、队列不倒序', async () => {
+  await withImageEnv('iterm2', async () => {
+    const { app, out } = makeApp({ cols: 80, rows: 24 })
+    app.registerOverlays({})
+    let release!: () => void
+    const gate = new Promise<void>(r => { release = r })
+    setTermImagePreparer(async () => {
+      await gate
+      return { b64: 'TVVURVg=' }
+    })
+
+    app.activateOverlay('choice-panel')
+    app.commitStatic('SYNC_A')
+    app.submitText('mutex-bubble', ['data:image/png;base64,QUJD'])
+    // 第一次退出：pump 同步排空 SYNC_A 后停在图片的 await ready 上
+    app.deactivateOverlay()
+    await tick(20)
+    // pump 等待期间再开/再退一轮 overlay 并排队 SYNC_B——requestPump 必须
+    // 识别已有 pump 实例而不并发启动第二个（否则两条泵交错回放、重复擦写）。
+    app.activateOverlay('choice-panel')
+    app.commitStatic('SYNC_B')
+    app.deactivateOverlay()
+    await tick(20)
+    release()
+    await tick()
+
+    const joined = out.chunks.join('')
+    const count = (s: string) => joined.split(s).length - 1
+    assert.equal(count('SYNC_A'), 1, 'SYNC_A 恰好写一次')
+    assert.equal(count('SYNC_B'), 1, 'SYNC_B 恰好写一次（无并发 pump 重复回放）')
+    assert.equal(count('mutex-bubble'), 1, '气泡恰好写一次')
+    const iA = joined.indexOf('SYNC_A')
+    const iBubble = joined.indexOf('mutex-bubble')
+    const iImg = joined.indexOf('TVVURVg=')
+    const iB = joined.indexOf('SYNC_B')
+    assert.ok(iA < iBubble && iBubble < iImg && iImg < iB, 'FIFO：SYNC_A → 气泡+图片 → SYNC_B')
+  })
+})
+
+test('deferred write 抛错：无 unhandledRejection，后续同步 commit 仍执行', async () => {
+  await withImageEnv('iterm2', async () => {
+    const { app, out } = makeApp({ cols: 80, rows: 24 })
+    app.registerOverlays({})
+    const rejections: unknown[] = []
+    const onRejection = (reason: unknown) => { rejections.push(reason) }
+    process.on('unhandledRejection', onRejection)
+    try {
+      app.activateOverlay('choice-panel')
+      // 直接注入一个 ready 会兑现「抛错写闭包」的条目（等价旧 deferred slot
+      // 兑现后 write 抛出的形态）；后面再排一个正常同步 commit。
+      const pending = (app as unknown as {
+        enqueueMainCommit(ready: Promise<() => void>): Promise<void> | null
+      }).enqueueMainCommit(Promise.resolve(() => { throw new Error('write exploded') }))
+      app.commitStatic('AFTER_THROW')
+      app.deactivateOverlay()
+      await tick()
+      assert.ok(pending, '异步条目返回完成 Promise')
+      await pending
+      assert.ok(out.chunks.join('').includes('AFTER_THROW'), '单条目异常不丢剩余队列')
+      await tick(20)
+      assert.deepEqual(rejections, [], '写闭包抛错不得成为 unhandled rejection')
+    } finally {
+      process.removeListener('unhandledRejection', onRejection)
+    }
+  })
+})
+
+test('队列空闲时 commitStatic 仍在返回前完成（同步 fast path）', () => {
+  const { app, out } = makeApp({ cols: 80, rows: 24 })
+  app.commitStatic('SYNC_STATIC')
+  assert.ok(out.chunks.join('').includes('SYNC_STATIC'), '返回前已落 scrollback（零 tick）')
+})
+
+test('async barrier 后的同步 commit 严格排队、不越过 barrier', async () => {
+  await withImageEnv('iterm2', async () => {
+    const { app, out } = makeApp({ cols: 80, rows: 24 })
+    let release!: () => void
+    const gate = new Promise<void>(r => { release = r })
+    setTermImagePreparer(async () => {
+      await gate
+      return { b64: 'QkFSUklFUg==' }
+    })
+
+    app.submitText('barrier-bubble', ['data:image/png;base64,QUJD'])
+    app.commitStatic('SYNC_AFTER')
+    await tick(20)
+    // barrier（带图 prepare）未完成：同步 commit 不得直写越过——这是设计意图
+    // 的行为变化（统一队列的代价）：严格 FIFO 优先于同步直写。
+    assert.ok(!out.chunks.join('').includes('SYNC_AFTER'), 'barrier 未完成时同步项不得越过')
+    release()
+    await tick()
+    const joined = out.chunks.join('')
+    const iBubble = joined.indexOf('barrier-bubble')
+    const iImg = joined.indexOf('QkFSUklFUg==')
+    const iAfter = joined.indexOf('SYNC_AFTER')
+    assert.ok(iBubble !== -1 && iImg !== -1 && iAfter !== -1, '全部内容最终写出')
+    assert.ok(iBubble < iImg && iImg < iAfter, '同步项严格排在 barrier 之后')
+  })
+})
+
+// ── 写入失败的显式 false 契约 ─────────────────────────────
+
+/** 注入一次性写失败：commit.write 下一次调用抛错后自动恢复原实现。 */
+function injectOneShotWriteFailure(app: unknown): void {
+  const commit = (app as { commit: { write: (...args: never[]) => void } }).commit
+  const origWrite = commit.write.bind(commit)
+  let shouldThrow = true
+  commit.write = ((...args: unknown[]) => {
+    if (shouldThrow) {
+      shouldThrow = false
+      throw new Error('stdout broken')
+    }
+    return origWrite(...(args as never[]))
+  }) as typeof commit.write
+}
+
+test('写入失败：完成 Promise resolve false（不 reject），后续队列条目不受影响', async () => {
+  await withImageEnv('none', async () => {
+    const { app, out } = makeApp({ cols: 80, rows: 24 })
+    app.registerOverlays({})
+    const rejections: unknown[] = []
+    const onRejection = (reason: unknown) => { rejections.push(reason) }
+    process.on('unhandledRejection', onRejection)
+    try {
+      app.activateOverlay('choice-panel') // 强制走队列路径（必须返回 Promise）
+      injectOneShotWriteFailure(app)
+      const pending = (app as unknown as {
+        commitUserPrompt(content: string): Promise<boolean> | null
+      }).commitUserPrompt('fragile')
+      assert.ok(pending, 'overlay 激活时 commitUserPrompt 透传完成 Promise')
+      app.commitStatic('AFTER_BROKEN') // 排在失败条目之后
+      app.deactivateOverlay() // pump 回放：第一条写抛错，第二条正常写出
+      const written = await pending
+      assert.equal(written, false, '写入抛错被跳过 → resolve false（不 reject）')
+      assert.ok(out.chunks.join('').includes('AFTER_BROKEN'), '单条目失败不丢剩余队列')
+      await tick(20)
+      assert.deepEqual(rejections, [], '不得产生 unhandled rejection')
+    } finally {
+      process.removeListener('unhandledRejection', onRejection)
+    }
+  })
+})
+
+test('submitText 显示失败：警告落 scrollback、agent 仍启动、无 unhandledRejection', async () => {
+  await withImageEnv('none', async () => {
+    const { app, out } = makeApp({ cols: 80, rows: 24 })
+    app.registerOverlays({})
+    const rejections: unknown[] = []
+    const onRejection = (reason: unknown) => { rejections.push(reason) }
+    process.on('unhandledRejection', onRejection)
+    try {
+      app.activateOverlay('choice-panel')
+      injectOneShotWriteFailure(app)
+      let started = false
+      app.onSubmit(() => { started = true })
+      app.submitText('fragile')
+      await tick(20)
+      assert.equal(started, false, '提交未落地前 agent 不得启动')
+      app.deactivateOverlay() // pump 回放 → 写抛错 → pending resolve false
+      await tick()
+      assert.ok(started, '显示失败不阻塞 agent 启动')
+      assert.ok(
+        out.chunks.join('').includes('⚠ 用户消息显示失败'),
+        '显示失败先 commitStatic 一条 muted 警告',
+      )
+      await tick(20)
+      assert.deepEqual(rejections, [], '不得产生 unhandled rejection')
+    } finally {
+      process.removeListener('unhandledRejection', onRejection)
+    }
+  })
+})
+
+test('同步 fast path 写入失败：转为 false，仍启动 agent 并显示警告', async () => {
+  await withImageEnv('none', async () => {
+    const { app, out } = makeApp({ cols: 80, rows: 24 })
+    injectOneShotWriteFailure(app)
+    let started = false
+    app.onSubmit(() => { started = true })
+    app.submitText('sync fragile')
+    await tick()
+    assert.equal(started, true, '同步写失败不应阻止 agent 启动')
+    assert.ok(out.chunks.join('').includes('⚠ 用户消息显示失败'), '同步写失败应显示警告')
+  })
+})
+
+test('普通输入 handleInputSubmit awaitUserCommit=false：显示警告后仍执行后续提交动作', async () => {
+  await withImageEnv('none', async () => {
+    const { app, out } = makeApp({ cols: 80, rows: 24 })
+    const rejections: unknown[] = []
+    const onRejection = (reason: unknown) => { rejections.push(reason) }
+    process.on('unhandledRejection', onRejection)
+    try {
+      injectOneShotWriteFailure(app)
+      let submitted = ''
+      app.onSubmit((text) => { submitted = text })
+      await (app as unknown as {
+        handleInputSubmit(text: string, images?: string[]): Promise<void>
+      }).handleInputSubmit('ordinary fragile')
+
+      assert.equal(submitted, 'ordinary fragile', '显示失败后仍执行普通提交回调')
+      assert.ok(out.chunks.join('').includes('⚠ 用户消息显示失败'), 'awaitUserCommit=false 应显示警告')
+      await tick(20)
+      assert.deepEqual(rejections, [], 'awaitUserCommit 失败不得产生 unhandled rejection')
+    } finally {
+      process.removeListener('unhandledRejection', onRejection)
+    }
+  })
+})
+
+// ── onSubmit 注册处的 async catch 收口 ─────────────────────
+
+test('真实 Enter 按键链路 onSubmit 抛错：注册处 catch 收口为警告行，无 unhandledRejection', async () => {
+  const { app, out, stdin } = makeApp({ cols: 80, rows: 24 })
+  const rejections: unknown[] = []
+  const onRejection = (reason: unknown) => { rejections.push(reason) }
+  process.on('unhandledRejection', onRejection)
+  try {
+    app.onSubmit(() => { throw new Error('callback exploded') })
+    for (const ch of 'zzthrow') stdin.dataHandler!(ch)
+    stdin.dataHandler!('\r') // Enter → InputLine onSubmit → handleInputSubmit（async）
+    await tick()
+    const joined = out.chunks.join('')
+    assert.ok(joined.includes('zzthrow'), '用户气泡已写 scrollback')
+    assert.ok(joined.includes('⚠ 提交处理出错'), '回调异常被注册处 catch 收口为警告行')
+    assert.ok(joined.includes('callback exploded'), '警告含原始错误信息')
+    await tick(20)
+    assert.deepEqual(rejections, [], 'async 回调异常不得成为 unhandled rejection')
+  } finally {
+    process.removeListener('unhandledRejection', onRejection)
+  }
+})
+
+// ── 按协议显式定义的光标收尾字节 ───────────────────────────
+
+test('iTerm2 图片序列收尾为 \\x07\\r\\n：光标在图片末行右缘，归列首并落到图片下方', async () => {
+  await withImageEnv('iterm2', async () => {
+    const { app, out } = makeApp({ cols: 80, rows: 24 })
+    setTermImagePreparer(async () => ({ b64: 'QUJD' }))
+    app.submitText('img-iterm', ['data:image/png;base64,QUJD'])
+    await tick()
+    const chunk = out.chunks.find(c => c.includes('\x1B]1337;File='))
+    assert.ok(chunk, 'iTerm2 序列已写出')
+    assert.ok(
+      chunk!.endsWith('\x07\r\n'),
+      `序列收尾必须是 \\x07\\r\\n，实际: ${JSON.stringify(chunk!.slice(-8))}`,
+    )
+  })
+})
+
+test('kitty 图片序列收尾为 \\x1B\\\\\\r：光标已在图片下方 col c，仅归列首', async () => {
+  await withImageEnv('kitty', async () => {
+    const { app, out } = makeApp({ cols: 80, rows: 24 })
+    setTermImagePreparer(async () => ({ b64: 'QUJD' }))
+    app.submitText('img-kitty', ['data:image/png;base64,QUJD'])
+    await tick()
+    const chunk = out.chunks.find(c => c.includes('\x1B_G'))
+    assert.ok(chunk, 'kitty 序列已写出')
+    assert.ok(
+      chunk!.endsWith('\x1B\\\r'),
+      `序列收尾必须是 \\x1B\\\\\\r，实际: ${JSON.stringify(chunk!.slice(-8))}`,
+    )
+    assert.ok(!chunk!.endsWith('\n'), 'kitty 收尾不得带 \\n（光标已下移 r 行，补 \\n 会多一个空行）')
+  })
+})
+
+// ── overlay 退出统一收口 ──────────────────────────────────
+
+test('键盘 Esc 直连退出 overlay + 队列非空：回放走统一收口，恰好一帧 live、FIFO 不倒', async () => {
+  const { app, out, stdin } = makeApp({ cols: 80, rows: 24 })
+  app.registerOverlays({})
+  app.activateOverlay('choice-panel') // activateOverlay 已置 escapeImmediate，裸 \x1B 即时派发
+  app.commitStatic('QUEUED_X') // overlay 激活期间排队的主屏 commit
+  assert.ok(!out.chunks.join('').includes('QUEUED_X'), 'overlay 激活期间不写主屏')
+
+  stdin.dataHandler!('\x1B') // 真实 Esc 按键 → exitOverlayCore 统一收口
+  await tick()
+
+  const chunks = out.chunks
+  const joined = chunks.join('')
+  assert.equal(joined.split('QUEUED_X').length - 1, 1, '排队 commit 恰好回放一次')
+  const offIdx = chunks.findIndex(c => c.includes('\x1B[?1049l'))
+  assert.ok(offIdx !== -1, 'alt screen 退出序列已写')
+  assert.ok(
+    chunks.findIndex(c => c.includes('QUEUED_X')) > offIdx,
+    '退出 alt screen 之后才回放主屏 commit',
+  )
+  // 收口核心：suppress 窗口内回放只写 scrollback 不画 live 帧，退出后唯一一次
+  // renderLive——无收口的旧直连路径会先 flushNow 画一帧再 renderLive 画一帧（叠影）。
+  const liveFrames = chunks.slice(offIdx).filter(c => c.includes('❯'))
+  assert.equal(liveFrames.length, 1, '回放后只有唯一 live 帧（无叠影）')
+})
+
+test('键盘 Esc 退出时 async ready 回放仍只产生一帧 live', async () => {
+  await withImageEnv('iterm2', async () => {
+    const { app, out, stdin } = makeApp({ cols: 80, rows: 24 })
+    app.registerOverlays({})
+    let release!: () => void
+    const gate = new Promise<void>(resolve => { release = resolve })
+    setTermImagePreparer(async () => {
+      await gate
+      return { b64: 'RVND' }
+    })
+    app.activateOverlay('choice-panel')
+    app.submitText('async-esc', ['data:image/png;base64,QUJD'])
+    stdin.dataHandler!('\x1B')
+    release()
+    await tick()
+    const chunks = out.chunks
+    const offIdx = chunks.findIndex(c => c.includes('\x1B[?1049l'))
+    assert.ok(offIdx !== -1, 'alt screen 已退出')
+    const afterExit = chunks.slice(offIdx).join('')
+    assert.ok(afterExit.includes('async-esc'), 'async commit 在退出后回放')
+    assert.equal(afterExit.split('async-esc').length - 1, 1, '用户气泡只回放一次')
+    assert.equal(afterExit.split('RVND').length - 1, 1, '图片序列只回放一次')
+  })
+})

--- a/src/tui/engine/__tests__/term-image.test.ts
+++ b/src/tui/engine/__tests__/term-image.test.ts
@@ -1,0 +1,357 @@
+/**
+ * 终端内联图片协议检测与编码测试。
+ */
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { detectImageProtocol, setImageProtocol, imageProtocol } from '../ansi.js'
+import {
+  parseImageDataUrl,
+  encodeIterm2Image,
+  encodeKittyImage,
+  encodeTermImage,
+  prepareTermImage,
+} from '../term-image.js'
+import { runImageTool, toPngCandidates, resizeCandidates } from '../image-tool.js'
+import { MAX_IMAGE_BYTES } from '../image-attach.js'
+
+const PNG_1X1 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=='
+
+function env(overrides: Record<string, string | undefined>): NodeJS.ProcessEnv {
+  const base: NodeJS.ProcessEnv = { TERM: 'xterm-256color', TERM_PROGRAM: undefined, TMUX: undefined }
+  for (const [k, v] of Object.entries(overrides)) {
+    if (v === undefined) delete base[k]
+    else base[k] = v
+  }
+  return base
+}
+
+// ── 检测（isTTY 显式注入，不依赖测试进程 stdout）─────────────────
+
+test('RIVET_IMAGES 环境开关优先', () => {
+  assert.equal(detectImageProtocol(env({ RIVET_IMAGES: '0', TERM_PROGRAM: 'iTerm.app' }), true), 'none')
+  assert.equal(detectImageProtocol(env({ RIVET_IMAGES: 'off', TERM: 'xterm-kitty' }), true), 'none')
+  assert.equal(detectImageProtocol(env({ RIVET_IMAGES: 'kitty', TERM: 'dumb' }), false), 'kitty')
+  assert.equal(detectImageProtocol(env({ RIVET_IMAGES: 'iterm2', TERM: 'dumb' }), false), 'iterm2')
+})
+
+test('dumb / 非 TTY / tmux 降级为 none', () => {
+  assert.equal(detectImageProtocol(env({ TERM: 'dumb', TERM_PROGRAM: 'iTerm.app' }), true), 'none')
+  assert.equal(detectImageProtocol(env({ TERM_PROGRAM: 'iTerm.app' }), false), 'none')
+  assert.equal(detectImageProtocol(env({ TMUX: '/tmp/tmux-1000/default,1,0', TERM_PROGRAM: 'iTerm.app' }), true), 'none')
+  assert.equal(detectImageProtocol(env({ TERM: 'screen-256color', TERM_PROGRAM: 'iTerm.app' }), true), 'none')
+})
+
+test('终端识别矩阵', () => {
+  assert.equal(detectImageProtocol(env({ TERM_PROGRAM: 'iTerm.app' }), true), 'iterm2')
+  assert.equal(detectImageProtocol(env({ TERM: 'xterm-kitty' }), true), 'kitty')
+  assert.equal(detectImageProtocol(env({ TERM_PROGRAM: 'ghostty' }), true), 'kitty')
+  assert.equal(detectImageProtocol(env({ TERM_PROGRAM: 'WezTerm' }), true), 'kitty')
+  assert.equal(detectImageProtocol(env({ TERM_PROGRAM: 'WarpTerminal' }), true), 'kitty')
+  assert.equal(detectImageProtocol(env({ KONSOLE_VERSION: '2308000' }), true), 'kitty')
+  assert.equal(detectImageProtocol(env({ TERM_PROGRAM: 'vscode' }), true), 'none')
+  assert.equal(detectImageProtocol(env({}), true), 'none')
+})
+
+test('setImageProtocol 覆盖自动检测', () => {
+  setImageProtocol('kitty')
+  assert.equal(imageProtocol(), 'kitty')
+  setImageProtocol(null)
+  assert.ok(['kitty', 'iterm2', 'none'].includes(imageProtocol()))
+})
+
+// ── data URL 严格校验（控制字符注入面）─────────────────────────
+
+test('parseImageDataUrl 合法输入', () => {
+  assert.deepEqual(parseImageDataUrl(`data:image/png;base64,${PNG_1X1}`), { mime: 'image/png', b64: PNG_1X1 })
+  assert.deepEqual(parseImageDataUrl('data:image/JPEG;base64,/9j/4AA='), { mime: 'image/jpeg', b64: '/9j/4AA=' })
+})
+
+test('parseImageDataUrl 拒绝控制字符与畸形载荷', () => {
+  // BEL 可提前终止 OSC；ESC\ 可提前终止 APC —— 都必须拒绝
+  assert.equal(parseImageDataUrl('data:image/png;base64,QUJD\x07'), null)
+  assert.equal(parseImageDataUrl('data:image/png;base64,QUJD\x1B\\'), null)
+  assert.equal(parseImageDataUrl('data:image/png;base64,QUJD\n'), null)
+  // 空载荷 / 非法 padding / 长度非 4 对齐
+  assert.equal(parseImageDataUrl('data:image/png;base64,'), null)
+  assert.equal(parseImageDataUrl('data:image/png;base64,QU=J'), null)
+  assert.equal(parseImageDataUrl('data:image/png;base64,QUJD='), null)
+  assert.equal(parseImageDataUrl('data:image/png;base64,QUJ'), null)
+  // 非图片 / 非附件支持 MIME / 非 base64 段
+  assert.equal(parseImageDataUrl('data:text/plain;base64,QUJD'), null)
+  assert.deepEqual(parseImageDataUrl('data:image/tiff;base64,QUJD'), { mime: 'image/tiff', b64: 'QUJD' })
+  assert.deepEqual(parseImageDataUrl('data:image/bmp;base64,QUJD'), { mime: 'image/bmp', b64: 'QUJD' })
+  assert.equal(parseImageDataUrl('data:image/png,QUJD'), null)
+  assert.equal(parseImageDataUrl('not-a-data-url'), null)
+})
+
+test('parseImageDataUrl 拒绝超限载荷（按 base64 长度预估，不分配 Buffer）', () => {
+  const tooBig = 'A'.repeat(Math.ceil((MAX_IMAGE_BYTES * 4) / 3) + 4)
+  assert.equal(parseImageDataUrl(`data:image/png;base64,${tooBig}`), null)
+})
+
+/** 构造 n 个 base64 分组 + p 个 padding 的载荷，解码后恰为 3n - p 字节。 */
+function b64WithGroups(groups: number, padding: 0 | 1 | 2): string {
+  return 'A'.repeat(groups * 4 - padding) + '='.repeat(padding)
+}
+
+test('parseImageDataUrl 体积上限按精确解码长度判定（扣 padding）', () => {
+  // 解码长度 = 3n - p，随 n 步进 3。对每种 padding 取不超上限的最大 n 必须放行，
+  // n+1 必须拒绝——覆盖「解码后恰好等于上限」的边界（10MiB 时由 padding=2 命中）。
+  for (const padding of [0, 1, 2] as const) {
+    const maxGroups = Math.floor((MAX_IMAGE_BYTES + padding) / 3)
+    assert.ok(3 * maxGroups - padding <= MAX_IMAGE_BYTES)
+    assert.ok(3 * (maxGroups + 1) - padding > MAX_IMAGE_BYTES)
+    assert.notEqual(parseImageDataUrl(`data:image/png;base64,${b64WithGroups(maxGroups, padding)}`), null)
+    assert.equal(parseImageDataUrl(`data:image/png;base64,${b64WithGroups(maxGroups + 1, padding)}`), null)
+  }
+  // 具体边界值：上限-1 / 恰好上限 / 超上限 1 字节（各自对应可达的 padding）
+  const atMinusOne = b64WithGroups((MAX_IMAGE_BYTES - 1) / 3, 0)
+  const atExact = b64WithGroups((MAX_IMAGE_BYTES + 2) / 3, 2)
+  const atPlusOne = b64WithGroups((MAX_IMAGE_BYTES + 1 + 1) / 3, 1)
+  assert.notEqual(parseImageDataUrl(`data:image/png;base64,${atMinusOne}`), null)
+  assert.notEqual(parseImageDataUrl(`data:image/png;base64,${atExact}`), null)
+  assert.equal(parseImageDataUrl(`data:image/png;base64,${atPlusOne}`), null)
+})
+
+test('parseImageDataUrl 接受大写 MIME（data URL 惯例大小写不敏感）', () => {
+  assert.deepEqual(parseImageDataUrl(`data:IMAGE/PNG;base64,${PNG_1X1}`), { mime: 'image/png', b64: PNG_1X1 })
+  assert.deepEqual(parseImageDataUrl('data:image/PNG;base64,/9j/4AA='), { mime: 'image/png', b64: '/9j/4AA=' })
+})
+
+test('parseImageDataUrl 拒绝带参数或含空格的 MIME', () => {
+  // 只接受裸 `;base64,` 形式：charset 等参数不匹配正则，整体拒绝而非解析参数
+  assert.equal(parseImageDataUrl('data:image/png;charset=utf-8;base64,QUJD'), null)
+  // MIME 含空格不在正则字符集内
+  assert.equal(parseImageDataUrl('data:image/ png;base64,QUJD'), null)
+  assert.equal(parseImageDataUrl('data: image/png;base64,QUJD'), null)
+})
+
+// ── 编码器 ─────────────────────────────────────────────────────
+
+test('encodeIterm2Image 输出 OSC 1337 序列（宽高超框 + 保比例）', () => {
+  const seq = encodeIterm2Image('QUJD', 40, 12)
+  assert.ok(seq.startsWith('\x1B]1337;File=inline=1;width=40;height=12;preserveAspectRatio=1:'))
+  assert.ok(seq.endsWith('QUJD\x07'))
+})
+
+test('encodeKittyImage 小块单帧输出（c×r 有界矩形）', () => {
+  const seq = encodeKittyImage('QUJD', 40, 10)
+  assert.equal(seq, '\x1B_Ga=T,f=100,q=2,c=40,r=10,m=0;QUJD\x1B\\')
+})
+
+test('encodeKittyImage 大块分块且非末块为 4 的倍数', () => {
+  const b64 = 'A'.repeat(4096 * 2 + 100)
+  const seq = encodeKittyImage(b64, 40, 10)
+  const frames = seq.split('\x1B\\').filter(Boolean)
+  assert.equal(frames.length, 3)
+  assert.ok(frames[0]!.startsWith('\x1B_Ga=T,f=100,q=2,c=40,r=10,m=1;'))
+  assert.ok(frames[1]!.startsWith('\x1B_Gq=2,m=1;'))
+  assert.ok(frames[2]!.startsWith('\x1B_Gq=2,m=0;'))
+  for (const frame of frames.slice(0, -1)) {
+    const payload = frame.slice(frame.indexOf(';') + 1)
+    assert.equal(payload.length % 4, 0)
+    assert.ok(payload.length <= 4096)
+  }
+  // 重组后载荷完整
+  const reassembled = frames.map(f => f.slice(f.indexOf(';') + 1)).join('')
+  assert.equal(reassembled, b64)
+})
+
+test('encodeKittyImage 空载荷返回空串', () => {
+  assert.equal(encodeKittyImage('', 40, 10), '')
+})
+
+// ── encodeTermImage 行高几何 ───────────────────────────────────
+
+test('encodeTermImage kitty 按像素宽高比收紧 r 并封顶', () => {
+  // 1000×500 px，宽 40 列 → 行数 ≈ 0.5 * 40/2 = 10
+  const seq = encodeTermImage({ b64: 'QUJD', pixelWidth: 1000, pixelHeight: 500 }, 'kitty', 40, 18)
+  assert.ok(seq !== null && seq.includes('c=40,r=10,'))
+  // 超高图：100×5000 px → 需要 1000 行，被 maxRows=18 封顶
+  const tall = encodeTermImage({ b64: 'QUJD', pixelWidth: 100, pixelHeight: 5000 }, 'kitty', 40, 18)
+  assert.ok(tall !== null && tall.includes('c=40,r=18,'))
+  // 无尺寸信息 → 退回 maxRows（几何有界）
+  const unknown = encodeTermImage({ b64: 'QUJD' }, 'kitty', 40, 18)
+  assert.ok(unknown !== null && unknown.includes('c=40,r=18,'))
+})
+
+test('encodeTermImage iterm2 直出（宽高超框）', () => {
+  const seq = encodeTermImage({ b64: 'QUJD' }, 'iterm2', 40, 18)
+  assert.ok(seq !== null && seq.includes('width=40') && seq.includes('height=18'))
+})
+
+// ── prepareTermImage ───────────────────────────────────────────
+
+test('prepareTermImage：iterm2 直通，非法 data URL 返回 null', async () => {
+  const prepared = await prepareTermImage(`data:image/png;base64,${PNG_1X1}`, 'iterm2')
+  assert.deepEqual(prepared, { b64: PNG_1X1 })
+  assert.equal(await prepareTermImage('garbage', 'iterm2'), null)
+  assert.equal(await prepareTermImage('data:text/plain;base64,QUJD', 'iterm2'), null)
+  assert.equal(await prepareTermImage('data:image/png;base64,QUJD\x07', 'iterm2'), null)
+})
+
+test('prepareTermImage：kitty 对 PNG 直通并解析 IHDR 尺寸', async () => {
+  const prepared = await prepareTermImage(`data:image/png;base64,${PNG_1X1}`, 'kitty')
+  assert.ok(prepared !== null)
+  assert.equal(prepared.pixelWidth, 1)
+  assert.equal(prepared.pixelHeight, 1)
+  assert.equal(prepared.b64, PNG_1X1)
+})
+
+// ── runImageTool fallback 语义（候选级隔离：执行+读回+PNG 校验一体化）───────────────
+
+/** 用 node -e 构造假命令，不依赖 sips/ImageMagick 真实存在。 */
+function fakeCmd(script: string, ...extraArgs: string[]): { bin: string; args: string[] } {
+  return { bin: process.execPath, args: ['-e', script, ...extraArgs] }
+}
+
+/** 写出真实 PNG 字节的假命令脚本（runner 校验 magic，字符串残片过不了）。 */
+function writePngScript(): string {
+  return `require('node:fs').writeFileSync(process.argv[1], Buffer.from('${PNG_1X1}','base64'))`
+}
+
+const PNG_BUF = Buffer.from(PNG_1X1, 'base64')
+
+test('runImageTool：全部失败返回 null', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'rivet-imgtool-test-'))
+  try {
+    const out = join(dir, 'out.png')
+    const result = await runImageTool([
+      fakeCmd('process.exit(1)'),
+      fakeCmd('process.exit(1)', out),
+    ], out)
+    assert.equal(result, null)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('runImageTool：exit 0 但未产出文件时继续 fallback', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'rivet-imgtool-test-'))
+  try {
+    const out = join(dir, 'out.png')
+    // 第一个候选 exit 0 但不写文件 → 应跳过；第二个产出有效 PNG → 成功
+    const result = await runImageTool([
+      fakeCmd('process.exit(0)', out),
+      fakeCmd(writePngScript(), out),
+    ], out)
+    assert.deepEqual(result, PNG_BUF)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('runImageTool：exit 0 但产出空文件时继续 fallback', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'rivet-imgtool-test-'))
+  try {
+    const out = join(dir, 'out.png')
+    const result = await runImageTool([
+      fakeCmd("require('node:fs').writeFileSync(process.argv[1], '')", out),
+      fakeCmd(writePngScript(), out),
+    ], out)
+    assert.deepEqual(result, PNG_BUF)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('runImageTool：候选级隔离——A 留非空残片 + B 空退时不误判，fallback 到 C', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'rivet-imgtool-test-'))
+  try {
+    const out = join(dir, 'out.png')
+    // A：exit 1 但留下非空残片；B：exit 0 但没写文件——若 B 读到 A 的残片会被
+    // 误判成功。每个候选执行前删除 outputPath 后，B 读回失败，继续到 C。
+    const result = await runImageTool([
+      fakeCmd("require('node:fs').writeFileSync(process.argv[1], 'residue'); process.exit(1)", out),
+      fakeCmd('process.exit(0)', out),
+      fakeCmd(writePngScript(), out),
+    ], out)
+    assert.deepEqual(result, PNG_BUF)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('runImageTool：exit 0 但输出非 PNG 判失败', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'rivet-imgtool-test-'))
+  try {
+    const out = join(dir, 'out.png')
+    const result = await runImageTool([
+      fakeCmd("require('node:fs').writeFileSync(process.argv[1], 'not-a-png-at-all')", out),
+    ], out)
+    assert.equal(result, null)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('runImageTool：首个候选成功即短路（不执行后续候选）', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'rivet-imgtool-test-'))
+  try {
+    const out = join(dir, 'out.png')
+    // 第二个候选是不存在的二进制——若被执行会抛错，短路则不会触碰
+    const result = await runImageTool([
+      fakeCmd(writePngScript(), out),
+      { bin: '/nonexistent/rivet-imgtool-should-not-run', args: [out] },
+    ], out)
+    assert.deepEqual(result, PNG_BUF)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+// ── 候选命令构造的平台分支（只测构造，不测执行）─────────────────────
+
+function bins(commands: { bin: string }[]): string[] {
+  return commands.map(c => c.bin)
+}
+
+test('toPngCandidates：win32 不含 sips/convert，以 magick → powershell 兜底', () => {
+  const cmds = toPngCandidates('C:\\tmp\\in.jpg', 'C:\\tmp\\out.png', 'win32')
+  assert.deepEqual(bins(cmds), ['magick', 'powershell'])
+  const ps = cmds[1]!
+  assert.deepEqual(ps.args.slice(0, 3), ['-NoProfile', '-NonInteractive', '-Command'])
+  const script = ps.args[3]!
+  assert.ok(script.includes('System.Drawing'))
+  assert.ok(script.includes("[System.Drawing.Imaging.ImageFormat]::Png"))
+  assert.ok(script.includes("'C:\\tmp\\in.jpg'") && script.includes("'C:\\tmp\\out.png'"))
+  // 健壮性：non-terminating error 转为终止性 + try/finally 保证释放
+  assert.ok(script.includes("$ErrorActionPreference='Stop'"))
+  assert.ok(script.includes('try {') && script.includes('finally {'))
+})
+
+test('toPngCandidates：darwin 为 sips → magick → convert，无 powershell', () => {
+  const cmds = toPngCandidates('/tmp/in.jpg', '/tmp/out.png', 'darwin')
+  assert.deepEqual(bins(cmds), ['sips', 'magick', 'convert'])
+})
+
+test('resizeCandidates：win32 不含 sips/convert，PowerShell 脚本按 maxEdge 等比缩放', () => {
+  const cmds = resizeCandidates('C:\\tmp\\in.jpg', 'C:\\tmp\\out.png', 1568, 'win32')
+  assert.deepEqual(bins(cmds), ['magick', 'powershell'])
+  const script = cmds[1]!.args[3]!
+  assert.ok(script.includes('[Math]::Min(1.0,1568/[Math]::Max($img.Width,$img.Height))'))
+  assert.ok(script.includes('.Dispose()'))
+  // 健壮性：non-terminating error 转为终止性 + try/finally 空值检查逆序释放
+  assert.ok(script.includes("$ErrorActionPreference='Stop'"))
+  assert.ok(script.includes('try {') && script.includes('finally {'))
+  const finallyPart = script.slice(script.indexOf('finally'))
+  assert.ok(finallyPart.includes('if ($g)') && finallyPart.includes('if ($bmp)') && finallyPart.includes('if ($img)'))
+  assert.ok(finallyPart.indexOf('$g.Dispose()') < finallyPart.indexOf('$bmp.Dispose()'))
+  assert.ok(finallyPart.indexOf('$bmp.Dispose()') < finallyPart.indexOf('$img.Dispose()'))
+})
+
+test('resizeCandidates：darwin 为 sips → magick → convert，无 powershell', () => {
+  const cmds = resizeCandidates('/tmp/in.jpg', '/tmp/out.png', 1568, 'darwin')
+  assert.deepEqual(bins(cmds), ['sips', 'magick', 'convert'])
+  assert.ok(cmds[0]!.args.includes('-Z') && cmds[0]!.args.includes('1568'))
+})
+
+test('候选构造：路径中的单引号在 PowerShell 脚本里翻倍转义', () => {
+  const cmds = toPngCandidates("C:\\tmp\\it's.jpg", 'C:\\tmp\\out.png', 'win32')
+  const script = cmds[1]!.args[3]!
+  assert.ok(script.includes("'C:\\tmp\\it''s.jpg'"))
+})

--- a/src/tui/engine/ansi.ts
+++ b/src/tui/engine/ansi.ts
@@ -259,6 +259,52 @@ export function fileLink(text: string, filePath: string, cwd = process.cwd()): s
   return hyperlink(text, `file://${abs}`)
 }
 
+// ── 终端内联图片协议 ──────────────────────────────────────────
+
+/** 支持的终端内联图片协议。'none' 表示降级为文本占位。 */
+export type ImageProtocol = 'kitty' | 'iterm2' | 'none'
+
+let imageProtocolOverride: ImageProtocol | null = null
+
+/** 测试/配置钩子：强制指定图片协议（null 恢复自动检测）。 */
+export function setImageProtocol(value: ImageProtocol | null): void {
+  imageProtocolOverride = value
+}
+
+/**
+ * 内联图片协议启发式检测，与 detectHyperlinkSupport 同构：
+ * - 环境开关优先：`RIVET_IMAGES=0/off` 关闭，`kitty`/`iterm2` 强制指定
+ * - kitty 协议：kitty（TERM 前缀）、ghostty、WezTerm、Warp、Konsole
+ * - iTerm2 协议：iTerm.app
+ * - tmux/screen 与 dumb 终端保守降级（图形序列需 passthrough，默认关闭）
+ */
+export function detectImageProtocol(
+  env: NodeJS.ProcessEnv = process.env,
+  isTTY: boolean = Boolean(process.stdout.isTTY),
+): ImageProtocol {
+  const override = env.RIVET_IMAGES?.toLowerCase()
+  if (override === '0' || override === 'off' || override === 'none') return 'none'
+  if (override === 'kitty' || override === 'iterm2') return override
+  const term = env.TERM ?? ''
+  if (term === 'dumb' || !isTTY) return 'none'
+  if (env.TMUX || term.startsWith('screen')) return 'none'
+  const program = env.TERM_PROGRAM ?? ''
+  if (program === 'iTerm.app') return 'iterm2'
+  if (term.startsWith('xterm-kitty')) return 'kitty'
+  if (['ghostty', 'WezTerm', 'WarpTerminal', 'konsole'].includes(program)) return 'kitty'
+  if (env.KONSOLE_VERSION) return 'kitty'
+  return 'none'
+}
+
+let detectedImageProtocol: ImageProtocol | null = null
+
+/** 当前生效的图片协议（带缓存 + override 钩子）。 */
+export function imageProtocol(): ImageProtocol {
+  if (imageProtocolOverride !== null) return imageProtocolOverride
+  if (detectedImageProtocol === null) detectedImageProtocol = detectImageProtocol()
+  return detectedImageProtocol
+}
+
 // ── 终端查询 ──────────────────────────────────────────────────
 
 /** 查询光标位置。终端会通过 stdin 返回 `\x1B[row;colR`。 */

--- a/src/tui/engine/app.ts
+++ b/src/tui/engine/app.ts
@@ -30,7 +30,13 @@ import { ApprovalIntentController } from './approval-intent-controller.js'
 import { MetricsGlanceController } from './metrics-glance-controller.js'
 import { StreamRenderController } from './stream-render-controller.js'
 import { InputController } from './input-controller.js'
-import { ANSI, color, fg, bg, QUERY_CURSOR_POS, osc52Clipboard } from './ansi.js'
+import { ANSI, color, fg, bg, QUERY_CURSOR_POS, osc52Clipboard, imageProtocol } from './ansi.js'
+import {
+  encodeTermImage,
+  parseImageDataUrl,
+  prepareTermImageForCommit,
+  type PreparedTermImage,
+} from './term-image.js'
 
 import type { CacheStatus } from '../status-types.js'
 import { debugLog } from '../../utils/debug.js'
@@ -183,6 +189,15 @@ export function looksLikeFilePath(
     return !isKnownCommand(firstToken)
   }
   return false
+}
+
+/**
+ * 入口图片规范化：过滤非法 data URL 并按 MAX_IMAGES 截断。
+ * 气泡提示、终端渲染、onSubmitCallback 三处必须看到同一个数组。
+ */
+function normalizeSubmitImages(images?: string[]): string[] | undefined {
+  if (!images || images.length === 0) return images
+  return images.filter(u => parseImageDataUrl(u) !== null).slice(0, MAX_IMAGES)
 }
 
 /** 从 slashCommands 提示列表构建命令名谓词。
@@ -641,8 +656,10 @@ export class TuiApp {
   private inputController = new InputController()
   /** 输入框最近一次获得焦点的时间戳，用于 Ctrl+V 剪贴板图片防抖 */
   private lastInputFocusAt = 0
-  /** 批量回放 pending commit 时抑制每次 commitAbove 的 renderLive，最后统一画一帧。 */
+  /** overlay 退出回放排队的主屏 commit 时抑制每个条目的 renderLive，最后统一画一帧。 */
   private suppressCommitRender = false
+  /** renderLive requests deferred while an async overlay-commit pump is active. */
+  private deferredCommitRender = false
   /** 原始 stdout（用于直接写 DEC 私有模式如 bracketed paste 开关） */
   private stdout: WriteStream
   private terminalRestored = false
@@ -701,11 +718,12 @@ export class TuiApp {
       // alt screen 切换统一驱动 CPR 污染检测的暂停/恢复，覆盖所有 overlay
       // 入口（含直接调 this.overlay.activate 的快捷键路径）。
       onEnterAltScreen: () => this.live.suppressProbe(),
-      // 退出 alt screen 时恢复探针，并回放 overlay 期间排队的主屏 commit
-      // （deactivateInternal 先置 active=null 再退 alt screen，回放不会递归入队）。
+      // 退出 alt screen 时恢复探针，并驱动 pump 回放 overlay 期间排队的主屏
+      // commit（deactivateInternal 先置 active=null 再退 alt screen，同步条目
+      // 在 pump 同步段内排空，不会递归入队；异步条目后续微任务续跑）。
       onExitAltScreen: () => {
         this.live.resumeProbe()
-        this.flushPendingMainCommits()
+        this.requestPump()
       },
     })
     this.input = new InputHandler({ stdin: options.stdin, mode: 'input' })
@@ -716,7 +734,13 @@ export class TuiApp {
       history: options.history,
       placeholder: '询问任何事，或 / 唤起命令',
       onTabComplete: () => this.handleTabComplete(),
-      onSubmit: (text, images) => this.handleInputSubmit(text, images),
+      // handleInputSubmit 是 async：回调内任何异常都会成为 rejected Promise，
+      // 必须显式 catch 收口为一条警告行，否则 void 掉的是 unhandled rejection。
+      onSubmit: (text, images) => {
+        void this.handleInputSubmit(text, images).catch((err: unknown) => {
+          this.commitStatic(color(`⚠ 提交处理出错：${err instanceof Error ? err.message : String(err)}`, this.theme.warning))
+        })
+      },
     })
 
     // Write batcher: coalesce render calls
@@ -984,9 +1008,10 @@ export class TuiApp {
         // 空闲时 ESC 落入输入框的 vim normal/insert 切换（保持原行为）。
         if (this.inputLine.vimEnabled) {
           if (this.overlay.isActive()) {
-            // 直连 deactivate 也要清 detail 指针——否则看过一次的 job/worker
-            // 日志把后续 pager 内容永久劫持（pagerContent 把 detail 排在最前）。
-            this.overlay.deactivate()
+            // 键盘直连退出也走统一收口：suppress 窗口包住回放，避免叠影；
+            // detail 指针必清——否则看过一次的 job/worker 日志把后续 pager
+            // 内容永久劫持（pagerContent 把 detail 排在最前）。
+            this.exitOverlayCore()
             this.workerDetailWorkerId = null
             this.jobDetailId = null
             this.renderLive()
@@ -1004,7 +1029,8 @@ export class TuiApp {
           // 空闲 + vim：ESC 落入输入框处理 vim 模式切换
         } else {
           if (this.overlay.isActive()) {
-            this.overlay.deactivate()
+            // 键盘直连退出走统一收口，理由同上（vim 分支注释）。
+            this.exitOverlayCore()
             this.workerDetailWorkerId = null
             this.jobDetailId = null
             this.renderLive()
@@ -1289,7 +1315,9 @@ export class TuiApp {
   private contractBypass = false
 
   /** 输入提交主流程（InputLine onSubmit 回调；原构造器闭包提取，逻辑零改动）。 */
-  private handleInputSubmit(text: string, images?: string[]): void {
+  private async handleInputSubmit(text: string, images?: string[]): Promise<void> {
+    // 入口先规范化图片数组，后续气泡/渲染/回调看到的是同一份。
+    images = normalizeSubmitImages(images)
     let trimmed = text.trim()
     const hasImages = images && images.length > 0
     // 允许只发图片：空文本时补一个占位 prompt，让后端能触发 run。
@@ -1341,8 +1369,9 @@ export class TuiApp {
     // slash 命令（/ 开头）仍归主会话——用户在视图内还需要 /tasks 等导航。
     if (this.viewingWorkerId && trimmed && !trimmed.startsWith('/')) {
       const target = this.viewingWorkerId
+      // 先等气泡+图片落 scrollback 再 steer：worker 输出不得先于用户气泡。
+      await this.awaitUserCommit(`[→ ${shortOrderLabel(target)}] ${trimmed}`, images)
       const delivered = this.workerSteer?.(target, trimmed) ?? false
-      this.commitUserPrompt(`[→ ${shortOrderLabel(target)}] ${trimmed}`, images)
       if (!delivered) {
         this.commitStatic(color('⚠ 该子代理已结束或不支持直达，消息未送达', this.theme.warning))
       }
@@ -1353,7 +1382,7 @@ export class TuiApp {
     // W4a: agent 执行中 → 入队（turn 边界 drain 注入）。
     // 同时立即 commit 用户气泡到 scrollback，确保用户始终能看到自己说了什么。
     if (this.agentBusy && trimmed) {
-      this.commitUserPrompt(trimmed, images)
+      await this.awaitUserCommit(trimmed, images)
       this.steerBuffer.push(trimmed)
       this.renderLive()
       return
@@ -1385,7 +1414,7 @@ export class TuiApp {
     // Commit user message to scrollback（steer 已单独 commit 时跳过）
     if (trimmed) {
       if (!steerMerged) {
-        this.commitUserPrompt(submitText.trim(), images)
+        await this.awaitUserCommit(submitText.trim(), images)
       }
       // 新 run 启动前丢弃上一 run 未 finalize 的流式残留：blockWriter 缓冲
       // 与 streamRenderer pending 若不清，会把上一轮文字追加进新轮输出。
@@ -1407,7 +1436,10 @@ export class TuiApp {
     if (key.name === 'return') {
       this.contractPreview = null
       this.contractBypass = true
-      this.handleInputSubmit(pending.text, pending.images)
+      // 与 InputLine onSubmit 注册处同款收口：async 调用必须显式 catch。
+      void this.handleInputSubmit(pending.text, pending.images).catch((err: unknown) => {
+        this.commitStatic(color(`⚠ 提交处理出错：${err instanceof Error ? err.message : String(err)}`, this.theme.warning))
+      })
       return true
     }
     if (key.char === 'e') {
@@ -1648,17 +1680,46 @@ export class TuiApp {
     }
   }
 
-  /** 停用 overlay */
-  deactivateOverlay(): void {
+  /**
+   * overlay 退出的统一收口：所有「退出 overlay」路径必须经此，
+   * 不得裸调 this.overlay.deactivate()。
+   * 收口点保证：suppressCommitRender 包住 deactivate——deactivate 触发
+   * onExitAltScreen → requestPump，排队的主屏 commit 在 suppress 窗口内
+   * 回放时只写 scrollback 不重绘 live，最后由调用方 renderLive 画唯一帧，
+   * 避免「回放帧 + 退出帧」两层框体叠影/残帧。
+   */
+  private exitOverlayCore(): void {
+    // Every overlay exit path (including direct keyboard Esc) must restore the
+    // normal lone-Esc input behavior. Keep this reset at the shared core so
+    // callers cannot accidentally leave escapeImmediate enabled.
     this.input.setEscapeImmediate(false)
     const wasActive = this.overlay.isActive()
-    // suppressCommitRender 必须在 overlay.deactivate() 之前置位：deactivate 触发
-    // onExitAltScreen → flushPendingMainCommits，回放的 commitAbove 会调 renderLive
-    // 画第一帧；suppress 让回放只 write 到 scrollback，最后由本方法统一 renderLive
-    // 画唯一帧，避免两层框体叠影。
-    if (wasActive) this.suppressCommitRender = true
-    this.overlay.deactivate()
-    if (wasActive) this.suppressCommitRender = false
+    if (!wasActive) return
+    this.suppressCommitRender = true
+    try {
+      this.overlay.deactivate()
+    } finally {
+      const pump = this.mainCommitPump
+      if (!pump) {
+        this.suppressCommitRender = false
+      } else {
+        const finish = () => {
+          this.suppressCommitRender = false
+          if (this.deferredCommitRender && !this.overlay.isActive()) {
+            this.deferredCommitRender = false
+            this.renderLive()
+          }
+        }
+        void pump.then(finish, finish)
+      }
+    }
+  }
+
+  /** 停用 overlay */
+  deactivateOverlay(): void {
+    // 统一收口：suppress 窗口让回放只写 scrollback，最后由本方法
+    // 统一 renderLive 画唯一帧，避免两层框体叠影。
+    this.exitOverlayCore()
     // 记录焦点回归时间：Ctrl+V 剪贴板图片防抖窗口起点
     this.lastInputFocusAt = Date.now()
     this.workerDetailWorkerId = null
@@ -3228,14 +3289,36 @@ export class TuiApp {
    * Commits the user prompt to scrollback and fires onSubmitCallback.
    */
   submitText(text: string, images?: string[]): void {
-    this.commitUserPrompt(text, images)
-    this.blockWriter.discard()
-    this.streamRenderer.reset()
-    this.streamRenderController.assistantHeaderDone = false
-    this.agentBusy = true
-    this.state.turnStartMs = Date.now()
-    this.streamRenderController.lastActivityMs = Date.now()
-    this.onSubmitCallback?.(text, images)
+    // 入口先规范化图片数组，气泡/渲染/回调看到的是同一份。
+    images = normalizeSubmitImages(images)
+    // 带图提交是异步原子单元（转码完成后「气泡+图片」一起落 scrollback），
+    // agent 必须等它落地后再启动，保证图片先于 assistant 输出。
+    const pending = this.commitUserPrompt(text, images)
+    const start = () => {
+      this.blockWriter.discard()
+      this.streamRenderer.reset()
+      this.streamRenderController.assistantHeaderDone = false
+      this.agentBusy = true
+      this.state.turnStartMs = Date.now()
+      this.streamRenderController.lastActivityMs = Date.now()
+      this.onSubmitCallback?.(text, images)
+    }
+    // fire-and-forget 链上任何异常（prepare 漏网 / start 回调抛错）都静默，
+    // 绝不让 void 路径产生 unhandled rejection。
+    if (pending) {
+      void pending.then((written) => {
+        // 显示失败（written=false）不阻塞 agent：内容已交给 agent，只留一条
+        // muted 警告告知用户气泡没写出来。
+        if (!written) {
+          try {
+            this.commitStatic(color('⚠ 用户消息显示失败，但内容已发送给 agent', this.theme.muted))
+          } catch {
+            // stdout may remain unavailable; display failure must not prevent delivery.
+          }
+        }
+        start()
+      }).catch(() => {})
+    } else start()
   }
 
   /**
@@ -3243,17 +3326,68 @@ export class TuiApp {
    * 写入 scrollback 内容，再重绘 live region。
    * 不走该协议的裸 commit 会留下 ghost 行 / 覆盖已提交文本。
    *
-   * overlay（alt screen）激活期间主屏写入一律排队、一个字节都不写：
-   * clearForCommit 的 cursorUp+擦除与正文会落进 alt screen 擦花/顶滚动面板，
-   * 而 OverlayEngine 的行级 diff 缓存（lastFrame）对此无感知，之后只有光标
-   * 变化行被重绘——计划审批卡「按一下方向键才出来一行」的根因。
-   * 队列在 onExitAltScreen（flushPendingMainCommits）统一回放。
+   * 所有主屏 commit 统一经 enqueueMainCommit 定序：队列空闲时同步直写；
+   * 前方有异步条目（带图 prepare）或 overlay 激活时严格 FIFO 排队。
+   * overlay（alt screen）激活期间主屏写入一个字节都不写：clearForCommit 的
+   * cursorUp+擦除与正文会落进 alt screen 擦花/顶滚动面板，而 OverlayEngine
+   * 的行级 diff 缓存（lastFrame）对此无感知——计划审批卡「按一下方向键才
+   * 出来一行」的根因。排队条目在 overlay 退出时由 pump 回放。
    */
   private commitAbove(write: () => void): void {
-    if (this.overlay.isActive()) {
-      this.pendingMainCommits.push(write)
-      return
+    this.enqueueMainCommit(write)
+  }
+
+  /** 主屏 commit 队列条目：ready 为同步写闭包，或 prepare 完成后兑现写闭包的 Promise。 */
+  private mainCommitQueue: Array<{
+    ready: (() => void) | Promise<() => void>
+    /** 写完成后 resolve true；prepare 拒绝/写入抛错被跳过时 resolve false。 */
+    done: (written: boolean) => void
+  }> = []
+
+  /** 单实例 pump 互斥锁（非 null = 有 pump 在跑或刚同步排空待 settle）。 */
+  private mainCommitPump: Promise<void> | null = null
+
+  /** pump 同步段执行标志：堵住 mainCommitPump 赋值前的再入窗口。 */
+  private mainCommitPumping = false
+
+  /**
+   * 唯一有序 main commit 队列入口。位置在调用时一次性分配。
+   *
+   * 同步 fast path 契约：「队列空闲 + 无 pump 在跑 + overlay 未激活 + ready 是同步闭包」
+   * 四条件同时满足才走同步 fast path——立即 atomicCommitNow 并返回 null
+   * （保持 commitStatic/commitAbove 既有同步契约）。否则入队、requestPump，
+   * 返回 job 完成时 resolve 的 Promise<boolean>：true=已写出，false=prepare
+   * 拒绝或写入抛错被跳过（resolve 而非 reject，不给调用方制造 unhandled
+   * rejection）。前方存在 async barrier（带图 prepare）时后续条目严格
+   * FIFO 延后，哪怕它本身是同步闭包也绝不越过。
+   */
+  private enqueueMainCommit(ready: (() => void) | Promise<() => void>): Promise<boolean> | null {
+    if (
+      typeof ready === 'function'
+      && this.mainCommitQueue.length === 0
+      && this.mainCommitPump === null
+      && !this.mainCommitPumping
+      && !this.overlay.isActive()
+    ) {
+      try {
+        this.atomicCommitNow(ready)
+        return null
+      } catch {
+        return Promise.resolve(false)
+      }
     }
+    let done!: (written: boolean) => void
+    const finished = new Promise<boolean>(resolve => { done = resolve })
+    this.mainCommitQueue.push({ ready, done })
+    this.requestPump()
+    return finished
+  }
+
+  /**
+   * 纯同步原子提交窗口：cork → clearForCommit → write → flushNow → uncork。
+   * 函数内严禁任何 await——擦除与写入之间插入异步会把原子窗口掏空。
+   */
+  private atomicCommitNow(write: () => void): void {
     // H3：clearForCommit + commit + renderLive 三段写入用 cork/uncork 合并为一次 flush，
     // 减少 syscall 与中间态可见（提交时的瞬时闪烁）。协议顺序不变。
     const s = this.stdout as WriteStream & { cork?: () => void; uncork?: () => void }
@@ -3268,20 +3402,52 @@ export class TuiApp {
     }
   }
 
-  /** overlay 期间排队的主屏 commit。退出 alt screen 时 FIFO 回放（见 onExitAltScreen）。 */
-  private pendingMainCommits: Array<() => void> = []
+  /** 启动单实例 pump；pump 在跑 / 队列空 / overlay 激活时直接返回。 */
+  private requestPump(): void {
+    if (this.mainCommitPumping || this.mainCommitQueue.length === 0 || this.overlay.isActive()) return
+    this.mainCommitPumping = true
+    const pump = this.drainMainCommits()
+    this.mainCommitPump = pump
+    const settle = () => {
+      this.mainCommitPumping = false
+      if (this.mainCommitPump === pump) this.mainCommitPump = null
+      // 竞态收口：pump 同步排空后、本 settle 前入队的条目在这里续跑；
+      // drain 逐条目 try/catch 自身不抛，rejection 分支仅作兜底。
+      this.requestPump()
+    }
+    void pump.then(settle, settle)
+  }
 
   /**
-   * 回放 overlay 期间排队的主屏 commit。挂在 OverlayEngine.onExitAltScreen 上，
-   * 覆盖全部退出路径（deactivateOverlay / Esc 直连 deactivate / unregister /
-   * overlay 切换）。调用时 active 已置 null，commitAbove 走正常直写，不会递归入队。
+   * pump 循环：取队首（先不 shift）→ ready 是 Promise 则先 await（此时绝未
+   * 触碰 live 区）→ await 后重新检查 overlay，激活则保留队首退出（overlay
+   * 退出路径的 requestPump 续跑）→ 未激活才 shift 并 atomicCommitNow。
+   * 每个条目独立 try/catch：单条目异常只跳过该条目，不丢剩余队列。
    */
-  private flushPendingMainCommits(): void {
-    if (this.pendingMainCommits.length === 0) return
-    const queued = this.pendingMainCommits
-    this.pendingMainCommits = []
-    for (const write of queued) {
-      this.commitAbove(write)
+  private async drainMainCommits(): Promise<void> {
+    while (this.mainCommitQueue.length > 0) {
+      const job = this.mainCommitQueue[0]!
+      let write: () => void
+      try {
+        write = typeof job.ready === 'function' ? job.ready : await job.ready
+      } catch {
+        // prepare 失败：跳过该条目继续（commitUserPrompt 内部已把 prepare
+        // 失败降级为纯气泡闭包，正常不会走到这）。以 false 告知调用方未写出。
+        this.mainCommitQueue.shift()
+        job.done(false)
+        continue
+      }
+      // await 期间 overlay 可能（重）激活——主屏内容绝不可写进 alt screen。
+      if (this.overlay.isActive()) return
+      this.mainCommitQueue.shift()
+      let written = true
+      try {
+        this.atomicCommitNow(write)
+      } catch {
+        // 单条目写异常不丢剩余队列；以 false 告知调用方写入失败被跳过。
+        written = false
+      }
+      job.done(written)
     }
   }
 
@@ -3289,30 +3455,98 @@ export class TuiApp {
    * 统一用户消息提交入口。在 scrollback 中写入 ▍ You 气泡。
    * 所有 submit 路径（idle / slash passthrough / steer）共用此入口，
    * 确保用户始终能在终端历史中看到自己输入的内容。
+   *
+   * 返回值语义：直接透传 enqueueMainCommit 的返回值——
+   * 仅当四条件同步 fast path 真正同步执行时返回 null；其余一律返回
+   * 完成 Promise<boolean>（true=气泡已写出，false=写入失败被跳过）。
+   * 调用方需要「气泡已落地」保证时必须 await 返回值；返回 null 时
+   * 写入已在返回前同步完成。任何「前方无 barrier 即已同步写出」的
+   * 调用方推断都是错的（overlay 激活时同样入队返回 Promise）。
+   * 有图且终端支持图形协议：ready 为立即启动的 prepare 任务，转码完成后
+   * 兑现「气泡 + 图片」写闭包；队列位置在调用当刻预订，prepare 再慢、
+   * overlay 中途激活，物理回放顺序都不倒。
+   * 注意 await 语义的边界：await 返回的 Promise 保证「图片位于
+   * 所属用户气泡下方、先于 assistant 输出」；该 Promise resolve 的值
+   * 表示写入是否成功。
    */
-  private commitUserPrompt(content: string, images?: string[]): void {
-    this.commitAbove(() => {
-      const hasImages = images && images.length > 0
-      let imageNote = ''
-      if (hasImages) {
-        imageNote = `\n${color(`📎 ${images.length} image${images.length > 1 ? 's' : ''} attached`, this.theme.muted)}`
-        if (!this.supportsVision) {
-          if (this.visionBridgeEnabled) {
-            // 提示反映真实桥接来源，而非未经验证的话术。桥接=图先经视觉模型转文字描述再发。
-            const src = this.visionBridgeSource === 'auto' ? '（自动选用的视觉模型）' : ''
-            imageNote += `\n${color(`🖼 主模型不识图，将经识图桥${src}生成图片描述后发送`, this.theme.muted)}`
-          } else {
-            imageNote += `\n${color('⚠ 当前模型不支持识图，且无可用识图桥，图片未发送。请在 Settings → 识图模型 选一个视觉模型（或配置 agent.visionModel）。', this.theme.warning)}`
+  private commitUserPrompt(content: string, images?: string[]): Promise<boolean> | null {
+    const protocol = imageProtocol()
+    const withImages = images && images.length > 0 && protocol !== 'none'
+    if (!withImages) {
+      return this.enqueueMainCommit(() => this.writeUserBubbleLines(content, images))
+    }
+    const ready = (async (): Promise<() => void> => {
+      // 渲染失败的任何异常都静默降级为纯文本气泡——绝不让 fire-and-forget
+      // 路径产生 unhandled rejection。
+      let prepared: PreparedTermImage[] = []
+      try {
+        for (const dataUrl of images.slice(0, MAX_IMAGES)) {
+          const img = await prepareTermImageForCommit(dataUrl, protocol as 'kitty' | 'iterm2')
+          if (img) prepared.push(img)
+        }
+      } catch {
+        prepared = []
+      }
+      return () => {
+        this.writeUserBubbleLines(content, images)
+        if (prepared.length > 0) {
+          // 宽高在写入当刻取最新终端尺寸：转码期间的 resize 不会用过期值编码。
+          const cols = Math.max(10, this.columns - 4)
+          const maxRows = Math.max(5, Math.min(40, (this.stdout.rows || 24) - 6))
+          for (const img of prepared) {
+            const seq = encodeTermImage(img, protocol as 'kitty' | 'iterm2', cols, maxRows)
+            // 图形序列不含换行；光标收尾按协议规范显式定义：
+            // - kitty（默认 C=0）：placement 后光标右移 c 列、下移 r 行——已停在
+            //   图片下方一行的 col c，只需 \r 归列首（补 \n 会多一个空行）。
+            //   依据：kitty spec「cursor must be moved to the right by the number
+            //   of cols ... and down by the number of rows in the placement」。
+            // - iTerm2 OSC 1337：光标停在图片最后一行的右缘（wezterm#317 对真实
+            //   iTerm2 的观测；wezterm#3266 须补换行提示符才落到图片下方）——
+            //   需 \r\n：归列首并下移到图片下方。
+            if (seq) this.commit.writeRaw(seq + (protocol === 'kitty' ? '\r' : '\r\n'))
           }
         }
       }
-      const formatted = formatUserMessage({
-        content: content.trim() + imageNote,
-        width: this.columns,
-      }, this.theme)
-      this.commit.write({ text: formatted.join('\n'), trailingNewline: true })
-      this.state.committedCount++
-    })
+    })()
+    return this.enqueueMainCommit(ready)
+  }
+
+  /** Await a queued user commit and surface a display failure without blocking delivery. */
+  private async awaitUserCommit(content: string, images?: string[]): Promise<boolean> {
+    const pending = this.commitUserPrompt(content, images)
+    const written = pending ? await pending : true
+    if (!written) {
+      try {
+        this.commitStatic(color('⚠ 用户消息显示失败，但内容已发送给 agent', this.theme.muted))
+      } catch {
+        // A broken stdout must not prevent the caller from delivering the input.
+      }
+    }
+    return written
+  }
+
+  /** 气泡正文（须在 commitAbove 窗口内调用）。 */
+  private writeUserBubbleLines(content: string, images?: string[]): void {
+    const hasImages = images && images.length > 0
+    let imageNote = ''
+    if (hasImages) {
+      imageNote = `\n${color(`📎 ${images.length} image${images.length > 1 ? 's' : ''} attached`, this.theme.muted)}`
+      if (!this.supportsVision) {
+        if (this.visionBridgeEnabled) {
+          // 提示反映真实桥接来源，而非未经验证的话术。桥接=图先经视觉模型转文字描述再发。
+          const src = this.visionBridgeSource === 'auto' ? '（自动选用的视觉模型）' : ''
+          imageNote += `\n${color(`🖼 主模型不识图，将经识图桥${src}生成图片描述后发送`, this.theme.muted)}`
+        } else {
+          imageNote += `\n${color('⚠ 当前模型不支持识图，且无可用识图桥，图片未发送。请在 Settings → 识图模型 选一个视觉模型（或配置 agent.visionModel）。', this.theme.warning)}`
+        }
+      }
+    }
+    const formatted = formatUserMessage({
+      content: content.trim() + imageNote,
+      width: this.columns,
+    }, this.theme)
+    this.commit.write({ text: formatted.join('\n'), trailingNewline: true })
+    this.state.committedCount++
   }
 
   // ── W3: phase + ticker ───────────────────────────────────────
@@ -4728,6 +4962,10 @@ export class TuiApp {
   }
 
   private renderLive(): void {
+    if (this.suppressCommitRender) {
+      this.deferredCommitRender = true
+      return
+    }
     // start() 之前所有 setter / 用户输入回调都不应触发真正的 stdout 输出。
     // 构造后到 main.ts 清屏写欢迎屏之间若渲染一版输入框，旧帧可能残留在
     // 欢迎屏上方形成重影；统一在 start() 置 started=true 后才开始绘制。
@@ -5666,7 +5904,7 @@ export class TuiApp {
     if (!handled) {
       // 透传给 agent 前 commit 用户消息到 scrollback，确保 slash 命令
       // 也能在终端历史中看到（之前只有 agent 回复无用户气泡）。
-      this.commitUserPrompt(input)
+      await this.awaitUserCommit(input)
 
       if (this.agentBusy) {
         // 当前 run 仍在执行：把透传 slash 命令按高优先级排进 steer 队列，

--- a/src/tui/engine/image-attach.ts
+++ b/src/tui/engine/image-attach.ts
@@ -8,13 +8,8 @@
  */
 
 import { readFile, unlink } from 'node:fs/promises'
-import { execFile } from 'node:child_process'
-import { promisify } from 'node:util'
-import { basename, extname } from 'node:path'
-import { tmpdir } from 'node:os'
-import { randomUUID } from 'node:crypto'
-
-const execFileAsync = promisify(execFile)
+import { basename, extname, join } from 'node:path'
+import { makeImageTempDir, removeImageTempDir, resizeCandidates, runImageTool } from './image-tool.js'
 
 /** Provider cap: 10 MB decoded per image (matches common vision API limits). */
 export const MAX_IMAGE_BYTES = 10 * 1024 * 1024
@@ -29,6 +24,9 @@ const IMAGE_MIMES: Record<string, string> = {
   '.jpeg': 'image/jpeg',
   '.webp': 'image/webp',
   '.gif': 'image/gif',
+  '.tiff': 'image/tiff',
+  '.tif': 'image/tiff',
+  '.bmp': 'image/bmp',
 }
 
 export interface ImageAttachment {
@@ -43,8 +41,12 @@ export interface LoadImageOptions {
   maxEdge?: number
 }
 
-/** Detect MIME type from magic bytes; falls back to file extension. */
-export function detectImageMime(buf: Buffer, filePath: string): string | null {
+/**
+ * 仅按 magic bytes 识别 MIME；不识别即返回 null。
+ * 不做扩展名 fallback——真实图片（png/jpeg/webp/gif/tiff/bmp）都有可靠 magic，
+ * 任意内容改名 .png 不应进入转码流程。保留 filePath 参数仅为兼容既有调用签名。
+ */
+export function detectImageMime(buf: Buffer, _filePath: string): string | null {
   if (buf.length >= 8) {
     // PNG: 89 50 4E 47
     if (buf[0] === 0x89 && buf[1] === 0x50 && buf[2] === 0x4E && buf[3] === 0x47) {
@@ -84,8 +86,7 @@ export function detectImageMime(buf: Buffer, filePath: string): string | null {
       return 'image/bmp'
     }
   }
-  const ext = extname(filePath).toLowerCase()
-  return IMAGE_MIMES[ext] ?? null
+  return null
 }
 
 /** Returns true if the file extension looks like a supported image. */
@@ -95,26 +96,14 @@ export function looksLikeImagePath(text: string): boolean {
 }
 
 async function trySystemResize(path: string, maxEdge: number): Promise<Buffer | null> {
-  const outPath = `${tmpdir()}/rivet-img-${randomUUID()}.png`
-  const commands: { bin: string; args: string[] }[] = [
-    // macOS built-in
-    { bin: 'sips', args: ['-Z', String(maxEdge), path, '--out', outPath] },
-    // ImageMagick v7
-    { bin: 'magick', args: [path, '-resize', `${maxEdge}x${maxEdge}>`, outPath] },
-    // ImageMagick v6
-    { bin: 'convert', args: [path, '-resize', `${maxEdge}x${maxEdge}>`, outPath] },
-  ]
-  for (const { bin, args } of commands) {
-    try {
-      await execFileAsync(bin, args, { timeout: 15000 })
-      const resized = await readFile(outPath)
-      await unlink(outPath).catch(() => { /* best-effort cleanup */ })
-      return Buffer.from(resized)
-    } catch {
-      // try next command
-    }
+  const dir = await makeImageTempDir()
+  const outPath = join(dir, 'out.png')
+  try {
+    // runImageTool 一体化完成「执行 + 读回 + PNG 校验」，失败返回 null
+    return await runImageTool(resizeCandidates(path, outPath, maxEdge), outPath)
+  } finally {
+    await removeImageTempDir(dir)
   }
-  return null
 }
 
 async function compressImage(path: string, maxEdge: number, maxBytes: number): Promise<Buffer> {
@@ -129,7 +118,7 @@ async function compressImage(path: string, maxEdge: number, maxBytes: number): P
 /**
  * Load an image from disk and return it as a base64 data URL.
  *
- * - Validates format by magic bytes + extension.
+ * - Validates format by magic bytes (no extension fallback).
  * - Rejects unsupported formats.
  * - If the decoded file exceeds maxBytes, attempts to resize to maxEdge using
  *   system tools (sips on macOS, ImageMagick elsewhere).

--- a/src/tui/engine/image-tool.ts
+++ b/src/tui/engine/image-tool.ts
@@ -1,0 +1,214 @@
+/**
+ * 系统图像工具共享执行器 — 平台感知的候选命令构造与 fallback 执行、临时目录管理，
+ * 供 image-attach（缩放）与 term-image（格式转换）两条路径共用，
+ * 避免两套超时/清理策略漂移。
+ *
+ * 候选顺序按平台区分（见 toPngCandidates / resizeCandidates）：
+ * - darwin/linux：sips（macOS 内置，Linux 上不存在会自然失败进 fallback）
+ *   → ImageMagick v7（magick）→ v6（convert）。
+ * - win32：magick → PowerShell + System.Drawing 兜底。不含 sips（不存在），
+ *   也不含 convert——避免撞名系统工具 C:\Windows\System32\convert.exe
+ *   （FAT→NTFS 转换）；PowerShell 为 Windows 自带，覆盖未装 ImageMagick 的场景。
+ *   注意 System.Drawing 不支持 WebP（无 WebP 编解码器）——win32 未装 ImageMagick
+ *   时 WebP 转换必然失败：所有候选跑完返回 null，调用方退回文本占位。失败
+ *   不再是静默的：全部候选失败且 RIVET_DEBUG 非空时向 stderr 打一行调试输出
+ *   （见 runImageTool 末尾）。
+ *
+ * 临时目录约定：每次转换一个 `rivet-imgtool-*` 独立目录，finally 中删除；
+ * 进程崩溃/SIGKILL 残留由下一次转换时的惰性清扫兜底（mtime 超过 1 小时即删）。
+ */
+
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import { mkdtemp, readdir, readFile, rm, stat } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const execFileAsync = promisify(execFile)
+
+export const IMAGE_TEMP_DIR_PREFIX = 'rivet-imgtool-'
+/** 残留目录惰性清扫阈值。 */
+const STALE_MS = 60 * 60 * 1000
+
+export interface ImageToolCommand {
+  bin: string
+  args: string[]
+}
+
+/** PowerShell 单引号字符串字面量：内部 ' 翻倍转义。 */
+function psQuote(path: string): string {
+  return `'${path.replace(/'/g, "''")}'`
+}
+
+/** PowerShell 兜底命令：inbox powershell.exe + System.Drawing，-Command 执行脚本。 */
+function powershellCommand(script: string): ImageToolCommand {
+  return { bin: 'powershell', args: ['-NoProfile', '-NonInteractive', '-Command', script] }
+}
+
+/**
+ * 「任意格式 → PNG」转换候选命令（首个成功即采用）。
+ * darwin/linux：sips → magick → convert；win32：magick → PowerShell
+ * （convert 会撞名系统工具 convert.exe，sips 不存在，均排除）。
+ */
+export function toPngCandidates(
+  inPath: string,
+  outPath: string,
+  platform: NodeJS.Platform = process.platform,
+): ImageToolCommand[] {
+  if (platform === 'win32') {
+    return [
+      { bin: 'magick', args: [inPath, `png:${outPath}`] },
+      powershellCommand(
+        // $ErrorActionPreference='Stop'：把 non-terminating error 变为终止性，
+        // 否则脚本报错仍可能 exit 0；try/finally 保证 $img 释放
+        "$ErrorActionPreference='Stop'; " +
+        'Add-Type -AssemblyName System.Drawing; ' +
+        '$img=$null; ' +
+        `try { $img=[System.Drawing.Image]::FromFile(${psQuote(inPath)}); ` +
+        `$img.Save(${psQuote(outPath)},[System.Drawing.Imaging.ImageFormat]::Png) } ` +
+        'finally { if ($img) { $img.Dispose() } }',
+      ),
+    ]
+  }
+  return [
+    { bin: 'sips', args: ['-s', 'format', 'png', inPath, '--out', outPath] },
+    { bin: 'magick', args: [inPath, `png:${outPath}`] },
+    { bin: 'convert', args: [inPath, `png:${outPath}`] },
+  ]
+}
+
+/**
+ * 「等比缩放到长边 ≤ maxEdge 并输出 PNG」候选命令（首个成功即采用）。
+ * darwin/linux：sips → magick → convert；win32：magick → PowerShell。
+ */
+export function resizeCandidates(
+  inPath: string,
+  outPath: string,
+  maxEdge: number,
+  platform: NodeJS.Platform = process.platform,
+): ImageToolCommand[] {
+  if (platform === 'win32') {
+    const script = [
+      // 'Stop'：non-terminating error 转为终止性，保证失败时 exit code 非 0
+      "$ErrorActionPreference='Stop'",
+      'Add-Type -AssemblyName System.Drawing',
+      '$img=$null;$bmp=$null;$g=$null',
+      'try {',
+      `$img=[System.Drawing.Image]::FromFile(${psQuote(inPath)})`,
+      // 仅当长边超限时缩小（scale 封顶 1），保持宽高比
+      `$scale=[Math]::Min(1.0,${maxEdge}/[Math]::Max($img.Width,$img.Height))`,
+      '$w=[int][Math]::Max(1,[Math]::Round($img.Width*$scale))',
+      '$h=[int][Math]::Max(1,[Math]::Round($img.Height*$scale))',
+      '$bmp=New-Object System.Drawing.Bitmap($w,$h)',
+      '$g=[System.Drawing.Graphics]::FromImage($bmp)',
+      '$g.DrawImage($img,0,0,$w,$h)',
+      `$bmp.Save(${psQuote(outPath)},[System.Drawing.Imaging.ImageFormat]::Png)`,
+      '} finally {',
+      // 逆序释放；空值检查防止部分初始化失败时 finally 二次抛错掩盖原始异常
+      'if ($g) { $g.Dispose() }',
+      'if ($bmp) { $bmp.Dispose() }',
+      'if ($img) { $img.Dispose() }',
+      '}',
+    ].join(';')
+    return [
+      { bin: 'magick', args: [inPath, '-resize', `${maxEdge}x${maxEdge}>`, outPath] },
+      powershellCommand(script),
+    ]
+  }
+  return [
+    { bin: 'sips', args: ['-Z', String(maxEdge), inPath, '--out', outPath] },
+    { bin: 'magick', args: [inPath, '-resize', `${maxEdge}x${maxEdge}>`, outPath] },
+    { bin: 'convert', args: [inPath, '-resize', `${maxEdge}x${maxEdge}>`, outPath] },
+  ]
+}
+
+/** PNG 文件签名（magic bytes）。 */
+const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+/** 完整 IEND chunk：length 0 + 'IEND' + CRC（内容固定）。 */
+const PNG_IEND_CHUNK = Buffer.from([0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82])
+
+/**
+ * PNG 完整性校验：signature（8 字节）+ 首个 chunk 是长度 13 的 IHDR
+ * （宽高均为正整数）+ 文件末尾 12 字节为完整 IEND chunk。
+ * 防「工具 exit 0 但只写出签名/截断 PNG」被当成可渲染图片。
+ */
+export function isCompletePng(buf: Buffer): boolean {
+  // 最小完整 PNG：8 signature + 25 IHDR chunk（4 length + 4 type + 13 data + 4 CRC）+ 12 IEND
+  if (buf.length < 8 + 25 + 12) return false
+  if (!buf.subarray(0, 8).equals(PNG_SIGNATURE)) return false
+  // 首个 chunk 必须是 length=13 的 IHDR，且宽高均为正整数
+  if (buf.readUInt32BE(8) !== 13) return false
+  if (buf.toString('latin1', 12, 16) !== 'IHDR') return false
+  if (buf.readUInt32BE(16) === 0 || buf.readUInt32BE(20) === 0) return false
+  return buf.subarray(buf.length - PNG_IEND_CHUNK.length).equals(PNG_IEND_CHUNK)
+}
+
+/**
+ * 依序尝试候选命令，首个产出有效 PNG 的候选返回其内容 Buffer；全部失败返回 null。
+ *
+ * 候选级隔离：每个候选把「执行 + 读回 + 校验」作为一体化尝试——先删除
+ * outputPath（不存在则忽略），再 execFile 要求 exit 0，readFile 读回后以
+ * isCompletePng 校验完整性（签名 + IHDR + IEND，截断 PNG 不算数）。
+ * 先删残片是为了避免前一候选留下的非空输出被后一候选
+ * （exit 0 但没写文件）误判为自己的产出。
+ *
+ * 全部失败时若 RIVET_DEBUG 非空，向 stderr 打一行带原因的调试输出
+ * （哪个工具、什么错误），避免静默降级不可观测。
+ *
+ * 注意：硬编码 PNG 校验的前提是两个调用方（toPngCandidates / resizeCandidates）
+ * 的产出都是 PNG；未来若接入其他输出格式需放宽此校验。
+ */
+export async function runImageTool(
+  candidates: ImageToolCommand[],
+  outputPath: string,
+  timeoutMs = 15000,
+): Promise<Buffer | null> {
+  let lastFailure: string | null = null
+  for (const { bin, args } of candidates) {
+    try {
+      await rm(outputPath, { force: true })
+      await execFileAsync(bin, args, { timeout: timeoutMs })
+      const out = await readFile(outputPath)
+      if (isCompletePng(out)) return out
+      // exit 0 但输出缺失/为空/非完整 PNG——尝试下一个候选
+      lastFailure = `${bin}: exit 0 但未产出完整 PNG`
+    } catch (err) {
+      lastFailure = `${bin}: ${err instanceof Error ? err.message : String(err)}`
+    }
+  }
+  if (lastFailure && process.env['RIVET_DEBUG']) {
+    console.error(`[image-tool] 全部 ${candidates.length} 个候选失败，最后一次：${lastFailure}`)
+  }
+  return null
+}
+
+/** 创建本次转换的独立临时目录，并顺手触发惰性清扫（fire-and-forget）。 */
+export async function makeImageTempDir(): Promise<string> {
+  void sweepStaleImageTempDirs().catch(() => { /* best-effort sweep */ })
+  return mkdtemp(join(tmpdir(), IMAGE_TEMP_DIR_PREFIX))
+}
+
+/** 删除转换临时目录；失败静默。 */
+export async function removeImageTempDir(dir: string): Promise<void> {
+  await rm(dir, { recursive: true, force: true }).catch(() => { /* best-effort cleanup */ })
+}
+
+/** 清扫超过 1 小时的残留临时目录（进程中断的兜底回收）。 */
+export async function sweepStaleImageTempDirs(now = Date.now()): Promise<void> {
+  let entries: string[]
+  try {
+    entries = await readdir(tmpdir())
+  } catch {
+    return
+  }
+  for (const entry of entries) {
+    if (!entry.startsWith(IMAGE_TEMP_DIR_PREFIX)) continue
+    const full = join(tmpdir(), entry)
+    try {
+      const st = await stat(full)
+      if (now - st.mtimeMs > STALE_MS) await rm(full, { recursive: true, force: true })
+    } catch {
+      // 单个目录失败不阻塞其余清扫
+    }
+  }
+}

--- a/src/tui/engine/term-image.ts
+++ b/src/tui/engine/term-image.ts
@@ -1,0 +1,194 @@
+/**
+ * 终端内联图片渲染 — 把 data URL 图片准备/编码为 kitty / iTerm2 图形协议序列。
+ *
+ * 协议事实（与 detectImageProtocol 配套）：
+ * - kitty APC：`\x1B_G<control>;<base64 payload>\x1B\\`，仅支持 RGB/RGBA/PNG 载荷
+ *   （f=100 = PNG），非 PNG 需先转码。base64 必须按 ≤4096 字节分块，除末块外
+ *   长度须为 4 的倍数，用 m=1/0 标记。q=2 抑制终端响应，避免污染 stdin 解析。
+ *   同时给 c（列）和 r（行）时终端把图片缩放进该单元格矩形（保持宽高比），
+ *   放置后光标下移 r 行、停在图片右缘列——几何有界、位置确定，这是 live 区
+ *   锚点安全的前提；调用方随后输出 `\r` 回到行首。
+ * - iTerm2 OSC 1337：`\x1B]1337;File=inline=1;width=N;height=M:<base64>\x07`，
+ *   直接支持 png/jpeg/gif/webp，宽高以单元格计，preserveAspectRatio=1 下
+ *   图片适配进宽高超框，绘制后光标停在图片末行右缘；调用方随后输出 `\r\n`
+ *   把光标移到图片下方行首。
+ * 两种序列都会被不支持的终端静默忽略，因此检测失误的最坏结果是图片不显示。
+ *
+ * 安全边界：data URL 载荷在编码前必须通过严格 base64 校验（RFC 4648 字母表 +
+ * 合法 padding + 非空 + 长度 4 对齐），否则载荷里的 BEL/ESC/ST 可以提前终止
+ * OSC/APC 序列并向终端注入任意控制序列。
+ */
+
+import { writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import type { ImageProtocol } from './ansi.js'
+import { makeImageTempDir, removeImageTempDir, runImageTool, toPngCandidates } from './image-tool.js'
+import { MAX_IMAGE_BYTES } from './image-attach.js'
+
+/** kitty 协议单块 base64 上限（协议规定 ≤4096 且除末块外须为 4 的倍数）。 */
+const KITTY_CHUNK = 4096
+
+/**
+ * 估算字符 cell 高宽比（≈2，主流等宽字体）。
+ * 只用于把 kitty 的 r 收紧到图片实际需要行数；估错只会留白或轻微缩放，
+ * 不影响正确性（光标移动行数以我们给出的 r 为准，与图片内容无关）。
+ */
+const CELL_ASPECT = 2
+
+/** 编码白名单：两种协议合计可直接/可转换展示的 MIME。 */
+const SUPPORTED_MIMES = new Set(['image/png', 'image/jpeg', 'image/gif', 'image/webp', 'image/tiff', 'image/bmp'])
+
+const MIME_EXTS: Record<string, string> = {
+  'image/png': '.png',
+  'image/jpeg': '.jpg',
+  'image/gif': '.gif',
+  'image/webp': '.webp',
+  'image/tiff': '.tiff',
+  'image/bmp': '.bmp',
+}
+
+/** RFC 4648 base64（标准字母表 + 合法 padding）。 */
+const BASE64_RE = /^[A-Za-z0-9+/]+={0,2}$/
+
+/**
+ * 解析并校验 data URL → { mime, b64 }。
+ * 拒绝：非 data URL、非白名单 MIME、空载荷、含控制字符/非法字符的载荷、
+ * 非法 padding、长度非 4 对齐、解码后超过 MAX_IMAGE_BYTES。
+ */
+export function parseImageDataUrl(dataUrl: string): { mime: string; b64: string } | null {
+  // MIME 大小写不敏感（RFC 2045），统一转小写后过白名单；字符集不含空格/分号，
+  // 因此 `data:image/png;charset=...;base64,` 这类带参数的形式整体不匹配、直接拒绝——
+  // 只接受裸 `;base64,` 形式，不做参数解析。
+  const m = /^data:([a-zA-Z0-9.+-]+\/[a-zA-Z0-9.+-]+);base64,(.*)$/.exec(dataUrl)
+  if (!m || m[1] === undefined || m[2] === undefined) return null
+  const mime = m[1].toLowerCase()
+  if (!SUPPORTED_MIMES.has(mime)) return null
+  const b64 = m[2]
+  if (b64.length === 0 || b64.length % 4 !== 0 || !BASE64_RE.test(b64)) return null
+  // base64 解码大小 = 3/4 长度减尾部 padding（BASE64_RE 已限定 0/1/2 个 '='）；
+  // 精确计算而非高估，否则解码后恰为上限的合法图片会被误拒。超限直接拒，避免分配大 Buffer
+  const padding = b64.endsWith('==') ? 2 : b64.endsWith('=') ? 1 : 0
+  if ((b64.length * 3) / 4 - padding > MAX_IMAGE_BYTES) return null
+  return { mime, b64 }
+}
+
+/** 已备图片：编码所需的全部材料。kitty 路径保证是 PNG 且带像素尺寸。 */
+export interface PreparedTermImage {
+  b64: string
+  pixelWidth?: number
+  pixelHeight?: number
+}
+
+/** 从 PNG base64 解出 IHDR 宽高（解码前 33 字节即可）；非法 PNG 返回 null。 */
+function pngDimensions(pngB64: string): { width: number; height: number } | null {
+  const head = Buffer.from(pngB64.slice(0, 44), 'base64')
+  if (head.length < 24 || head[0] !== 0x89 || head[1] !== 0x50 || head[2] !== 0x4e || head[3] !== 0x47) return null
+  const width = head.readUInt32BE(16)
+  const height = head.readUInt32BE(20)
+  if (width <= 0 || height <= 0) return null
+  return { width, height }
+}
+
+/**
+ * 非 PNG 转码为 PNG base64（kitty 协议只接受 PNG 容器）。
+ * 走共享图像工具执行器的平台感知候选（见 toPngCandidates），每次转换独立
+ * 临时目录；全部失败返回 null，调用方降级为文本占位。
+ */
+async function ensurePngBase64(mime: string, b64: string): Promise<string | null> {
+  if (mime === 'image/png') return b64
+  const dir = await makeImageTempDir()
+  const inPath = join(dir, `in${MIME_EXTS[mime] ?? '.img'}`)
+  const outPath = join(dir, 'out.png')
+  try {
+    await writeFile(inPath, Buffer.from(b64, 'base64'))
+    // runImageTool 返回校验过的 PNG 内容；全部候选失败返回 null
+    const png = await runImageTool(toPngCandidates(inPath, outPath), outPath)
+    if (!png) return null
+    return png.toString('base64')
+  } finally {
+    await removeImageTempDir(dir)
+  }
+}
+
+/**
+ * data URL → 已备图片（慢速部分：校验 + 必要的 PNG 转码）。
+ * 在 commit 前异步完成；编码（快速、与终端尺寸相关）留到写入时进行，
+ * 使转码期间的终端 resize 不会用过期宽度编码。
+ * 返回 null 表示无法准备，调用方保持文本占位。
+ */
+export async function prepareTermImage(
+  dataUrl: string,
+  protocol: Exclude<ImageProtocol, 'none'>,
+): Promise<PreparedTermImage | null> {
+  const parsed = parseImageDataUrl(dataUrl)
+  if (!parsed) return null
+  // iTerm2 accepts the common web image containers directly. TIFF/BMP are
+  // retained for the vision payload but converted before terminal rendering.
+  if (protocol === 'iterm2' && (parsed.mime === 'image/png' || parsed.mime === 'image/jpeg' || parsed.mime === 'image/gif' || parsed.mime === 'image/webp')) {
+    return { b64: parsed.b64 }
+  }
+  const png = await ensurePngBase64(parsed.mime, parsed.b64)
+  if (!png) return null
+  const dims = pngDimensions(png)
+  return { b64: png, pixelWidth: dims?.width, pixelHeight: dims?.height }
+}
+
+/** iTerm2 OSC 1337 内联图片序列。宽高以单元格计，图片按比例适配进超框。 */
+export function encodeIterm2Image(b64: string, cols: number, maxRows: number): string {
+  return `\x1B]1337;File=inline=1;width=${cols};height=${maxRows};preserveAspectRatio=1:${b64}\x07`
+}
+
+/** kitty APC 图形序列（f=100 PNG，分块直传，c×r 有界单元格矩形）。 */
+export function encodeKittyImage(b64Png: string, cols: number, rows: number): string {
+  const chunks: string[] = []
+  for (let i = 0; i < b64Png.length; i += KITTY_CHUNK) {
+    chunks.push(b64Png.slice(i, i + KITTY_CHUNK))
+  }
+  if (chunks.length === 0) return ''
+  return chunks
+    .map((chunk, i) => {
+      const more = i < chunks.length - 1 ? 1 : 0
+      const control = i === 0 ? `a=T,f=100,q=2,c=${cols},r=${rows},m=${more}` : `q=2,m=${more}`
+      return `\x1B_G${control};${chunk}\x1B\\`
+    })
+    .join('')
+}
+
+/**
+ * 已备图片 → 终端图形序列。cols/maxRows 应在写入当刻取最新终端尺寸。
+ * kitty 用像素尺寸把 r 收紧到实际需要行数（受 maxRows 封顶），
+ * 拿不到尺寸时退回 maxRows（宁可留白，几何必须有界）。
+ * 序列末尾不含换行，由调用方控制光标。
+ */
+export function encodeTermImage(
+  image: PreparedTermImage,
+  protocol: Exclude<ImageProtocol, 'none'>,
+  cols: number,
+  maxRows: number,
+): string | null {
+  const width = Math.max(10, cols)
+  const rowCap = Math.max(1, maxRows)
+  if (protocol === 'iterm2') return encodeIterm2Image(image.b64, width, rowCap)
+  let rows = rowCap
+  if (image.pixelWidth && image.pixelHeight) {
+    rows = Math.min(rowCap, Math.max(1, Math.ceil((image.pixelHeight / image.pixelWidth) * (width / CELL_ASPECT))))
+  }
+  return encodeKittyImage(image.b64, width, rows)
+}
+
+// ── 测试注入 seam ─────────────────────────────────────────────
+
+let prepareOverride: typeof prepareTermImage | null = null
+
+/** 测试钩子：替换 prepare 实现（null 恢复真实实现）。 */
+export function setTermImagePreparer(fn: typeof prepareTermImage | null): void {
+  prepareOverride = fn
+}
+
+/** app 层统一入口：走注入点后的 prepare。 */
+export async function prepareTermImageForCommit(
+  dataUrl: string,
+  protocol: Exclude<ImageProtocol, 'none'>,
+): Promise<PreparedTermImage | null> {
+  return (prepareOverride ?? prepareTermImage)(dataUrl, protocol)
+}


### PR DESCRIPTION
## 变更摘要

CLI 对话中内联展示图片：用户提交的图片附件在支持图形协议的终端（kitty / iTerm2 / Ghostty / WezTerm 等）中直接渲染到用户气泡下方；不支持的终端、非法图片或转换失败时保留原有 📎 文本占位，agent 始终收到原始附件。

## 动机

此前 TUI 中图片附件只能以 `📎 N images attached` 文本占位显示，用户无法确认自己提交的图片内容。终端图形协议（kitty APC / iTerm2 OSC 1337）已为主流终端广泛支持，可以让用户在 scrollback 中直接看到所附图片。

难点不在协议编码本身，而在 TUI 的渲染模型：图片转码是异步的，而 assistant 流式输出、用户连续提交、overlay（alt-screen）切换都在并发发生——图片必须恰好落在所属用户气泡下方、alt-screen 激活期间主屏零写入、慢转码不得乱序。为此把原先分散的主屏写入路径重构为单一有序 commit 队列。

## 主要改动

**`src/tui/engine/term-image.ts`（新增）—— 图形协议编码**
- data URL 严格校验：RFC 4648 字母表 + 合法 padding + 非空 + MIME 白名单 + 精确体积上限（扣 padding 的解码长度），杜绝 BEL/ESC/ST 注入终止序列；
- kitty APC：`f=100`（仅 PNG 载荷）、`q=2` 抑制终端响应保护 stdin、≤4096 分块 `m=1/0`、`c×r` 有界矩形 placement（按 PNG IHDR 宽高比收紧行数）；
- iTerm2 OSC 1337：BEL 终止，宽高以单元格计；
- 收尾光标按协议规范显式处理：kitty placement 后光标已在图片下方 → 补 `\r`；iTerm2 停在图片末行右缘 → 补 `\r\n`。

**`src/tui/engine/image-tool.ts`（新增）—— 图像转码 runner**
- 平台 fallback：macOS `sips` → `magick` → `convert`；win32 排除撞名系统工具的 `convert.exe`，兜底 PowerShell `System.Drawing`（`$ErrorActionPreference='Stop'` + try/finally 逆序 Dispose + 单引号转义）；
- 独立临时目录 + 超 1 小时残留清扫 + 每候选执行前删除旧输出 + `isCompletePng` 完整性校验（签名 + IHDR + 正宽高 + IEND）；
- Windows 无 ImageMagick 时 WebP 明确降级为文本占位（已文档化）。

**`src/tui/engine/app.ts` —— 统一 main commit 队列**
- 所有主屏 commit（用户气泡/图片/assistant stable commit/静态消息）经 `enqueueMainCommit` 统一分配顺序，队列空闲时保留同步 fast path；
- 单实例 pump + await ready 后重查 overlay：alt-screen 激活期间主屏零写入，pump 等待期间 overlay 重激活不污染；
- `atomicCommitNow` 纯同步 cork → clear → write → flush → uncork，原子窗口内无 await；
- 完成 Promise 为 `boolean` 契约（false=写入失败，降级警告但不阻塞 agent 启动），`awaitUserCommit` 统一收口 worker-steer / busy steer / 普通提交 / slash passthrough；
- `exitOverlayCore` 统一 overlay 退出：suppress 窗口包住回放 + deferred 补唯一 live 帧 + `setEscapeImmediate(false)` 复位。

**`src/tui/engine/ansi.ts`** —— 终端能力检测（kitty/iTerm2/Ghostty/WezTerm/tmux/screen 保守降级），`RIVET_IMAGES` 强制覆盖，可注入 `isTTY`。

**`src/tui/engine/image-attach.ts`** —— `detectImageMime` 仅按 magic bytes 识别（删除扩展名 fallback）；`looksLikeImagePath` 增补 `.tiff/.tif/.bmp`。

## 测试

- 新增 `term-image.test.ts`（29 项）：base64 注入负向用例、MIME 边界、10MiB 精确边界（三 padding 参数化）、kitty 分块字节级断言、终端识别矩阵（显式覆盖 isTTY true/false）；
- 新增 `term-image-commit.test.ts`（app 级集成）：慢转码连续提交、overlay 重激活 ALT_SCREEN_ON→OFF 零主屏字节、单 pump 互斥、FIFO 不倒序、写失败降级不阻塞 agent、真实 Enter 链路异常收口、kitty/iTerm2 收尾字节断言；
- 新增 `image-tool.test.ts`：截断 PNG 四种形态识别、PowerShell 脚本构造（Stop/Dispose 顺序/引号转义）；
- 修改 `image-attach.test.ts`（magic 识别行为反转 + 新扩展名）、`orchestration-live.test.ts`（ask 面板提交异步化适配）；
- `npx tsc --noEmit` 通过；`src/tui/engine/__tests__/` 全量 487/489 通过，唯一失败为 `app-clipboard-image.test.ts` 既有环境性 flake（读真实 macOS 剪贴板，本机剪贴板有文本时必败；该文件不在本 PR diff 内，与本改动无关）。

## 检查清单

- [x] 本地 `npm test` 通过（唯一失败为上述既有环境性 flake，非本 PR 引入）
- [x] `npx tsc --noEmit` 无类型错误
- [x] 变更范围最小化，无关改动已排除（仅 `src/tui/`，Open Zone，单一逻辑变更）
- [ ] 文档（README / 用户手册 / CHANGELOG）已同步更新——未更新；内联图片为渐进增强（不支持即回退文本占位），如维护者认为需要在 README/用户手册中补充说明，我可以在本 PR 中追加

## 相关 Issue

无关联 issue。

---

**审查过程说明**：本 PR 经多轮跨模型独立审查（BLOCKED → 修复 → 复审），累计修复 data URL 注入防护、两套提交队列合并、overlay 异步回放竞态、worker steer 顺序、unhandled rejection 收口、PNG 完整性校验、Windows 适配等问题。当前审查结论 PASS_WITH_ADVISORIES，遗留一般级建议（写失败遥测、`pngDimensions` IHDR 头校验、部分测试盲点补全）将在后续 PR 跟进。已阅读并理解 CONTRIBUTING 的 sync-merge 流程（closed + `sync-merged` 标签 = 已合并）。