### PR TITLE
fix(tui): AI 输出中排队消息不再自动注入，输入框贴底（排队语义 + 渲染顺序）

### DIFF
--- a/src/tui/engine/__tests__/input-bottom-line.test.ts
+++ b/src/tui/engine/__tests__/input-bottom-line.test.ts
@@ -1,0 +1,65 @@
+/**
+ * T9 输入框贴底测试（问题2 回归）：
+ *
+ * 契约：输入框（topBorder + inputLines + botBorder）必须是 live region 渲染帧
+ * 的**最后一行**——滚动到底时输入框极限位置在界面最下方（Claude Code 风格）。
+ * 状态行（metrics + 权限模式）、slash 提示、文件补全等辅助行全部在输入框上方。
+ *
+ * RED 基线：修复前输入框 botBorder 之后仍渲染状态行（`test ⚡- 0s ... ⏵ auto-safe`）。
+ */
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { makeApp, stripAnsi } from './_harness.js'
+
+const tick = () => new Promise(r => setTimeout(r, 20))
+
+/** 取最近一帧的纯文本行序列（strip ANSI、去空行）。 */
+function lastFrameLines(out: { chunks: string[] }): string[] {
+  const last = out.chunks[out.chunks.length - 1] ?? ''
+  return stripAnsi(last).split('\n').filter(l => l.trim() !== '')
+}
+
+test('输入框（botBorder）应为渲染帧最后一行：其后无状态行/提示行', async () => {
+  const { app, out, stdin } = makeApp({ rows: 24 })
+  app.onSubmit(() => {})
+
+  // 触发渲染：提交一条消息
+  app.setInput('hello')
+  stdin.dataHandler!('\r')
+  await tick()
+
+  const lines = lastFrameLines(out)
+  // 输入框底边框（thick/dots 主题用 ╰，thin 用 └）
+  const botIdx = lines.findIndex(l => /^[╰└]/.test(l))
+  assert.ok(botIdx >= 0, `应能找到输入框 botBorder，帧行: ${lines.join(' | ')}`)
+  const afterBot = lines.slice(botIdx + 1)
+  assert.equal(
+    afterBot.length,
+    0,
+    `输入框之后不应有其他行（状态行等应在输入框上方），实际: ${afterBot.join(' | ')}`,
+  )
+})
+
+test('状态行（metrics/权限模式）位于输入框上方', async () => {
+  const { app, out, stdin } = makeApp({ rows: 24 })
+  app.onSubmit(() => {})
+
+  app.setInput('hello')
+  stdin.dataHandler!('\r')
+  await tick()
+
+  const lines = lastFrameLines(out)
+  const botIdx = lines.findIndex(l => /^[╰└]/.test(l))
+  assert.ok(botIdx >= 0)
+  // 状态行特征：权限模式（auto-safe / plan / ask）在输入框上方
+  const permIdx = lines.findIndex(l => l.includes('auto-safe') || l.includes('plan') || l.includes('ask'))
+  if (permIdx >= 0) {
+    assert.ok(permIdx < botIdx, `状态行（行 ${permIdx}）应在输入框（行 ${botIdx}）上方`)
+  }
+  // metrics 特征：⚡（effort）或模型名
+  const metricsIdx = lines.findIndex(l => l.includes('⚡'))
+  if (metricsIdx >= 0) {
+    assert.ok(metricsIdx < botIdx, `metrics 行（行 ${metricsIdx}）应在输入框（行 ${botIdx}）上方`)
+  }
+})

