### PR TITLE
修复：加固运行时正确性与边界场景

### DIFF
--- a/src/config/__tests__/config-cli.test.ts
+++ b/src/config/__tests__/config-cli.test.ts
@@ -4,6 +4,7 @@ import { mkdtempSync, rmSync, realpathSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { loadConfig, runConfigCLI, type ConfigCliIO } from '../manager.js'
+import { resolveTransportType } from '../../mcp/transport-factory.js'
 
 function makeIo() {
   const stdout: string[] = []
@@ -98,6 +99,16 @@ describe('runConfigCLI provider commands', () => {
     await runConfigCLI(['setup', 'deepseek', '--key-env', '--default'], io)
     assert.deepEqual(exits, [1])
     assert.match(stderr.join('\n'), /--key-env requires a value/)
+  })
+
+  it('configures add-sse servers to use the legacy SSE transport', async () => {
+    const { io } = makeIo()
+    await runConfigCLI(['mcp', 'add-sse', 'legacy', 'http://localhost:3001/sse'], io)
+
+    const server = loadConfig().mcp.servers['legacy']
+    assert.ok(server)
+    assert.equal(server.transportHint, 'sse')
+    assert.equal(resolveTransportType(server), 'sse-legacy')
   })
 })
 

--- a/src/config/manager.ts
+++ b/src/config/manager.ts
@@ -1972,7 +1972,7 @@ export async function runConfigCLI(args: string[], io: ConfigCliIO = {}): Promis
             return
           }
           const cfg = loadConfig()
-          cfg.mcp.servers[id] = { url }
+          cfg.mcp.servers[id] = { url, transportHint: 'sse' }
           saveConfig(cfg)
           cliOut(io, formatSuccess(`MCP server "${id}" added (sse: ${url}). Restart Rivet to connect.`, fmtOpts))
         } else if (subcmd === 'remove') {

--- a/src/server/__tests__/mcp-hot-add.test.ts
+++ b/src/server/__tests__/mcp-hot-add.test.ts
@@ -65,6 +65,46 @@ test('POST /mcp/servers persists even when manager is null (startup race)', asyn
   })
 })
 
