### PR TITLE
fix: 全局安装 postinstall 失败（patch-package）+ 默认星域/模型重启后状态栏不恢复

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "rivet": "dist/main.js"
   },
   "scripts": {
-    "postinstall": "patch-package && (node scripts/install-git-hooks.mjs || node -e 1) && (node scripts/fetch-native-sqlite.js || node -e 1) && (node scripts/prune-installed-wasms.js || node -e 1)",
+    "postinstall": "(node scripts/install-git-hooks.mjs || node -e 1) && (node scripts/fetch-native-sqlite.js || node -e 1) && (node scripts/prune-installed-wasms.js || node -e 1)",
     "prepack": "npm run build && node scripts/stage-cli-sqlite-wrapper.js",
     "dev": "tsup --watch",
     "build": "tsup && node scripts/pack-native.js && node scripts/stage-runtime-deps.js",

--- a/src/main.ts
+++ b/src/main.ts
@@ -770,24 +770,28 @@ async function main() {
   }
 
   // ── Build TuiApp ─────────────────────────────────────────────
-  // 状态栏初始模型名：优先取配置的默认模型（agent.defaultModel 的 modelId），
-  // 与 bootstrap 的默认启动模型解析同源；未配置时回退 provider 首模型。
-  // 修复：此前恒取 provider.models[0]（预设首模型），设置默认模型后重启，
-  // 状态栏仍显示旧默认（如 v4-pro）而非用户配置的模型（如 v4-flash）。
+  // 状态栏初始模型名：以运行时实际模型为准（promptEngine 装配值，覆盖
+  // resume 恢复模型与显式 --model 场景），回退链：运行时模型 → 配置默认
+  // 模型（agent.defaultModel）→ provider 首模型。此前恒取 provider.models[0]，
+  // 设置默认模型后重启状态栏仍显示旧默认（如 v4-pro），与后台实际运行
+  // （如 v4-flash）不一致。
+  let runtimeModelId: string | undefined
+  try { runtimeModelId = ctx.agent.config.promptEngine.getModel() } catch { /* 未初始化 */ }
   const configuredModelId = (() => {
     const ref = ctx.config.agent.defaultModel
     return ref && ref.includes(':') ? ref.slice(ref.indexOf(':') + 1) : undefined
   })()
-  const configuredModel = configuredModelId
-    ? ctx.provider.models.find(m => m.id === configuredModelId || m.alias === configuredModelId)
+  const displayRef = runtimeModelId ?? configuredModelId
+  const configuredModel = displayRef
+    ? ctx.provider.models.find(m => m.id === displayRef || m.alias === displayRef)
     : undefined
-  // 当前模型 spec：配置的默认模型优先；未配置/不匹配回退 provider 首模型。
+  // 当前模型 spec：显示基准模型优先；未匹配回退 provider 首模型。
   // currentModel 供状态栏模型名、上下文窗口等 UI 元数据使用。
   const currentModel = configuredModel ?? ctx.provider.models[0]
-  // 显示名：配置的默认模型优先（匹配到用 alias；未匹配到用原始 modelId——
-  // 与 bootstrap 运行时解析同源，避免显示与运行时不一致）；未配置回退 provider 首模型。
-  const modelName = configuredModelId
-    ? (configuredModel?.alias ?? configuredModelId)
+  // 显示名：匹配到用 alias；未匹配用原始 modelId（与 bootstrap 运行时解析
+  // 同源，避免显示与运行时不一致）；无基准回退 provider 首模型。
+  const modelName = displayRef
+    ? (configuredModel?.alias ?? displayRef)
     : (currentModel?.alias ?? currentModel?.id ?? 'unknown')
 
   // git branch（启动时读取一次，GlanceBar 显示）

--- a/src/main.ts
+++ b/src/main.ts
@@ -770,8 +770,25 @@ async function main() {
   }
 
   // ── Build TuiApp ─────────────────────────────────────────────
-  const currentModel = ctx.provider.models[0]
-  const modelName = currentModel?.alias ?? currentModel?.id ?? 'unknown'
+  // 状态栏初始模型名：优先取配置的默认模型（agent.defaultModel 的 modelId），
+  // 与 bootstrap 的默认启动模型解析同源；未配置时回退 provider 首模型。
+  // 修复：此前恒取 provider.models[0]（预设首模型），设置默认模型后重启，
+  // 状态栏仍显示旧默认（如 v4-pro）而非用户配置的模型（如 v4-flash）。
+  const configuredModelId = (() => {
+    const ref = ctx.config.agent.defaultModel
+    return ref && ref.includes(':') ? ref.slice(ref.indexOf(':') + 1) : undefined
+  })()
+  const configuredModel = configuredModelId
+    ? ctx.provider.models.find(m => m.id === configuredModelId || m.alias === configuredModelId)
+    : undefined
+  // 当前模型 spec：配置的默认模型优先；未配置/不匹配回退 provider 首模型。
+  // currentModel 供状态栏模型名、上下文窗口等 UI 元数据使用。
+  const currentModel = configuredModel ?? ctx.provider.models[0]
+  // 显示名：配置的默认模型优先（匹配到用 alias；未匹配到用原始 modelId——
+  // 与 bootstrap 运行时解析同源，避免显示与运行时不一致）；未配置回退 provider 首模型。
+  const modelName = configuredModelId
+    ? (configuredModel?.alias ?? configuredModelId)
+    : (currentModel?.alias ?? currentModel?.id ?? 'unknown')
 
   // git branch（启动时读取一次，GlanceBar 显示）
   let gitBranch: string | undefined
@@ -860,7 +877,13 @@ async function main() {
   ctx!.agent.onAskUserQuestionRequested = (info) => {
     setImmediate(() => tuiApp.openAskUserQuestionPanel(info))
   }
+  // 初始星域显示：agent 已钉定（resume/已绑定）用 agent 的；全新会话未绑定时
+  // 按配置 defaultDomain 显示（非 auto）——与 bindSessionDomain 首条消息的钉定
+  // 同源，避免启动时状态栏落回 glance-bar 的「天枢」兜底显示。
   const initialDomain = ctx!.agent.getSessionDomain()?.name
+    ?? (ctx!.config.agent.defaultDomain && ctx!.config.agent.defaultDomain !== 'auto'
+      ? starDomainRegistry.get(ctx!.config.agent.defaultDomain)?.name
+      : undefined)
   if (initialDomain) {
     tuiApp.setSessionStarDomain(initialDomain)
   }


### PR DESCRIPTION
## 问题一：`npm install -g tianshu-tui` 一条命令更新失败

**现象**：Windows 上全局更新到 3.2.0 时，`npm install -g tianshu-tui@latest` 报错退出：

```
npm error command failed
npm error command ... cmd.exe /d /s /c patch-package && (node scripts/install-git-hooks.mjs || node -e 1) && ...
npm error 'patch-package' 不是内部或外部命令，也不是可运行的程序或批处理文件
npm warn cleanup Failed to remove some directories [ ... esbuild ... EBUSY: resource busy or locked ... ]
```

**根因**：
- `patch-package` 声明在 `devDependencies`，而全局安装只安装 `dependencies` —— postinstall 首步 `patch-package` 在消费者环境必然 command not found，npm 判定安装失败。
- 仓库中**不存在 `patches/` 目录**（git ls-tree 确认），这行命令即使存在也无任何补丁可应用，属于死代码。上游 commit eaf06449（"chore: 删除遗留的 ink 补丁 — Ink 已从依赖移除，patch-package 每次安装报错"）已记录过此问题，但只删了补丁、未删 postinstall 里的命令。
- postinstall 失败触发 npm 回滚，回滚删除旧版 `esbuild` / `@ast-grep` 等 native 目录时在 Windows 上遇到文件锁，产生 EBUSY cleanup 噪音（次生现象，非根因）。

**修复**：postinstall 移除 `patch-package &&` 前缀。其余脚本（install-git-hooks / fetch-native-sqlite / prune-installed-wasms）均自带 `|| node -e 1` 兜底，行为不受影响。

**验证（消费者场景 RED→GREEN）**：
- RED：在无 `patch-package` 的干净 PATH 下执行旧 postinstall → 输出 `'patch-package' 不是内部或外部命令`（与用户报错逐字一致）
- GREEN：同一环境执行新 postinstall → exit 0；修复后 tarball 在临时目录 `npm install` 成功（exit 0, 0 vulnerabilities）

## 问题二：设置默认星域/默认模型后，重启会话状态栏不恢复

**现象**：设置默认星域（如太一）与默认模型（如 DeepSeek-V4-Flash）后退出会话，重新进入 Tui，状态栏仍显示「天枢 / v4-pro」；发送首条消息后星域变为默认值（太一），但模型仍显示 v4-pro。

**关键证据（显示层与运行时不一致）**：用户核查后台数据确认，**实际运行的模型是默认设置 v4-flash（config.agent.defaultModel 已生效）**，仅状态栏显示 v4-pro——即运行时正确、显示层错误。这直接印证了根因在 TUI 状态栏的初始模型名取值，而非模型装配逻辑。

**根因**：
1. **模型**：`src/main.ts` 构造 TuiApp 时，状态栏初始模型名恒取 `ctx.provider.models[0]`（provider 预设首模型 deepseek-v4-pro 的 alias `v4-pro`），从不读取 `config.agent.defaultModel`（deepseek-v4-flash）；且 `setModelInfo` 只在手动切换模型时调用，首条消息后无人把运行时模型同步回状态栏 → 显示与运行时不一致且永不修正。运行时模型本身由 bootstrap 的 `decideStartupResumeModel` 正确消费 `agent.defaultModel`（用户后台数据证实），故无需改动装配逻辑。
2. **星域**：全新会话启动时 `bindSessionDomain`（loop.ts:1165）尚未执行（它接收 taskDescription，首条消息才被调用钉定），`agent.getSessionDomain()` 为 undefined，`initialDomain` 不设置，状态栏 `state.domainName` 保持 undefined，渲染时落回 `glance-bar.ts` 的 `domainName ?? '天枢'` 兜底。首条消息钉定后经 onDomainResolved 回调才修正显示。

**修复**（`src/main.ts`）：
- **模型（改进版）**：状态栏初始模型名以**运行时实际模型为准**——`promptEngine.getModel()`（返回装配后的真实 modelId），回退链：运行时模型 → 配置默认模型（agent.defaultModel 的 modelId）→ provider 首模型。匹配到（id 或 alias）显示 alias；未匹配显示原始 modelId。这比仅按 defaultModel 显示更完整：同时覆盖 **resume 恢复原模型**与**显式 `--model` 参数**两个场景，显示恒等于运行时实际模型（与 bootstrap 的 decideStartupResumeModel 决策完全同源）。
- **星域**：`initialDomain` 回退读取 `config.agent.defaultDomain`（非 auto 时经 starDomainRegistry 取显示名），与首条消息 bindSessionDomain 的钉定同源，启动即显示正确星域。

**验证**：
- `tsc --noEmit` 通过
- 相关测试 54/54 通过（config-cli / domain-pinning / format-glance-bar）
- 模型名解析五场景探针（真实 PROVIDER_PRESETS 数据）全 PASS：用户场景（runtime=flash）→ `v4-flash`；无配置→`v4-pro`（原行为）；resume 恢复 pro→`v4-pro`；未知模型→原始 id
- 星域映射探针通过：`defaultDomain=taiyi` → 显示「太一」；`qiming` → 「启明」
- 全量 `test:fast` 6466 tests / 6422 pass / 43 fail —— 43 个失败均为环境/工具链既有失败（网络渲染兜底、node --test 入口审计、Windows 路径判定等），与本次 diff 文件（package.json、src/main.ts）零交集