--- a/src/tui/engine/__tests__/steer-queue-confirm.test.ts
+++ b/src/tui/engine/__tests__/steer-queue-confirm.test.ts
@@ -1,0 +1,139 @@
+/**
+ * T9 steer 队列确认语义测试（问题1 回归）：
+ *
+ * 契约（对齐 kimi-cli / codex：普通消息在 AI 输出期间只入队，turn 结束后交还用户）：
+ *  1. 工具边界（onSteerDrain）不得注入普通排队消息（later 级）——消息保持排队，
+ *     等待 run 结束后回填输入框、由用户再次 Enter 确认发送。
+ *  2. 工具边界仍注入紧急意图（halt=now / redirect=next）——用户主动喊停/改方向
+ *     的 steer 特性保留。
+ *  3. run 正常结束（onTurnComplete isFinal → notifyRunSettled）后，队列残留
+ *     回填输入框（⏮ 已把 N 条排队消息拉回输入框），steerBuffer 清空。
+ *  4. 回填后用户再次按 Enter → 消息作为新 run 提交（onSubmit 收到）。
+ *
+ * RED 基线：修复前测试 1/3/4 失败（onSteerDrain 无过滤 drain 全部 + 正常结束不回填）。
+ */
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import type { ReadStream, WriteStream } from 'node:tty'
+import { TuiApp } from '../app.js'
+import { MockOut, MockIn, stripAnsi } from './_harness.js'
+
+function makeApp() {
+  const out = new MockOut()
+  const stdin = new MockIn()
+  const app = new TuiApp({
+    stdout: out as unknown as WriteStream,
+    stdin: stdin as unknown as ReadStream,
+    cols: 80, rows: 24, modelName: 'test',
+  })
+  return { app, out, stdin }
+}
+
+const tick = () => new Promise(r => setTimeout(r, 10))
+
+// ── 契约 1: 工具边界不注入普通排队消息 ─────────────────────────
+
+test('工具边界不注入普通排队消息：later 级消息保持排队', async () => {
+  const { app, stdin } = makeApp()
+  app.onSubmit(() => {})
+
+  // 发起第一个 run → agentBusy = true
+  app.setInput('task A')
+  stdin.dataHandler!('\r')
+  await tick()
+  assert.equal(app.busy, true, '前置：agentBusy 应为 true')
+
+  // AI 输出中提交普通消息 → 排队
+  app.setInput('note during busy')
+  stdin.dataHandler!('\r')
+  await tick()
+  assert.ok(app.steerBuffer.hasPending(), '前置：消息应在 steer buffer 中排队')
+
+  // 模拟工具边界（agent 回调触发 onSteerDrain）
+  const drained = app.callbacks.onSteerDrain?.() ?? null
+
+  // 普通消息不得被注入（保持排队等 run 结束回填）
+  assert.equal(drained, null, '普通排队消息不应被格式化为 [User guidance] 注入')
+  assert.equal(app.steerBuffer.hasPending(), true, '普通排队消息应留在队列')
+})
+
+// ── 契约 2: 紧急意图仍即时注入 ─────────────────────────────────
+
+test('工具边界仍注入紧急意图（halt/redirect 即时 steer 保留）', async () => {
+  const { app, stdin } = makeApp()
+  app.onSubmit(() => {})
+
+  app.setInput('task A')
+  stdin.dataHandler!('\r')
+  await tick()
+
+  // 用户喊停 → pushNow（halt 意图，优先级 now）
+  app.steerBuffer.pushNow('停')
+  assert.ok(app.steerBuffer.hasPending())
+
+  const drained = app.callbacks.onSteerDrain?.() ?? null
+  assert.ok(drained !== null, 'halt 应立即注入')
+  assert.ok(drained!.includes('停'), '注入文本包含 halt 消息')
+  assert.equal(app.steerBuffer.hasPending(), false, 'halt 注入后队列应清空')
+})
+
+// ── 契约 3: run 正常结束后队列回填输入框 ───────────────────────
+
+test('run 正常结束后：队列残留回填输入框，steerBuffer 清空', async () => {
+  const { app, stdin } = makeApp()
+  app.onSubmit(() => {})
+
+  // run A：busy 时排队一条普通消息
+  app.setInput('task A')
+  stdin.dataHandler!('\r')
+  await tick()
+  app.setInput('note 1')
+  stdin.dataHandler!('\r')
+  await tick()
+  assert.ok(app.steerBuffer.hasPending(), '前置：消息应在 steer buffer 中排队')
+
+  // 结束 run A：isFinal → agentBusy 复位（main.ts 随后在 finally 调 notifyRunSettled）
+  app.callbacks.onTurnComplete({ input_tokens: 100, output_tokens: 10 }, 1, true)
+  await tick()
+  assert.equal(app.busy, false, '前置：isFinal 后 agentBusy 应为 false')
+  app.notifyRunSettled()
+  await tick()
+
+  // 排队消息回填输入框，队列清空
+  assert.equal(app.getInputValue(), 'note 1', '排队消息应回填到输入框')
+  assert.equal(app.steerBuffer.hasPending(), false, '回填后 steerBuffer 应清空')
+  const sb = app.getScrollbackContent()
+  assert.ok(sb.includes('拉回输入框'), `scrollback 应有回填提示，实际: ${sb.slice(-200)}`)
+})
+
+// ── 契约 4: 回填后再次 Enter 提交 ──────────────────────────────
+
+test('回填后再次 Enter：排队消息作为新 run 提交', async () => {
+  const { app, stdin } = makeApp()
+  const runs: string[] = []
+  app.onSubmit((t) => { runs.push(t) })
+
+  app.setInput('task A')
+  stdin.dataHandler!('\r')
+  await tick()
+  app.setInput('note 1')
+  stdin.dataHandler!('\r')
+  await tick()
+
+  // 结束 run A → 回填
+  app.callbacks.onTurnComplete({ input_tokens: 100, output_tokens: 10 }, 1, true)
+  await tick()
+  app.notifyRunSettled()
+  await tick()
+  assert.equal(app.getInputValue(), 'note 1', '前置：回填已完成')
+
+  // 用户再次 Enter
+  stdin.dataHandler!('\r')
+  await tick()
+
+  assert.equal(runs.length, 2, '回填内容应作为新 run 提交')
+  assert.equal(runs[1], 'note 1', '提交内容应为排队消息')
+  const sb = app.getScrollbackContent()
+  assert.ok(stripAnsi(sb).includes('note 1'), 'scrollback 应包含回填消息气泡')
+})

