### PR TITLE
fix(tui): isolate clipboard fallback tests

### DIFF
--- a/src/tui/engine/__tests__/app-clipboard-image.test.ts
+++ b/src/tui/engine/__tests__/app-clipboard-image.test.ts
@@ -75,8 +75,11 @@ test('RED #2: Ctrl+V onAnyKey → handleCtrlV → inputLine.addImage (end-to-end
 // ── RED #3: 剪贴板里没图 → fallback 到文本 Ctrl+V ─────────────────────
 test('RED #3: Ctrl+V with no image in clipboard → text fallback', async () => {
   const { app, stdin } = makeApp()
+  setClipboardReader({
+    async readImage() { return null },
+    async readText() { return 'clipboard text' },
+  })
   app.start()
-  setClipboardReader({ async readImage() { return null } })
   ;(app as any).lastInputFocusAt = Date.now() - 2_000
 
   stdin.dataHandler!('\x16')
@@ -85,11 +88,9 @@ test('RED #3: Ctrl+V with no image in clipboard → text fallback', async () => 
   setClipboardReader(null)
 
   // reader 报 null → handleCtrlV 调 readTextFromClipboard 走文本路径
-  // readTextFromClipboard 在 mock stdin 不可用 → 整体 silently no-op
-  // 接线断言：images 不增，value 不被填
+  // 接线断言：images 不增，value 插入 mock 文本
   assert.equal((app as any).getInputImagesCount(), 0, 'no image → no addImage call')
-  // 文本 path 调 insertText 但 mock env 无 clipboard 工具 → null → value 仍空
-  assert.equal(app.getInputValue(), '', 'no text in clipboard → value stays empty')
+  assert.equal(app.getInputValue(), 'clipboard text', 'no image → text fallback is inserted')
 })
 
 // ── RED #4: 焦点防抖 1s 内的 Ctrl+V 跳过剪贴板读图 ───────────────────

--- a/src/tui/engine/__tests__/clipboard-image.test.ts
+++ b/src/tui/engine/__tests__/clipboard-image.test.ts
@@ -81,6 +81,19 @@ test('RED #3: readImageFromClipboard returns null when reader throws → no cras
   setClipboardReader(null)
 })
 
+test('injected clipboard reader isolates the plain-text fallback from the host clipboard', async () => {
+  const mod = await import('../clipboard-image.js')
+  const { setClipboardReader, readTextFromClipboard } = mod
+
+  setClipboardReader({
+    async readImage() { return null },
+    async readText() { return 'injected text' },
+  })
+
+  assert.equal(await readTextFromClipboard(), 'injected text')
+  setClipboardReader(null)
+})
+
 test('RED #4: tryShellClipboard returns null when no shell tools available', async () => {
   const mod = await import('../clipboard-image.js')
   const { tryShellClipboard } = mod

--- a/src/tui/engine/clipboard-image.ts
+++ b/src/tui/engine/clipboard-image.ts
@@ -32,6 +32,8 @@ export interface ClipboardImage {
 
 export interface ClipboardReader {
   readImage(): Promise<ClipboardImage | null>
+  /** Optional text fallback; omission means the injected clipboard has no text. */
+  readText?(): Promise<string | null>
 }
 
 export interface ShellClipboardOpts {
@@ -75,6 +77,14 @@ export async function readImageFromClipboard(): Promise<ClipboardImage | null> {
  * Used as fallback when Ctrl+V finds no image in clipboard.
  */
 export async function readTextFromClipboard(): Promise<string | null> {
+  if (_reader) {
+    try {
+      return await _reader.readText?.() ?? null
+    } catch {
+      return null
+    }
+  }
+
   const pf = process.platform
   try {
     if (pf === 'darwin') {


### PR DESCRIPTION
## 变更摘要

隔离 Ctrl+V 文本回退测试与开发者机器的真实系统剪贴板，避免本地剪贴板有文本时产生不稳定失败。

## 动机

全新 clone 在 macOS 上执行 `npm test` 时，`app-clipboard-image.test.ts` 的 “Ctrl+V with no image” 用例会调用真实 `pbpaste`。如果开发者剪贴板中恰好有文本，测试期望空输入但实际插入该文本，导致失败。

复现时剪贴板包含一个 GitHub URL，断言得到：

```text
actual:   https://github.com/maoqiu77/Tianshu-Tui
expected: ''
```

这使测试结果依赖宿主机状态，也无法真正断言图片为空后的文本回退接线。

## 主要改动

- 为现有 `ClipboardReader` 测试注入接口增加可选 `readText()`。
- 注入 reader 时，`readTextFromClipboard()` 使用注入结果，不再读取宿主机剪贴板。
- Ctrl+V 集成测试注入固定文本，并断言无图片时文本确实插入输入框。
- 增加文本剪贴板注入的单元回归测试。

## 测试

- [x] `npx tsc --noEmit`
- [x] `npm test -- src/tui/`：2248 tests，0 failures，1 todo
- [x] 完整 `npm test` 的 TUI 批次：3231 tests，0 failures，1 todo；修复前同批次为 1 failure
- [ ] 完整 `npm test` 全绿：公开仓库基线仍有与本 PR 无关的失败，例如缺失 `desktop/`、`.claude/skills/writing-plans/` 和部分 `.rivet/` 文件；上游 `main` 当前 CI 也为 failure

## 检查清单

- [ ] 本地 `npm test` 通过
- [x] `npx tsc --noEmit` 无类型错误
- [x] 变更范围最小化，无关改动已排除
- [x] 文档无需更新：用户可见行为不变，仅增强测试注入与回归覆盖

## 相关 Issue

无。
