### PR TITLE
Fix/security and test wsl2

### DIFF
--- a/src/api/__tests__/redact-sensitive-args.test.ts
+++ b/src/api/__tests__/redact-sensitive-args.test.ts
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { redactSensitiveArgs } from '../openai-client.js'
+
+describe('redactSensitiveArgs', () => {
+  it('masks string values of sensitive keys', () => {
+    const input = '{"command":"curl x","password":"hunter2","user":"alice"}'
+    const out = redactSensitiveArgs(input)
+    assert.ok(out.includes('"password":"[REDACTED]"'))
+    assert.ok(!out.includes('hunter2'))
+    assert.ok(out.includes('"user":"alice"'))
+  })
+
+  it('handles common sensitive key shapes case-insensitively', () => {
+    const input = '{"API_KEY":"abc","Authorization":"Bearer t","db_secret": "s3","access-key":"k"}'
+    const out = redactSensitiveArgs(input)
+    assert.ok(!out.includes('abc'))
+    assert.ok(!out.includes('Bearer t'))
+    assert.ok(!out.includes('s3"'))
+    assert.ok(!out.includes('"k"'))
+  })
+
+  it('masks an unterminated trailing value in truncated fragments', () => {
+    const out = redactSensitiveArgs('{"token":"very-long-secret-that-was-cu')
+    assert.ok(!out.includes('very-long-secret'))
+    assert.ok(out.includes('[REDACTED]'))
+  })
+
+  it('leaves non-sensitive content untouched', () => {
+    const input = '{"file_path":"/tmp/a.txt","content":"hello"}'
+    assert.equal(redactSensitiveArgs(input), input)
+  })
+
+  it('handles escaped quotes inside values', () => {
+    const input = '{"password":"a\\"b","next":"keep"}'
+    const out = redactSensitiveArgs(input)
+    assert.ok(!out.includes('a\\"b'))
+    assert.ok(out.includes('"next":"keep"'))
+  })
+})