+test('POST /mcp/servers preserves transport, auth, and tool policy config', async () => {
+  await withTempHome(async () => {
+    const routes = buildMcpRoutes({
+      getMcpManager: () => null,
+      apiToken: 'tok',
+    })
+    const res = await routes['POST /mcp/servers']!(
+      {
+        serverId: 'remote',
+        url: 'https://mcp.example.com/sse',
+        transportHint: 'sse',
+        auth: { type: 'oauth', provider: 'github', scopes: ['repo'] },
+        policy: {
+          tools: {
+            search: { capability: 'read' },
+            mutate: { capability: 'write', requireApproval: true },
+          },
+        },
+      },
+      undefined,
+      { authorization: 'Bearer tok' },
+      undefined,
+    )
+    assert.equal(res.status, 200, JSON.stringify(res.body))
+
+    const { loadConfig } = await import('../../config/manager.js')
+    assert.deepEqual(loadConfig().mcp.servers['remote'], {
+      url: 'https://mcp.example.com/sse',
+      transportHint: 'sse',
+      auth: { type: 'oauth', provider: 'github', scopes: ['repo'] },
+      policy: {
+        tools: {
+          search: { capability: 'read' },
+          mutate: { capability: 'write', requireApproval: true },
+        },
+      },
+    })
+  })
+})
+
 test('POST /mcp/servers hot-connects and notifies onToolsReady when manager live', async () => {
   await withTempHome(async () => {
     const mgr = new McpManager({ enabled: true, servers: {} })

--- a/src/server/__tests__/task-registry.test.ts
+++ b/src/server/__tests__/task-registry.test.ts
@@ -368,6 +368,43 @@ describe('TaskRegistry', () => {
     }
   })
 
+  it('reschedules a persisted pending task after process restart', async () => {
+    const pending = makeRecord('task_pending', undefined, 'pending', 'api', 'restart-key')
+    await store.save(pending)
+
+    let executeCalls = 0
+    let markRuntimeReleased!: () => void
+    const runtimeReleased = new Promise<void>((resolve) => { markRuntimeReleased = resolve })
+    const restartedRegistry = new TaskRegistry({
+      taskStore: new JsonTaskStore(TEST_DIR),
+      runtimePool: {
+        size: 0,
+        acquire: async () => ({
+          execute: async () => {
+            executeCalls++
+            return { summary: 'recovered', changedFiles: [] }
+          },
+          release: markRuntimeReleased,
+        }),
+      },
+    })
+
+    try {
+      const returned = await restartedRegistry.createTask({
+        prompt: pending.prompt,
+        source: pending.source,
+        callerId: pending.callerId,
+        idempotencyKey: pending.idempotencyKey,
+      })
+      assert.equal(returned.id, pending.id)
+      await runtimeReleased
+      assert.equal(executeCalls, 1)
+      assert.equal((await restartedRegistry.getTask(pending.id))?.status, 'completed')
+    } finally {
+      restartedRegistry.dispose()
+    }
+  })
+
   it('concurrent createTask with force creates two tasks', async () => {
     const [t1, t2] = await Promise.all([
       registry.createTask({ prompt: 'concurrent', source: 'api', callerId: 'u1' }),
@@ -442,19 +479,33 @@ describe('TaskRegistry', () => {
     assert.equal(apiTasks.length, 2)
   })
 
-  it('recoverStaleTasks marks running tasks as timed_out', async () => {
+  it('recoverStaleTasks marks running tasks as timed_out and resumes pending tasks', async () => {
     const t1 = await registry.createTask({ prompt: 'a', source: 'cron' })
     const t2 = await registry.createTask({ prompt: 'b', source: 'api' })
     await registry.transition(t1.id, 'running')
     await registry.transition(t2.id, 'running')
 
+    const pending = await registry.createTask({ prompt: 'pending', source: 'api' })
+    let markRuntimeReleased!: () => void
+    const runtimeReleased = new Promise<void>((resolve) => { markRuntimeReleased = resolve })
+    registry.setRuntimePool({
+      size: 0,
+      acquire: async () => ({
+        execute: async () => ({ summary: 'resumed', changedFiles: [] }),
+        release: markRuntimeReleased,
+      }),
+    })
+
     const recovered = await registry.recoverStaleTasks()
     assert.equal(recovered.length, 2)
+
+    await runtimeReleased
 
     const check1 = await registry.getTask(t1.id)
     const check2 = await registry.getTask(t2.id)
     assert.equal(check1!.status, 'timed_out')
     assert.equal(check2!.status, 'timed_out')
+    assert.equal((await registry.getTask(pending.id))?.status, 'completed')
   })
 
   it('getActiveTasks returns only pending and running', async () => {

--- a/src/server/__tests__/task-registry.test.ts
+++ b/src/server/__tests__/task-registry.test.ts
@@ -331,6 +331,43 @@ describe('TaskRegistry', () => {
     assert.equal(all.length, 1)
   })
 
+  it('deduplicated createTask schedules the existing task only once', async () => {
+    let releaseExecution!: () => void
+    const executionBlocked = new Promise<void>((resolve) => { releaseExecution = resolve })
+    let markRuntimeReleased!: () => void
+    const runtimeReleased = new Promise<void>((resolve) => { markRuntimeReleased = resolve })
+    let executeCalls = 0
+    const runtimePool = {
+      size: 0,
+      acquire: async () => ({
+        execute: async () => {
+          executeCalls++
+          await executionBlocked
+          return { summary: 'done', changedFiles: [] }
+        },
+        release: markRuntimeReleased,
+      }),
+    }
+    const registryWithRuntime = new TaskRegistry({ taskStore: store, runtimePool })
+
+    try {
+      const first = await registryWithRuntime.createTask({
+        prompt: 'run once', source: 'api', callerId: 'u1', idempotencyKey: 'same-key',
+      })
+      const duplicate = await registryWithRuntime.createTask({
+        prompt: 'run once', source: 'api', callerId: 'u1', idempotencyKey: 'same-key',
+      })
+
+      assert.equal(duplicate.id, first.id)
+      await new Promise<void>((resolve) => setImmediate(resolve))
+      assert.equal(executeCalls, 1, 'returning an existing task must not start it again')
+    } finally {
+      releaseExecution()
+      if (executeCalls > 0) await runtimeReleased
+      registryWithRuntime.dispose()
+    }
+  })
+
   it('concurrent createTask with force creates two tasks', async () => {
     const [t1, t2] = await Promise.all([
       registry.createTask({ prompt: 'concurrent', source: 'api', callerId: 'u1' }),

--- a/src/server/mcp-api.ts
+++ b/src/server/mcp-api.ts
@@ -119,6 +119,9 @@ export function buildMcpRoutes(
       if (input.env && typeof input.env === 'object') configInput.env = input.env as Record<string, string>
       if (input.headers && typeof input.headers === 'object') configInput.headers = input.headers as Record<string, string>
       if (typeof input.cwd === 'string') configInput.cwd = input.cwd
+      if (typeof input.transportHint === 'string') configInput.transportHint = input.transportHint
+      if (input.auth && typeof input.auth === 'object') configInput.auth = input.auth
+      if (input.policy && typeof input.policy === 'object') configInput.policy = input.policy
 
       const parsed = mcpServerConfigSchema.safeParse(configInput)
       if (!parsed.success) {

--- a/src/server/task-registry.ts
+++ b/src/server/task-registry.ts
@@ -131,11 +131,11 @@ export class TaskRegistry {
     const force = input.force ?? false
 
     // 整块串行化：find → build → save 在同一个 per-key 锁内完成
-    const record = await this.serialized(idempotencyKey, async () => {
+    const { record, created } = await this.serialized(idempotencyKey, async () => {
       // 去重检查（force 跳过）
       if (!force) {
         const existing = await this.store.findActiveByIdempotencyKey(idempotencyKey)
-        if (existing) return existing
+        if (existing) return { record: existing, created: false }
       }
 
       const timeoutMs = input.timeoutMs ??
@@ -161,11 +161,12 @@ export class TaskRegistry {
 
       await this.store.save(r)
       this.emit({ taskId: r.id, type: 'created', timestamp: r.createdAt })
-      return r
+      return { record: r, created: true }
     })
 
-    // 如有 runtime 池，立即调度
-    if (this.runtimePool) {
+    // Deduplicated callers share the original execution. Scheduling an existing
+    // record again would run the same task twice and duplicate its side effects.
+    if (created && this.runtimePool) {
       this.scheduleExecution(record).catch(err => {
         this.transition(record.id, 'failed', { error: String(err) }).catch(transitionErr => {
           serverLogger.error('Failed to mark task execution failure', {

--- a/src/server/task-registry.ts
+++ b/src/server/task-registry.ts
@@ -110,6 +110,9 @@ export class TaskRegistry {
   /** 待触发的重试 timer（进程关闭时清理，避免泄漏）。 */
   private retryTimers = new Set<ReturnType<typeof setTimeout>>()
 
+  /** 本进程已认领执行的 pending 任务，防止幂等请求重复调度。 */
+  private executionClaims = new Set<string>()
+
   /** 每任务串行化锁：防止 transition/createTask 并发竞态 */
   private idLocks = new Map<string, Promise<void>>()
 
@@ -131,11 +134,11 @@ export class TaskRegistry {
     const force = input.force ?? false
 
     // 整块串行化：find → build → save 在同一个 per-key 锁内完成
-    const { record, created } = await this.serialized(idempotencyKey, async () => {
+    const record = await this.serialized(idempotencyKey, async () => {
       // 去重检查（force 跳过）
       if (!force) {
         const existing = await this.store.findActiveByIdempotencyKey(idempotencyKey)
-        if (existing) return { record: existing, created: false }
+        if (existing) return existing
       }
 
       const timeoutMs = input.timeoutMs ??
@@ -161,22 +164,12 @@ export class TaskRegistry {
 
       await this.store.save(r)
       this.emit({ taskId: r.id, type: 'created', timestamp: r.createdAt })
-      return { record: r, created: true }
+      return r
     })
 
-    // Deduplicated callers share the original execution. Scheduling an existing
-    // record again would run the same task twice and duplicate its side effects.
-    if (created && this.runtimePool) {
-      this.scheduleExecution(record).catch(err => {
-        this.transition(record.id, 'failed', { error: String(err) }).catch(transitionErr => {
-          serverLogger.error('Failed to mark task execution failure', {
-            taskId: record.id,
-            executionError: errorContext(err),
-            transitionError: errorContext(transitionErr),
-          })
-        })
-      })
-    }
+    // 同一进程内，重复请求共享首次调度；新进程则可重新认领崩溃前尚未启动的
+    // pending 记录，避免只按“是否本次创建”判断而让任务永久滞留。
+    if (this.claimPendingExecution(record)) this.dispatchExecution(record)
 
     return record
   }
@@ -333,14 +326,21 @@ export class TaskRegistry {
     return this.store.list({ status: ['pending', 'running'] })
   }
 
-  /** 获取运行时超时的 running 任务，用于恢复 */
+  /** 恢复中断的任务：running 记为超时，尚未启动的 pending 重新调度。 */
   async recoverStaleTasks(): Promise<TaskRecord[]> {
-    // 进程重启后，所有 running 任务应标记为 timed_out
+    // 进程重启后，所有 running 任务应标记为 timed_out。
     const running = await this.store.list({ status: 'running' })
     const results: TaskRecord[] = []
     for (const r of running) {
       const t = await this.transition(r.id, 'timed_out')
       if (t) results.push(t)
+    }
+
+    // save 成功但调度前崩溃会留下 pending。恢复只在 CronWiring 获得进程锁后
+    // 调用，executionClaims 继续防止同一 registry 内的重复调度。
+    const pending = await this.store.list({ status: 'pending' })
+    for (const r of pending) {
+      if (this.claimPendingExecution(r)) this.dispatchExecution(r)
     }
     return results
   }
@@ -388,6 +388,32 @@ export class TaskRegistry {
       this.timeoutTimers.delete(id)
     }
     this.abortControllers.delete(id)
+  }
+
+  /** 仅认领本进程尚未调度的 pending 任务。 */
+  private claimPendingExecution(record: TaskRecord): boolean {
+    if (!this.runtimePool || record.status !== 'pending' || this.executionClaims.has(record.id)) return false
+    this.executionClaims.add(record.id)
+    return true
+  }
+
+  /** 启动已认领任务，并在整个执行/失败落库结束后释放认领。 */
+  private dispatchExecution(record: TaskRecord): void {
+    void this.scheduleExecution(record)
+      .catch(async err => {
+        try {
+          await this.transition(record.id, 'failed', { error: String(err) })
+        } catch (transitionErr) {
+          serverLogger.error('Failed to mark task execution failure', {
+            taskId: record.id,
+            executionError: errorContext(err),
+            transitionError: errorContext(transitionErr),
+          })
+        }
+      })
+      .finally(() => {
+        this.executionClaims.delete(record.id)
+      })
   }
 
   /**

--- a/src/tools/net/__tests__/http-fetch.test.ts
+++ b/src/tools/net/__tests__/http-fetch.test.ts
@@ -73,6 +73,21 @@ describe('httpFetchGuarded', () => {
     )
   })
 
+  it('rejects an IPv4-mapped loopback target before fetching', async () => {
+    let fetched = false
+    await assert.rejects(
+      () => httpFetchGuarded('http://mapped.example.test/private', {
+        lookup: async () => ({ address: '::ffff:127.0.0.1', family: 6 }),
+        fetch: mockFetch(async () => {
+          fetched = true
+          return new Response('should not run')
+        }),
+      }),
+      (err: unknown) => err instanceof SSRFError && err.address === '::ffff:127.0.0.1',
+    )
+    assert.equal(fetched, false)
+  })
+
   it('rejects unsupported protocol', async () => {
     await assert.rejects(
       async () => httpFetchGuarded('file:///etc/passwd', { lookup: publicLookup() }),

--- a/src/tools/net/__tests__/ssrf.test.ts
+++ b/src/tools/net/__tests__/ssrf.test.ts
@@ -32,6 +32,18 @@ describe('isPrivateIP', () => {
     assert.equal(isPrivateIP('::1'), true)
   })
 
+  it('detects IPv4-mapped private IPv6 addresses', () => {
+    assert.equal(isPrivateIP('::ffff:127.0.0.1'), true)
+    assert.equal(isPrivateIP('::ffff:10.0.0.1'), true)
+    assert.equal(isPrivateIP('::ffff:a9fe:a9fe'), true)
+  })
+
+  it('detects reserved IPv6 ranges', () => {
+    assert.equal(isPrivateIP('::'), true)
+    assert.equal(isPrivateIP('fe90::1'), true)
+    assert.equal(isPrivateIP('ff02::1'), true)
+  })
+
   it('allows public IPv6', () => {
     assert.equal(isPrivateIP('2001:4860:4860::8888'), false)
   })

--- a/src/tools/net/ssrf.ts
+++ b/src/tools/net/ssrf.ts
@@ -1,23 +1,41 @@
-import { isIP } from 'node:net'
+import { BlockList, isIP } from 'node:net'
+
+const RESERVED_IPS = new BlockList()
+
+for (const [network, prefix] of [
+  ['0.0.0.0', 8],
+  ['10.0.0.0', 8],
+  ['100.64.0.0', 10],
+  ['127.0.0.0', 8],
+  ['169.254.0.0', 16],
+  ['172.16.0.0', 12],
+  ['192.0.0.0', 24],
+  ['192.0.2.0', 24],
+  ['192.168.0.0', 16],
+  ['198.18.0.0', 15],
+  ['198.51.100.0', 24],
+  ['203.0.113.0', 24],
+  ['224.0.0.0', 4],
+  ['240.0.0.0', 4],
+] as const) {
+  RESERVED_IPS.addSubnet(network, prefix, 'ipv4')
+}
+
+for (const [network, prefix] of [
+  ['::', 128],
+  ['::1', 128],
+  ['fc00::', 7],
+  ['fe80::', 10],
+  ['ff00::', 8],
+  ['2001:db8::', 32],
+] as const) {
+  RESERVED_IPS.addSubnet(network, prefix, 'ipv6')
+}
 
 export function isPrivateIP(ip: string): boolean {
-  if (isIP(ip) === 4) {
-    const octets = ip.split('.').map(Number)
-    if (octets[0] === 10) return true
-    if (octets[0] === 172 && octets[1]! >= 16 && octets[1]! <= 31) return true
-    if (octets[0] === 192 && octets[1] === 168) return true
-    if (octets[0] === 127) return true
-    if (octets[0] === 0) return true
-    if (octets[0] === 169 && octets[1] === 254) return true
-    return false
-  }
-  if (isIP(ip) === 6) {
-    const lower = ip.toLowerCase()
-    if (lower === '::1') return true
-    if (lower.startsWith('fc') || lower.startsWith('fd')) return true
-    if (lower.startsWith('fe80')) return true
-    return false
-  }
+  const family = isIP(ip)
+  if (family === 4) return RESERVED_IPS.check(ip, 'ipv4')
+  if (family === 6) return RESERVED_IPS.check(ip, 'ipv6')
   return false
 }
 

--- a/src/tui/__tests__/history-async.test.ts
+++ b/src/tui/__tests__/history-async.test.ts
@@ -1,0 +1,34 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+test('appendHistoryAsync serializes concurrent appends and recovers after a failed write', async () => {
+  const home = mkdtempSync(join(tmpdir(), 'rivet-history-'))
+  const previousHome = process.env.RIVET_HOME
+  process.env.RIVET_HOME = home
+
+  try {
+    const { appendHistoryAsync } = await import('../history.js')
+    const historyFile = join(home, 'history.json')
+
+    await Promise.all([
+      appendHistoryAsync('first'),
+      appendHistoryAsync('second'),
+    ])
+    assert.deepEqual(JSON.parse(readFileSync(historyFile, 'utf8')), ['second', 'first'])
+
+    rmSync(historyFile)
+    mkdirSync(historyFile)
+    await assert.rejects(appendHistoryAsync('blocked'))
+    rmSync(historyFile, { recursive: true })
+
+    await appendHistoryAsync('recovered')
+    assert.deepEqual(JSON.parse(readFileSync(historyFile, 'utf8')), ['recovered'])
+  } finally {
+    if (previousHome === undefined) delete process.env.RIVET_HOME
+    else process.env.RIVET_HOME = previousHome
+    rmSync(home, { recursive: true, force: true })
+  }
+})

--- a/src/tui/engine/__tests__/image-attach.test.ts
+++ b/src/tui/engine/__tests__/image-attach.test.ts
@@ -64,3 +64,33 @@ test('loadImageAttachment rejects unsupported formats', async () => {
     rmSync(dir, { recursive: true, force: true })
   }
 })
+
+test('loadImageAttachment advertises resized JPEG bytes as PNG', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'rivet-img-'))
+  const path = join(dir, 'large.jpg')
+  const oversizedJpeg = Buffer.concat([
+    Buffer.from([0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46]),
+    Buffer.alloc(192),
+  ])
+  writeFileSync(path, oversizedJpeg)
+  let resizeCalls = 0
+  try {
+    const attachment = await loadImageAttachment(path, {
+      maxBytes: 100,
+      maxEdge: 32,
+      resizeImage: async () => {
+        resizeCalls++
+        return Buffer.from(PNG_B64, 'base64')
+      },
+    })
+    const encoded = attachment.dataUrl.split(',')[1]!
+    const payload = Buffer.from(encoded, 'base64')
+
+    assert.equal(resizeCalls, 1)
+    assert.equal(attachment.mime, 'image/png')
+    assert.ok(attachment.dataUrl.startsWith('data:image/png;base64,'))
+    assert.equal(detectImageMime(payload, path), 'image/png')
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})

--- a/src/tui/engine/__tests__/image-tool.test.ts
+++ b/src/tui/engine/__tests__/image-tool.test.ts
@@ -8,7 +8,7 @@ import assert from 'node:assert/strict'
 import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { isCompletePng, runImageTool } from '../image-tool.js'
+import { isCompletePng, resizeCandidates, runImageTool } from '../image-tool.js'
 
 // 1x1 transparent PNG（含完整 IHDR + IEND）
 const PNG_1X1 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=='
@@ -118,4 +118,11 @@ test('runImageTool：全部失败但无 RIVET_DEBUG 时保持静默', async () =
   } finally {
     if (origDebug !== undefined) process.env.RIVET_DEBUG = origDebug
   }
+})
+
+test('resizeCandidates：macOS sips 缩放时显式输出 PNG', () => {
+  assert.deepEqual(resizeCandidates('/tmp/in.jpg', '/tmp/out.png', 1568, 'darwin')[0], {
+    bin: 'sips',
+    args: ['-Z', '1568', '-s', 'format', 'png', '/tmp/in.jpg', '--out', '/tmp/out.png'],
+  })
 })

--- a/src/tui/engine/__tests__/input-niceties.test.ts
+++ b/src/tui/engine/__tests__/input-niceties.test.ts
@@ -60,6 +60,28 @@ describe('D2 · multi-line Up/Down', () => {
     assert.equal(input.value, 'prev1', '单行 Up 走历史')
     assert.equal(historyValue, 'prev1')
   })
+
+  it('Up preserves a grapheme column without splitting a ZWJ emoji', () => {
+    const family = '👨‍👩‍👧'
+    const input = new InputLine({ value: `${family}x\nz` })
+
+    input.handleKey('up', '', false, false)
+    assert.equal(input.cursor, family.length, 'cursor must land after the complete emoji cluster')
+
+    input.handleKey('unknown', 'Q', false, false)
+    assert.equal(input.value, `${family}Qx\nz`)
+  })
+
+  it('Down preserves a grapheme column without splitting a surrogate pair', () => {
+    const input = new InputLine({ value: 'z\n😀x' })
+    input.setValue(input.value, 1)
+
+    input.handleKey('down', '', false, false)
+    assert.equal(input.cursor, 4, 'cursor must land after the complete emoji')
+
+    input.handleKey('unknown', 'Q', false, false)
+    assert.equal(input.value, 'z\n😀Qx')
+  })
 })
 
 describe('D4 · Shift+Enter inserts newline without submitting', () => {

--- a/src/tui/engine/image-attach.ts
+++ b/src/tui/engine/image-attach.ts
@@ -39,6 +39,8 @@ export interface ImageAttachment {
 export interface LoadImageOptions {
   maxBytes?: number
   maxEdge?: number
+  /** PNG-producing resize hook; injectable so the oversized-image path is testable. */
+  resizeImage?: (path: string, maxEdge: number) => Promise<Buffer | null>
 }
 
 /**
@@ -106,8 +108,13 @@ async function trySystemResize(path: string, maxEdge: number): Promise<Buffer | 
   }
 }
 
-async function compressImage(path: string, maxEdge: number, maxBytes: number): Promise<Buffer> {
-  const resized = await trySystemResize(path, maxEdge)
+async function compressImage(
+  path: string,
+  maxEdge: number,
+  maxBytes: number,
+  resizeImage: (path: string, maxEdge: number) => Promise<Buffer | null>,
+): Promise<Buffer> {
+  const resized = await resizeImage(path, maxEdge)
   if (resized && resized.length <= maxBytes) return resized
 
   throw new Error(
@@ -132,13 +139,15 @@ export async function loadImageAttachment(
 
   const raw = await readFile(absolutePath)
   let buf: Buffer = Buffer.from(raw) as Buffer
-  const mime = detectImageMime(buf, absolutePath)
+  let mime = detectImageMime(buf, absolutePath)
   if (!mime) {
     throw new Error(`Unsupported image format: ${absolutePath}`)
   }
 
   if (buf.length > maxBytes) {
-    buf = (await compressImage(absolutePath, maxEdge, maxBytes)) as Buffer
+    buf = await compressImage(absolutePath, maxEdge, maxBytes, options.resizeImage ?? trySystemResize)
+    // Every resize candidate is required to produce a validated PNG.
+    mime = 'image/png'
   }
 
   const b64 = buf.toString('base64')

--- a/src/tui/engine/image-tool.ts
+++ b/src/tui/engine/image-tool.ts
@@ -116,7 +116,7 @@ export function resizeCandidates(
     ]
   }
   return [
-    { bin: 'sips', args: ['-Z', String(maxEdge), inPath, '--out', outPath] },
+    { bin: 'sips', args: ['-Z', String(maxEdge), '-s', 'format', 'png', inPath, '--out', outPath] },
     { bin: 'magick', args: [inPath, '-resize', `${maxEdge}x${maxEdge}>`, outPath] },
     { bin: 'convert', args: [inPath, '-resize', `${maxEdge}x${maxEdge}>`, outPath] },
   ]

--- a/src/tui/engine/input-line.ts
+++ b/src/tui/engine/input-line.ts
@@ -965,19 +965,20 @@ export class InputLine {
 
   // ── Multi-line Navigation ────────────────────────────────────
 
-  /** 当前光标的（行,列），列以 code-unit 计。 */
+  /** 当前光标的（行,列），列以 grapheme 计。 */
   private getLineCol(pos: number): { line: number; col: number } {
     const parts = this._value.slice(0, pos).split('\n')
-    return { line: parts.length - 1, col: parts[parts.length - 1]!.length }
+    return { line: parts.length - 1, col: graphemeBoundaries(parts[parts.length - 1]!).length - 1 }
   }
 
-  /** 由（行,列）还原 code-unit 偏移，col 超出行长则贴到行尾。 */
+  /** 由（行,grapheme 列）还原 code-unit 偏移，col 超出行长则贴到行尾。 */
   private posFromLineCol(line: number, col: number): number {
     const lines = this._value.split('\n')
     const clampedLine = Math.max(0, Math.min(line, lines.length - 1))
     let pos = 0
     for (let i = 0; i < clampedLine; i++) pos += lines[i]!.length + 1 // +1 = '\n'
-    pos += Math.min(col, lines[clampedLine]!.length)
+    const bounds = graphemeBoundaries(lines[clampedLine]!)
+    pos += bounds[Math.min(Math.max(0, col), bounds.length - 1)]!
     return pos
   }
 

--- a/src/tui/history.ts
+++ b/src/tui/history.ts
@@ -6,6 +6,7 @@ import { historyPath } from '../config/paths.js'
 
 export const MAX_HISTORY = 1000
 const HISTORY_PATH = historyPath()
+let historyAppendQueue: Promise<void> = Promise.resolve()
 
 export function loadHistory(): string[] {
   try {
@@ -38,8 +39,14 @@ export function appendHistory(entry: string): void {
 
 /** 异步持久化历史记录，不阻塞调用方。供 key handler 等延迟敏感路径使用。 */
 export async function appendHistoryAsync(entry: string): Promise<void> {
-  const history = nextHistoryAfterSubmit(await loadHistoryAsync(), entry)
-  await writeFileAtomicAsync(HISTORY_PATH, JSON.stringify(history, null, 2))
+  const pending = historyAppendQueue.then(async () => {
+    const history = nextHistoryAfterSubmit(await loadHistoryAsync(), entry)
+    await writeFileAtomicAsync(HISTORY_PATH, JSON.stringify(history, null, 2))
+  })
+  // Keep later appends runnable after a rejected write while preserving the
+  // rejection for this caller.
+  historyAppendQueue = pending.catch(() => {})
+  return pending
 }
 
 /** 模糊搜索历史记录，返回匹配项及得分 */


### PR DESCRIPTION
## 变更摘要

本 PR 修复了网络访问防护、任务调度、MCP 配置和 TUI 中 6 类可复现的运行时问题。其中前两类是影响较大的安全与重复副作用问题，其余四类涉及配置可靠性、历史记录持久化、Unicode 编辑和图片上传。

## 修复的问题

### 高优先级

1. **SSRF 防护可被 IPv4-mapped IPv6 和部分保留地址绕过**
   - 原实现依赖字符串前缀判断，`::ffff:127.0.0.1`、`::ffff:10.0.0.1` 和 `::ffff:169.254.169.254` 等地址不会被识别为私有地址。
   - 改用 Node.js `BlockList` 按网段检查，在发起请求前拦截 IPv4-mapped 私网/回环地址，以及 unspecified、链路本地、组播、文档、基准测试、CGNAT 等非公网范围。
   - 增加 `httpFetchGuarded` 集成回归，确认被拦截时底层 `fetch` 不会执行。

2. **幂等任务可能重复执行，或在重启后永久停留为 `pending`**
   - 原实现返回已有任务记录后仍会再次调度，同一任务可能执行两次并重复产生工具或外部副作用。
   - 初步修复若只按“是否本次创建”判断，又会使“保存成功、调度前崩溃”留下的 `pending` 任务无法恢复。
   - 现在通过进程内执行认领保证同一 `TaskRegistry` 只调度一次；新进程可重新认领持久化的 `pending` 任务，`recoverStaleTasks()` 也会在获得调度锁后主动恢复它们。
   - 增加同进程去重、持久化任务重启恢复和启动恢复回归测试。

### 可靠性与交互

3. **远程 MCP 配置会丢失传输、认证和工具策略字段**
   - `POST /mcp/servers` 现在保留并通过 schema 校验 `transportHint`、`auth` 和 `policy`，不再静默丢弃这些字段。
   - `rivet config mcp add-sse` 现在写入 `transportHint: 'sse'`，避免 legacy SSE 端点被误判为 Streamable HTTP。

4. **并发异步写入提示历史时会丢记录**
   - 将完整的“读取、更新、原子写入”事务串行化，避免多个 fire-and-forget 写入相互覆盖。
   - 某次写入失败仍会向该调用方返回错误，但不会让后续写入队列永久失效。

5. **多行输入上下移动可能把光标落在 Emoji 内部**
   - 原逻辑按 UTF-16 code unit 保存列位置，可能把光标放进 surrogate pair 或 ZWJ Emoji 序列中，后续输入会产生损坏字符串。
   - 现在按 grapheme 列计算并钳制到合法边界，覆盖普通 Emoji 和 ZWJ 序列。

6. **macOS 大图缩放可能失败或生成错误的 MIME 声明**
   - `sips` 以前只把输出路径命名为 `.png`，并未显式转换格式；JPEG 内容仍可能是 JPEG，随后会被 PNG 校验拒绝。
   - 现在为 `sips` 显式指定 PNG 输出，缩放后的附件统一声明为 `image/png`，与经过校验的真实字节一致。

## 验证结果

- [x] `npx tsc --noEmit --pretty false`
- [x] 任务注册表回归测试：49 通过，0 失败
- [x] 任务重试、Cron 接线与锁邻接测试：24 通过，0 失败
- [x] Server / Config / Network 定向测试：120 通过，0 失败
- [x] TUI 定向回归测试：29 通过，0 失败
- [x] `npm test -- src/tui/`：2251 通过，0 失败，1 个既有 todo
- [x] macOS 实机 `sips` 检查：输出 MIME、data URL 前缀和 magic bytes 均为 PNG
- [x] `git diff --check`

每处生产代码变更均有对应回归测试。独立 diff 评审发现并促成了 `pending` 任务重启恢复补丁；修复后相关任务、重试和 Cron 邻接套件均已重新通过。

## 已知限制

公开仓库当前缺少 `desktop/src-tauri/tauri.conf.json` 等全量测试入口依赖，因此无法把仓库级全量测试作为本 PR 的有效验收信号；该问题在未修改的 `upstream/main` 上同样存在。本 PR 已运行所有受影响模块的定向和邻接测试。