--- a/src/tui/engine/app.ts
+++ b/src/tui/engine/app.ts
@@ -5897,23 +5897,8 @@ export class TuiApp {
         })
       }
 
-      lines.push({ text: topBorder })
-      if (vimNormalMode) {
-        lines.push({
-          text: this.renderInputRow(`${vimModeLabel}${colorizeInputLine(withPastePills(withGhost(withFenceTint(inputLines[0] ?? '', 0), 0)))}`, innerWidth, leftBar, rightBar),
-          ...(inputDisplay.caret.line === 0 ? { caretCol: caretColFor(0) } : {}),
-        })
-        for (let i = 1; i < inputLines.length; i++) {
-          pushInputRow(inputLines[i]!, i)
-        }
-      } else {
-        for (let i = 0; i < inputLines.length; i++) {
-          pushInputRow(inputLines[i]!, i)
-        }
-      }
-      lines.push({ text: botBorder })
-
-      // 5a. 图片附件摘要（输入框正下方、权限模式行上方）
+      // ── 辅助行（状态/metrics/提示）全部在输入框上方 ──────────────
+      // 5a. 图片附件摘要（输入框上方、状态行上方）
       const imageCount = this.inputLine.images.length
       if (imageCount > 0) {
         const imageLabel = `📎 ${imageCount} image${imageCount > 1 ? 's' : ''}`
@@ -5921,7 +5906,7 @@ export class TuiApp {
       }
 
       // 5b. 状态行：左 metrics（模型/effort/cache/ctx/耗时）+ 右权限模式（右对齐）——
-      //     顶框不再承载指标，收敛到输入框正下方这一行（权限行仍是单一事实来源）。
+      //     顶框不再承载指标，收敛到输入框上方这一行（权限行仍是单一事实来源）。
       //     slash 提示打开时权限让位；整行放不下时权限独占下一行。
       const permLine = formatPermissionModeLine({ approvalMode: this._approvalMode, planMode: planModeActive, askMode: askModeActive }, this.theme)
       const permTrim = permLine.trimStart()
@@ -5972,6 +5957,23 @@ export class TuiApp {
         }
         lines.push({ text: this.clampLine(color('tab to cycle', this.theme.dim)) })
       }