--- a/src/api/openai-client.ts
+++ b/src/api/openai-client.ts
@@ -199,6 +199,22 @@ export const SLOW_THINKING_PROVIDERS = new Set(['glm', 'mimo', 'deepseek', 'code
  * rather than fill disk.
  */
 const TOOL_STREAM_LOG_MAX_LINES = 2000
+
+/**
+ * Best-effort redaction for tool-argument previews before they reach stderr
+ * debug logs (CWE-532): blank out string values of sensitive-looking JSON keys
+ * (password/token/secret/api_key/...). Works on truncated fragments too — an
+ * unterminated trailing string value is masked as well. Not a guarantee: args
+ * that embed secrets in free-form strings can still slip through; the always-on
+ * disk log therefore carries no argument content at all.
+ */
+export function redactSensitiveArgs(fragment: string): string {
+  return fragment
+    .replace(
+      /("(?:[^"\\]*(?:password|passwd|secret|token|api[_-]?key|apikey|authorization|credential|private[_-]?key|access[_-]?key)[^"\\]*)"\s*:\s*")((?:[^"\\]|\\.)*)("?)/gi,
+      '$1[REDACTED]$3',
+    )
+}
 // Thinking-stall timeout 现由 config.thinkingStallTimeoutMs 控制（默认禁用，见
 // resetIdleTimer 与 OpenAIClientConfig 注释）。旧的模块级常量已移除——它恒等于
 // SLOW_READ_TIMEOUT_MS（实为禁用），且配套错误文案硬编码"90s"与实际值不符。
@@ -972,7 +988,7 @@ export class OpenAIClient implements StreamClient {
           this.logToolStreamEvent({
             phase: 'reattach-by-id', openBuffers: this.toolCallBuffer.size,
             id: tc.id, name: buf.function.name,
-            argsLen: tc.function?.arguments?.length, argsPreview: tc.function?.arguments?.slice(0, 80),
+            argsLen: tc.function?.arguments?.length,
           })
           return idx
         }
@@ -985,7 +1001,7 @@ export class OpenAIClient implements StreamClient {
       const idx = this.toolCallBuffer.keys().next().value!
       this.logToolStreamEvent({
         phase: 'reattach-sole', openBuffers: 1,
-        argsLen: tc.function?.arguments?.length, argsPreview: tc.function?.arguments?.slice(0, 80),
+        argsLen: tc.function?.arguments?.length,
       })
       return idx
     }
@@ -998,7 +1014,7 @@ export class OpenAIClient implements StreamClient {
     // is visible without RIVET_DEBUG.
     this.logToolStreamEvent({
       phase: 'drop-ambiguous', openBuffers: this.toolCallBuffer.size,
-      argsLen: tc.function?.arguments?.length, argsPreview: tc.function?.arguments?.slice(0, 80),
+      argsLen: tc.function?.arguments?.length,
     })
     return null
   }
@@ -1165,7 +1181,7 @@ export class OpenAIClient implements StreamClient {
         this.logToolStreamEvent({
           phase: 'final-flush-empty', openBuffers: this.toolCallBuffer.size,
           id: buf.id, name: buf.function.name,
-          argsLen: buf.function.arguments.length, argsPreview: buf.function.arguments.slice(0, 120),
+          argsLen: buf.function.arguments.length,
         })
         callbacks.onContentBlock?.({ type: 'tool_use', id: buf.id, name: buf.function.name, input: {}, argsTruncated: true })
         this.toolCallBuffer.delete(idx)
@@ -1211,7 +1227,7 @@ export class OpenAIClient implements StreamClient {
     if (process.env.RIVET_DEBUG_TOOL_STREAM !== '1') return
     debugLog(
       `[tool-stream] phase=${phase} idx=${idx} id=${buf.id ?? '?'} name=${buf.function.name ?? '?'}` +
-      ` argsLen=${buf.function.arguments.length} args=${JSON.stringify(buf.function.arguments.slice(0, 200))}`,
+      ` argsLen=${buf.function.arguments.length} args=${JSON.stringify(redactSensitiveArgs(buf.function.arguments.slice(0, 200)))}`,
     )
   }
 
@@ -1221,6 +1237,11 @@ export class OpenAIClient implements StreamClient {
    * cross-tool argument-pollution class of bug leaves a trace without anyone
    * having to enable RIVET_DEBUG up front. Best-effort: any IO failure disables
    * further logging for this client (sets path to null), never throws.
+   *
+   * Security: events carry argsLen only, NEVER raw argument content — tool
+   * arguments can embed secrets (passwords/tokens passed to Bash etc.) and an
+   * always-on disk log must not capture them (CWE-532). Content previews exist
+   * only in the RIVET_DEBUG_TOOL_STREAM stderr path, redacted.
    *
    * Capped at TOOL_STREAM_LOG_MAX_LINES per process — once hit, logging stops to
    * bound disk on long sessions. The cap is generous: these events are rare
@@ -1233,7 +1254,6 @@ export class OpenAIClient implements StreamClient {
     id?: string
     name?: string
     argsLen?: number
-    argsPreview?: string
   }): void {
     if (this.toolStreamLogPath === null) return
     if (this.toolStreamLogLines >= TOOL_STREAM_LOG_MAX_LINES) return
@@ -1276,7 +1296,7 @@ export class OpenAIClient implements StreamClient {
   ): void {
     const msg =
       `[tool-arg-parse-failure] id=${buf.id ?? '?'} name=${buf.function.name ?? '?'}` +
-      ` argsLen=${buf.function.arguments.length} args=${JSON.stringify(buf.function.arguments.slice(0, 300))}`
+      ` argsLen=${buf.function.arguments.length} args=${JSON.stringify(redactSensitiveArgs(buf.function.arguments.slice(0, 300)))}`
     debugLog(msg)
   }
 

--- a/src/tools/__tests__/sandbox-diagnose.test.ts
+++ b/src/tools/__tests__/sandbox-diagnose.test.ts
@@ -144,8 +144,12 @@ describe('recordSandboxLearn', () => {
   })
 
   it('never throws when the target directory is unwritable', () => {
+    // Path under an existing FILE: mkdir fails ENOTDIR everywhere, fast.
+    // NOT a /proc/... path — on WSL2, mkdir on procfs returns ENOENT, and
+    // Node's recursive mkdirSync reads that as "parent missing", retrying the
+    // same mkdir forever (infinite loop, ~100% CPU). ENOTDIR terminates it.
     assert.doesNotThrow(() => recordSandboxLearn({
       cwd: '/w', command: 'x', backend: 'none', deniedPaths: [], retried: false,
-    }, '/proc/nonexistent-rivet-learn'))
+    }, '/dev/null/nonexistent-rivet-learn'))
   })
 })


### PR DESCRIPTION
    ## 变更摘要

    修复工具参数明文落盘的日志泄漏（CWE-532），并修复 sandbox-diagnose 测试在 WSL2 下的死循环挂死。

    ## 动机

    1. **日志泄漏**：`logToolStreamEvent` 的 `argsPreview` 字段会把工具调用的原始参数片段写入 tool-stream 日志文件，若参数中含 API key、密码、token 等敏感内容会明文落盘（CWE-532）。stderr
    调试输出的参数预览同样未脱敏。
    2. **测试挂死**：`sandbox-diagnose.test.ts` 用 `/proc/nonexistent-rivet-learn` 作为"不可写目录"探针。在 WSL2 上对 procfs 执行 mkdir 返回 ENOENT（而非 EPERM/EACCES），Node 的 recursive `mkdirSync` 将 ENOENT
     解读为"父目录缺失"并对同一路径无限重试，造成纯 CPU 空转（实测全量测试卡死 54 分钟、子进程 92% CPU）。macOS/Linux 原生不触发，但 WSL2 开发者必中。

    ## 主要改动

    - `src/api/openai-client.ts`
      - 移除 `logToolStreamEvent` 事件类型及 4 处调用点的 `argsPreview` 字段，仅保留 `argsLen`（长度信息不含内容）；docstring 明确"事件只携带 argsLen，绝不携带原始参数内容"
      - 新增 `redactSensitiveArgs()`：对 password/secret/token/api_key/authorization/credential/private_key/access_key 等键的值做 `[REDACTED]` 掩码
      - `maybeTraceToolStream` 与 `warnToolArgParseFailure` 的参数预览经 `redactSensitiveArgs` 脱敏后再输出
    - `src/api/__tests__/redact-sensitive-args.test.ts`（新增）：5 个用例——敏感键掩码、大小写变体、未闭合截断值、非敏感内容不动、转义引号
    - `src/tools/__tests__/sandbox-diagnose.test.ts`：探针路径改为 `/dev/null/nonexistent-rivet-learn`（父路径为已存在文件，mkdir 立即返回 ENOTDIR，Linux/macOS/root 下均快速失败），注释说明 WSL2
    陷阱；测试意图不变

    ## 测试

    - 新增脱敏单测 5/5 通过；sandbox-diagnose 全套 18/18 通过（修复前该文件在 WSL2 无法在有限时间内完成）
    - 两个修复在基于最新 `upstream/main`（v3.0.0）的分支上复测 23/23 通过
    - pre-push typecheck（`npx tsc --noEmit`）clean

    ## 检查清单

    - [x] 本地 `npm test` 通过（相关测试文件全绿；说明：全量套件此前在 WSL2 因本 PR 修复的挂死无法完成，修复后相关模块已单独验证）
    - [x] `npx tsc --noEmit` 无类型错误
    - [x] 变更范围最小化，无关改动已排除
    - [ ] 文档（README / 用户手册 / CHANGELOG）已同步更新（纯修复，未涉及用户可见行为变更）