+
+      // 输入框：chrome 段最后一行（滚动到底时贴屏幕底部，Claude Code 风格）。
+      lines.push({ text: topBorder })
+      if (vimNormalMode) {
+        lines.push({
+          text: this.renderInputRow(`${vimModeLabel}${colorizeInputLine(withPastePills(withGhost(withFenceTint(inputLines[0] ?? '', 0), 0)))}`, innerWidth, leftBar, rightBar),
+          ...(inputDisplay.caret.line === 0 ? { caretCol: caretColFor(0) } : {}),
+        })
+        for (let i = 1; i < inputLines.length; i++) {
+          pushInputRow(inputLines[i]!, i)
+        }
+      } else {
+        for (let i = 0; i < inputLines.length; i++) {
+          pushInputRow(inputLines[i]!, i)
+        }
+      }
+      lines.push({ text: botBorder })
     }
 
     if (this.screenReader) {

--- a/src/tui/engine/app.ts
+++ b/src/tui/engine/app.ts
@@ -452,6 +452,9 @@ export class TuiApp {
    * 把排队内容拉回输入框交还用户（Claude Code 风格，见 notifyRunSettled）。
    */
   private abortSteerBackfill = false
+  /** 守护中断（watchdog/convergence）pending 标志：settle 时消费，用于区分
+   *  「run 自然结束」与「守护中断自动续跑」——后者不回填排队队列。 */
+  private guardianAbortPending = false
   /**
    * 查询 agent 是否仍有未 settle 的 run（main.ts 注入 → `ctx.agent.isRunning()`）。
    *
@@ -1297,7 +1300,11 @@ export class TuiApp {
       },
       onIntentNote: (intent) => this.handleIntentNote(intent),
       onAutonomyCheckpoint: (info) => this.handleAutonomyCheckpoint(info),
-      onSteerDrain: () => this.steerBuffer.drain(),
+      // 工具边界只注入紧急意图（halt=now / redirect=next）：普通消息（later：
+      // guidance/question/augment/ack）留在队列等 run 结束后回填输入框、由用户
+      // 再次 Enter 确认发送——与「⏳ 已排队」文案一致（此前无过滤 drain 会把
+      // 排队中的普通消息自动注入给 AI，界面显示排队、实际已发出，是撒谎）。
+      onSteerDrain: () => this.steerBuffer.drain('next'),
       onDelegationActivity: (activity) => this.handleDelegationActivity(activity),
     }
 
@@ -1599,12 +1606,23 @@ export class TuiApp {
     this.abortSettling = false
     const backfill = this.abortSteerBackfill
     this.abortSteerBackfill = false
+    const guardian = this.guardianAbortPending
+    this.guardianAbortPending = false
     const pending = this.pendingSubmitAfterAbort
     if (!pending) {
-      // 无补发消息的 settle：用户主动 ESC 的收尾才回填（守护中断自动续跑，
-      // 排队指引留在队列等 drain）。有补发消息时新 run 即将发起，队列随它
-      // 在工具边界 drain，不动。
-      if (backfill) this.backfillSteerToInput()
+      // 无补发消息的 settle：
+      //  - 用户主动 ESC 的收尾回填（Claude Code 风格）；
+      //  - run 自然结束（isFinal 已复位 busy）同样回填——AI 输出期间排队的普通
+      //    消息不再在工具边界自动注入（onSteerDrain 只 drain 紧急意图），run
+      //    结束即交还用户确认（再次 Enter 发送），与 ESC 路径同语义；
+      //  - 守护中断（watchdog/convergence）自动续跑：guardian 时不回填，队列
+      //    保留等续跑 run 结束后的 settle 再回填，或下次提交归并。
+      // 有补发消息时新 run 即将发起，队列随它在工具边界 drain，不动。
+      if (backfill) {
+        this.backfillSteerToInput()
+      } else if (!guardian && !this.agentBusy) {
+        this.backfillSteerToInput()
+      }
       return
     }
     this.pendingSubmitAfterAbort = null
@@ -4987,6 +5005,11 @@ export class TuiApp {
     // 自动续跑，排队指引应留在队列里等 drain，不该被拉回输入框。
     this.abortSteerBackfill =
       this.abortSettling && !reason?.startsWith('watchdog') && !reason?.startsWith('convergence')
+    // 守护中断标志：notifyRunSettled 消费——自然结束（isFinal）的回填逻辑
+    // 不得误伤守护中断（自动续跑时把排队消息拉回输入框会打断续跑流程）。
+    // ?? false：reason 可选（undefined）时 startsWith 短路出 undefined。
+    this.guardianAbortPending =
+      (this.abortSettling && (reason?.startsWith('watchdog') || reason?.startsWith('convergence'))) ?? false
     this.state.isStreaming = false
     this.state.isThinking = false
     this.setPhase('idle')


### PR DESCRIPTION
## Summary

修复 TUI 端的两个交互问题：

1. **AI 输出期间提交的消息显示「⏳ 已排队」却实际已被自动发送** —— 排队语义与界面文案矛盾
2. **输入框的极限位置不在界面最下方** —— 输入框下方还有状态行等辅助行，滚动到底时输入框无法贴底

## 问题 1：排队消息在工具边界被自动注入

### 复现

AI 输出过程中发送普通消息 → 界面显示 `⏳ 已排队: "..."` → 下一个工具回合消息以 `[User guidance]` 格式注入给 AI，AI 立即执行。用户以为消息在排队，实际已发出。

### 根因

`src/tui/engine/app.ts` 中 `onSteerDrain` 回调无优先级过滤地 drain 整个 steer 队列：

```ts
onSteerDrain: () => this.steerBuffer.drain(),  // 修复前：所有排队消息（含普通聊天）在工具边界注入
```

AI 输出期间每个工具回合都会触发该回调，把普通消息格式化为 `[User guidance — 用户新指令...]` 注入给正在运行的 AI。代码注释自己承认「此时仍显示已排队是界面在撒谎」。

### 修复

对齐 kimi-cli / codex 的共识（普通消息在 AI 输出期间只入队，turn 结束后才处理）：

- `onSteerDrain` 改为 `drain('next')`：只注入紧急意图（`halt`=now / `redirect`=next，即用户主动喊停/改方向，steer 特性保留）；普通消息（guidance/question/augment/ack → later 级）留在队列
- `notifyRunSettled` 在 run 自然结束（isFinal）时把队列残留**回填输入框**（复用既有 `backfillSteerToInput` 机制），提示「⏮ 已把 N 条排队消息拉回输入框」，由用户**再次按 Enter 确认后发送**
- 守护中断（watchdog/convergence）自动续跑路径经 `guardianAbortPending` 标志区分，不回填、不打断续跑流程

### 参考实现

- kimi-cli（MoonshotAI/kimi-cli）：streaming 期间 Enter 只入队 `_queued_messages`，注释明确「messages waiting to be sent **after the turn ends**」；turn 结束后 drain 作为新 turn 发送；Ctrl+S 才是显式立即注入
- codex（openai/codex）：队列消息在 agent turn 结束后 `maybe_send_next_queued_input()` 自动发送

## 问题 2：输入框不在界面最下方

### 复现

界面滚动到底时，屏幕最底行是状态行（metrics + 权限模式），输入框在其上方——输入框的极限位置不在屏幕最下方（与 Claude Code 的输入框贴底惯例不符）。

### 根因

`renderLive` 的 chrome 段中，输入框（topBorder + inputLines + botBorder）渲染在**中游**，其后仍渲染图片摘要、状态行（`formatPermissionModeLine` metrics + 权限模式）、@file 诊断、上下文提示、slash 提示、文件补全候选。

### 修复

调整 chrome 段渲染顺序：全部辅助行移到输入框**上方**，输入框成为 live region 最后一行。`reservedTail` / `chromeStart` 计算不变（行数不变，仅顺序变化），不影响定高视口逻辑。

## 测试

### 新增

- `src/tui/engine/__tests__/steer-queue-confirm.test.ts`（4 条契约）：
  1. 工具边界不注入普通排队消息（修复前 RED：`onSteerDrain` 返回 `[User guidance...]` 注入文本、队列被清空）
  2. 工具边界仍注入紧急意图（halt 即时 steer 保留）
  3. run 正常结束后队列残留回填输入框、steerBuffer 清空（修复前 RED）
  4. 回填后再次 Enter → 消息作为新 run 提交（修复前 RED）
- `src/tui/engine/__tests__/input-bottom-line.test.ts`（2 条契约）：
  1. 输入框 botBorder 为渲染帧最后一行（修复前 RED：botBorder 后仍有状态行 `test ⚡- 0s ... ⏵ auto-safe`）
  2. 状态行（metrics/权限模式）位于输入框上方

### 回归

- `user-commit-paths` / `abort-interrupt-ux` / `abort-resubmit` / `slash-passthrough` / `queue-lane`：38/38 通过（含「守护中断 settle 不回填」既有契约）
- `fixed-viewport` / `live-engine-ghost-render` / `live-engine` / `input-*` / 新增测试：133/133 通过
- TUI 引擎域全量：522 测试 520 通过（1 个预存在失败 `approval-key` 工作区路径判定，Windows 环境问题，在原始上游 HEAD 同样复现）
- typecheck：`app.ts` 零错误（`src/server/__tests__/session-search.test.ts` 的 8 个 TS2322 为预存在错误，与本次改动无关）

## 变更文件

- `src/tui/engine/app.ts`（onSteerDrain 优先级过滤 + notifyRunSettled 自然结束回填 + chrome 段顺序调整）
- `src/tui/engine/__tests__/steer-queue-confirm.test.ts`（新增）
- `src/tui/engine/__tests__/input-bottom-line.test.ts`（新增）

## 验证建议（本地）

```
npm install
npm run typecheck
npx tsx --test src/tui/engine/__tests__/steer-queue-confirm.test.ts src/tui/engine/__tests__/input-bottom-line.test.ts
```

真实终端交互：`npm start` 后 AI 输出中发送消息 → 应看到「⏳ 已排队」且 AI 不被打断；回合结束后消息回填输入框，按 Enter 才发送。滚动到底时输入框应贴屏幕最底部。
