### PR TITLE
fix(tui): 命令面板换绑 Ctrl+P（Ctrl+Esc 在 Windows 被开始菜单抢占且三条送达路径全断）

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -523,7 +523,7 @@ Tianshu's command-line interface runs on a purpose-built **T9 rendering engine**
 | **Inline terminal images** | Renders images right in the terminal via the kitty / iTerm2 graphics protocols (tool artifacts, screenshot verifications). Auto-detects the protocol; `RIVET_IMAGES=0` disables, `kitty`/`iterm2` forces one. |
 | **@mention completion** | Type `@file:` / `@folder:` / `@symbol:` to trigger path completion (via `git ls-files`; supports the quoted form `@file:"a b.ts"` for paths with spaces). Pasting an image auto-converts to inline base64 (3-tier fallback across macOS/Linux/Windows). |
 | **Rewind** | Double-tap `ESC` (within 400ms) to open message history; pick any past user message to rewind to, with three restore granularities (conversation only / code only / both) and a precise file-impact preview for code actions. See [Rewind](#rewind). |
-| **Command palette** | `Ctrl+Esc` opens a fuzzy-searchable list of all slash commands and surface actions (toggle side panel, switch theme, enter Cockpit, etc.) — ↑/↓ to select, Enter to run. |
+| **Command palette** | `Ctrl+P` opens a fuzzy-searchable list of all slash commands and surface actions (toggle side panel, switch theme, enter Cockpit, etc.) — ↑/↓ to select, Enter to run, `Ctrl+P` again to close. Rebinds the original `Ctrl+Esc`, which Windows reserves for the Start menu and which legacy escape sequences cannot distinguish from plain Esc. |
 | **Cockpit** | Open via the palette or `/cockpit <panel>`. An 8-panel fullscreen view — summary / trace / verify / context / safety / model / mcp / advisory — switch focus with ←/→/Tab. Real-time view of doom-loop level, delivery/verification status, cache + speculative pre-read stats, MCP connections, advisory lifts, etc. |
 | **Multi-agent panels** | `/tasks` opens a fullscreen worker detail view (fusing the live view + JSONL transcript, with Contract/Activity/Result/Transcript sections and honesty labels); on wide terminals (≥100 columns), `Ctrl+]` toggles a right-side drawer showing the fleet tree, team-wave DAG, todos, and token gauge in real time. |
 | **Themes & accessibility** | `/theme [name\|list]` switches palettes; the `auto` theme probes the terminal background via OSC 11 to adapt light/dark. Truecolor / 256-color / 16-color auto-downgrade. `/vim` toggles vim keybindings; `ui.reducedMotion: true` staticizes spinner and badge animation (accessibility). |
@@ -535,7 +535,7 @@ Tianshu's command-line interface runs on a purpose-built **T9 rendering engine**
 | `Enter` | Send · `Shift+Enter` for newline |
 | `Ctrl+C` | Three states: abort the current run while the agent is active; clear the input line when there's input; double-press within 2s when idle to exit |
 | `Esc` | Close overlay / exit worker view; interrupt while the agent runs; toggle normal↔insert in vim mode; double-tap (<400ms) to rewind |
-| `Ctrl+Esc` | Command palette |
+| `Ctrl+P` | Command palette (rebinds Ctrl+Esc, reserved by the Windows Start menu) |
 | `Ctrl+]` | Toggle the right-side drawer (wide terminals) |
 | `Ctrl+R` | History-search overlay (only when idle) |
 | `Ctrl+O` | Expand/collapse the most recently truncated tool result |

--- a/README.md
+++ b/README.md
@@ -554,8 +554,8 @@ rivet config mcp list                                              # 列出 + �
 | **终端内联图片** | kitty / iTerm2 图形协议在终端里直接渲染图片（工具产物、截图验证结果）。默认自动检测协议，`RIVET_IMAGES=0` 关闭、`kitty`/`iterm2` 强制指定。 |
 | **@mention 补全** | 输入 `@file:` / `@folder:` / `@symbol:` 触发路径补全（走 `git ls-files`，支持带空格的 `@file:"a b.ts"` 引用形）。直接粘贴图片自动转 base64 内联（macOS/Linux/Windows 三级降级）。 |
 | **倒带 Rewind** | 双击 `ESC`（间隔 <400ms）打开消息历史，选任一过往用户消息倒带到该点；可选「仅对话 / 仅代码改动 / 两者」三种恢复粒度，代码动作附带精确的文件影响预览。详见 [倒带](#倒带rewind)。 |
-| **命令面板** | `Ctrl+Esc` 打开，模糊搜索所有 slash 命令与 surface 动作（开关侧栏、切主题、进 Cockpit 等），↑/↓ 选中、Enter 执行。 |
-| **Cockpit 驾驶舱** | `Ctrl+Esc` → 选 Cockpit，或 `/cockpit <panel>` 进入。8 面板全屏视图：summary / trace / verify / context / safety / model / mcp / advisory，←/→/Tab 切换聚焦，实时展示 doom-loop 等级、验证交付状态、缓存与投机预读统计、MCP 连接、advisory 提醒等。 |
+| **命令面板** | `Ctrl+P` 打开，模糊搜索所有 slash 命令与 surface 动作（开关侧栏、切主题、进 Cockpit 等），↑/↓ 选中、Enter 执行，再按 `Ctrl+P` 关闭。原 `Ctrl+Esc` 在 Windows 被系统「开始菜单」抢占、在传统转义序列下与 Esc 同码不可区分，已换绑。 |
+| **Cockpit 驾驶舱** | `Ctrl+P` → 选 Cockpit，或 `/cockpit <panel>` 进入。8 面板全屏视图：summary / trace / verify / context / safety / model / mcp / advisory，←/→/Tab 切换聚焦，实时展示 doom-loop 等级、验证交付状态、缓存与投机预读统计、MCP 连接、advisory 提醒等。 |
 | **多智能体面板** | `/tasks` 打开全屏 worker 详情（融合 live 视图 + JSONL 转录，含 Contract/Activity/Result/Transcript 分段与诚实标签）；宽终端（≥100 列）下 `Ctrl+]` 切出右侧抽屉，实时展示舰队树、团队波次 DAG、todo、token 仪表。 |
 | **主题与无障碍** | `/theme [name|list]` 切换色彩主题；`auto` 主题用 OSC 11 探测终端背景色自动适配明暗。truecolor / 256 色 / 16 色三轨自动降级。`/vim` 切换 vim 键绑定；`ui.reducedMotion: true` 把 spinner 与徽章动画静态化（无障碍）。读屏用户用 `--screen-reader`（或 `ui.screenReader: true`）：动态段整体不渲染、周期重绘停转，活动的开始与等待批准改为静态行播报——`reducedMotion` 只冻结字形，救不了每 120ms 被复读一遍。 |
 
@@ -566,7 +566,7 @@ rivet config mcp list                                              # 列出 + �
 | `Enter` | 发送 · `Shift+Enter` 换行 |
 | `Ctrl+C` | 三态：agent 活跃时中断当前 run；有输入时清空输入行；空闲时 2 秒内双击退出 |
 | `Esc` | 关闭覆盖层 / 退出 worker 视图；agent 跑时中断；vim 模式下兼 normal↔insert；双击（<400ms）倒带 |
-| `Ctrl+Esc` | 命令面板 |
+| `Ctrl+P` | 命令面板（Ctrl+Esc 被 Windows「开始菜单」抢占，已换绑） |
 | `Ctrl+]` | 切右侧抽屉（宽终端） |
 | `Ctrl+R` | 历史搜索 overlay（仅空闲时） |
 | `Ctrl+O` | 展开/折叠最近被截断的工具结果 |

--- a/src/tui/__tests__/engine-input-line.test.ts
+++ b/src/tui/__tests__/engine-input-line.test.ts
@@ -431,12 +431,12 @@ describe('InputLine', () => {
       assert.equal(input.value, 'line1\nline2\nline3') // value 不变，只是光标上移
     })
 
-    it('多行内容：Ctrl+P 仍能翻历史（替代入口）', () => {
+    it('多行内容：Ctrl+P 不再翻历史（已让位给命令面板，Ctrl+R 兜底）', () => {
       const input = new InputLine({ history: ['old1', 'old2'] })
       input.setValue('line1\nline2', 0)
       const ev = input.handleKey('ctrl_p', '', true, false)
-      assert.ok(ev?.type === 'change')
-      assert.equal(input.value, 'old1') // Ctrl+P 翻到历史，不受多行禁用影响
+      assert.equal(ev, null) // Ctrl+P 被 TuiApp 全局拦截开命令面板，InputLine 不响应
+      assert.equal(input.value, 'line1\nline2')
     })
   })
 

--- a/src/tui/engine/__tests__/palette-hotkey.test.ts
+++ b/src/tui/engine/__tests__/palette-hotkey.test.ts
@@ -1,0 +1,126 @@
+/**
+ * 命令面板快捷键契约：Ctrl+P 开关（替代原 Ctrl+Esc）。
+ *
+ * 背景（换绑理由，三条路全断）：
+ *  - Windows 宿主：Ctrl+Esc 被系统抢占（打开开始菜单），按键事件到不了终端；
+ *  - 传统转义序列：Ctrl+Esc 与单独 Esc 同码（0x1B），解析层不可区分；
+ *  - kitty 增强键盘：Ctrl+Esc 编码 \x1B[27;5u，解析器未映射该码位（unknown）。
+ * Ctrl+P 是 0x10 单控制字符，所有终端都能可靠送达。
+ *
+ * 历史回溯不因此失去入口：单行 ↑/↓、Ctrl+N（下一条）、Ctrl+R 全屏历史搜索；
+ * 多行编辑时方向键仍只做行间导航（防误触设计，见 input-line moveUpOrHistory）。
+ */
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import type { ReadStream, WriteStream } from 'node:tty'
+import { TuiApp } from '../app.js'
+import { InputLine } from '../input-line.js'
+
+class MockOut {
+  columns = 80
+  rows = 24
+  chunks: string[] = []
+  write = (s: string): boolean => { this.chunks.push(s); return true }
+  on(): this { return this }
+  removeListener(): this { return this }
+  clear() { this.chunks = [] }
+}
+class MockIn {
+  isTTY = true
+  dataHandler: ((d: string) => void) | null = null
+  setRawMode(): this { return this }
+  resume(): this { return this }
+  setEncoding(): this { return this }
+  on(ev: string, h: (d: string) => void): this { if (ev === 'data') this.dataHandler = h; return this }
+  removeAllListeners(): this { return this }
+  pause(): this { return this }
+}
+
+function makeApp() {
+  const out = new MockOut()
+  const stdin = new MockIn()
+  const app = new TuiApp({
+    stdout: out as unknown as WriteStream,
+    stdin: stdin as unknown as ReadStream,
+    cols: 80, rows: 24, modelName: 'test',
+  })
+  return { app, out, stdin }
+}
+
+const tick = () => new Promise(r => setTimeout(r, 10))
+
+/** 终端把 Ctrl+P 送达为单控制字节 DLE(0x10)，走真实解析器。 */
+const CTRL_P = '\x10'
+const ALT_OFF = '\x1B[?1049l'
+
+const activeId = (app: TuiApp) =>
+  (app as unknown as { overlay: { activeId(): string | null } }).overlay.activeId()
+
+const inputLineValue = (app: TuiApp) =>
+  (app as unknown as { inputLine: { value: string } }).inputLine.value
+
+function registerPalette(app: TuiApp) {
+  app.registerOverlays(
+    { paletteCommands: () => ({ commands: [{ label: '/x' }, { label: '/y' }], selectedIndex: 0 }) },
+    () => {},
+  )
+}
+
+test('Ctrl+P（0x10）经真实解析器打开命令面板', async () => {
+  const { app, stdin } = makeApp()
+  registerPalette(app)
+  stdin.dataHandler!(CTRL_P)
+  await tick()
+  assert.equal(activeId(app), 'command-palette', '空闲时 Ctrl+P 激活 command-palette overlay')
+})
+
+test('命令面板已开时 Ctrl+P 关闭（toggle）', async () => {
+  const { app, out, stdin } = makeApp()
+  registerPalette(app)
+  app.activateOverlay('command-palette')
+  out.clear()
+  stdin.dataHandler!(CTRL_P)
+  await tick()
+  assert.equal(activeId(app), null, '面板开着时 Ctrl+P 关闭')
+  assert.ok(out.chunks.join('').includes(ALT_OFF), '关闭时退出 alt-screen')
+})
+
+test('其他 overlay 开着时 Ctrl+P 切到命令面板', async () => {
+  const { app, stdin } = makeApp()
+  registerPalette(app)
+  app.activateOverlay('history-search')
+  stdin.dataHandler!(CTRL_P)
+  await tick()
+  assert.equal(activeId(app), 'command-palette', 'history-search 开着时 Ctrl+P 切换到 command-palette')
+})
+
+test('Ctrl+P 开面板不打扰输入框草稿（关闭面板后草稿仍在）', async () => {
+  const { app, stdin } = makeApp()
+  registerPalette(app)
+  stdin.dataHandler!('h')
+  stdin.dataHandler!('i')
+  stdin.dataHandler!(CTRL_P)
+  await tick()
+  assert.equal(activeId(app), 'command-palette', '草稿存在时也能开面板')
+  stdin.dataHandler!('\x1B') // Esc 关面板（overlay 激活时 ESC 立即派发）
+  await tick()
+  assert.equal(activeId(app), null)
+  assert.equal(inputLineValue(app), 'hi', '草稿不被面板吞掉')
+})
+
+test('InputLine：Ctrl+P 不再是历史回溯键（↑ 单行仍翻历史）', () => {
+  const input = new InputLine({ history: ['prev1'] })
+  input.handleKey('ctrl_p', '', true, false)
+  assert.equal(input.value, '', 'Ctrl+P 让位给命令面板，InputLine 不响应')
+  input.handleKey('up', '', false, false)
+  assert.equal(input.value, 'prev1', '单行 ↑ 仍取上一条历史')
+})
+
+test('InputLine：Ctrl+N 下一条历史保留（readline 对偶不受影响）', () => {
+  const input = new InputLine({ history: ['prev1', 'prev0'] })
+  input.handleKey('up', '', false, false)      // → prev1
+  input.handleKey('up', '', false, false)      // → prev0
+  input.handleKey('ctrl_n', '', true, false)
+  assert.equal(input.value, 'prev1', 'Ctrl+N 仍回到下一条历史')
+})

--- a/src/tui/engine/app.ts
+++ b/src/tui/engine/app.ts
@@ -1055,8 +1055,21 @@ export class TuiApp {
         }
         return
       }
+      if (key.name === 'ctrl_p') {
+        // Ctrl+P → 命令面板开关。原 Ctrl+Esc 三条送达路径全断：Windows 宿主
+        // 被「开始菜单」抢占（事件到不了终端）、传统转义序列下与单独 Esc 同码
+        // （0x1B）、kitty 增强键盘的 \x1B[27;5u 未被解析器映射。Ctrl+P（0x10）
+        // 在所有终端可靠送达。翻历史入口不受影响：单行 ↑/↓、Ctrl+N、Ctrl+R。
+        if (this.overlay.isActive() && this.overlay.activeId() === 'command-palette') {
+          this.deactivateOverlay()
+        } else {
+          this.activateOverlay('command-palette')
+        }
+        return
+      }
       if (key.name === 'escape' && key.ctrl) {
-        // Ctrl+Esc → 激活命令面板
+        // Ctrl+Esc → 激活命令面板（见上方 Ctrl+P 注释：此路径当前解析器
+        // 不可达，保留给未来增强键盘协议映射，主键位为 Ctrl+P）
         this.overlayController.resetNav()
         this.overlay.activate('command-palette')
         return

--- a/src/tui/engine/input-line.ts
+++ b/src/tui/engine/input-line.ts
@@ -700,7 +700,8 @@ export class InputLine {
         case 'ctrl_b': return this.moveLeft()
         case 'ctrl_f': return this.moveRight()
         case 'ctrl_n': return this.historyNext()
-        case 'ctrl_p': return this.historyPrev()
+        // Ctrl+P 已让位给命令面板（TuiApp 全局拦截）；多行时翻上一条历史
+        // 用 Ctrl+R 历史搜索。ctrl_n 保留 readline 对偶（下一条）。
         case 'ctrl_minus':
         case 'ctrl_z': return this.undo()
         case 'ctrl_y': return this.redo()
@@ -987,7 +988,8 @@ export class InputLine {
     if (this._value.includes('\n')) {
       // 多行：方向键专注行间导航，到首行原地停，不翻历史（防误触——
       // 多行编辑时光标频繁停在首行，按上想继续编辑却跳走）。
-      // 多行时翻历史用 Ctrl+P（historyPrev）/ Ctrl+N（historyNext）。
+      // 多行时翻历史用 Ctrl+N（下一条）/ Ctrl+R（历史搜索）；Ctrl+P 已让位
+      // 给命令面板，多行时上一条历史经 Ctrl+R 全屏搜索可达。
       const { line, col } = this.getLineCol(this._cursor)
       if (line > 0) {
         this.sealUndo()

--- a/src/tui/format/welcome.ts
+++ b/src/tui/format/welcome.ts
@@ -9,7 +9,7 @@
  *   │ deepseek-v4 · ◎high · auto-safe                                  │
  *   │ ~/app/deepseek-tui/opencode-tui · #7281                          │
  *   │                                                                  │
- *   │ /init 生成项目说明   /domain 切换星域   /help 全部命令 · ctrl+esc  │
+ *   │ /init 生成项目说明   /domain 切换星域   /help 全部命令 · ctrl+p   │
  *   │ ⏜ /handoff 上下文 50%–70% 时交接给新会话                          │
  *   ╰──────────────────────────────────────────────────────────────────╯
  *
@@ -95,7 +95,7 @@ const DIPPER_BOWL = [
 const TIPS = [
   { cmd: '/init', desc: '生成项目说明' },
   { cmd: '/domain', desc: '切换星域' },
-  { cmd: '/help', desc: '全部命令 · ctrl+esc 命令面板' },
+  { cmd: '/help', desc: '全部命令 · ctrl+p 命令面板' },
 ] as const
 
 function truncateToWidth(text: string, maxWidth: number): string {

--- a/src/tui/slash-commands.ts
+++ b/src/tui/slash-commands.ts
@@ -157,8 +157,8 @@ const HELP_TEXT = `Available commands:
 /rollback [<N>] — Rollback file changes (alias of /undo)
 /write-plan — Write current plan to file
 Ctrl+C — Interrupt current turn (press twice to exit)
-Ctrl+P / Ctrl+N — 翻历史命令（上一条 / 下一条；多行编辑时方向键不翻历史，用这组）
-Ctrl+Esc — 命令面板（模糊搜索全部命令与界面动作）
+↑ / Ctrl+N — 翻历史命令（单行 ↑ 上一条；多行编辑时方向键只做行间导航，用 Ctrl+R 历史搜索）
+Ctrl+P — 命令面板（模糊搜索全部命令与界面动作；Ctrl+Esc 被 Windows「开始菜单」抢占，已换绑）
 
 ▌▌ 上下文与缓存（DeepSeek V4 成本关键）▌▌
 


### PR DESCRIPTION
## 问题

命令面板原绑定 **Ctrl+Esc**，三条送达路径全部断裂，实测在任何终端都不可用：

| 路径 | 结果 |
|------|------|
| Windows 宿主 | Ctrl+Esc 被系统抢占（打开开始菜单），按键事件根本到不了终端 |
| 传统转义序列 | Ctrl+Esc 与单独 Esc 同码（`0x1B`），解析层不可区分（`input-handler.ts` 的 lone-ESC 派发恒为 `ctrl: false`） |
| kitty 增强键盘 | Ctrl+Esc 编码 `\x1B[27;5u`，`resolveEscapeSequence` 未映射该码位 → `unknown` |

即 `app.ts` 的 `escape + ctrl` 分支在当前解析器下不可达——面板实际上只能通过程序化 `activateOverlay` 打开。

## 方案

**Ctrl+P（0x10 单控制字符）** 作为命令面板开关，所有终端可靠送达：

- **开**：空闲或任意 overlay 激活时按 Ctrl+P → 激活命令面板（复用 `activateOverlay` 统一入口：`live.clear()` 防叠影 + `resetNav` + overlay 内 Esc 即时派发）
- **关**：面板已开时再按 Ctrl+P → 关闭（toggle 语义）
- **切换**：其他 overlay（如 history-search）开着时按 Ctrl+P → 切到命令面板

**历史回溯入口不受影响**（Ctrl+P 原为 InputLine 的 `historyPrev`）：

- 单行 `↑`/`↓` 翻历史（原有行为不变）
- `Ctrl+N` 下一条（readline 对偶保留）
- `Ctrl+R` 全屏历史搜索 overlay（多行编辑时方向键只做行间导航的防误触设计不变，翻上一条历史经 Ctrl+R 可达）

原 `escape + ctrl` 分支保留不删——当前不可达但无害，若未来解析器补充 kitty `\x1B[27;5u` 映射即可复用。

## 行业对照

- **codex**（Rust TUI）：`ctrl+p` 为列表 `move_up` 别名（keymap.rs）——readline 惯例键位，无命令面板
- **grok-build**：textarea 库 `ctrl_p_moves_cursor_up`（readline 惯例），无命令面板
- **kimi-cli** / **Claude Code**：均无命令面板（斜杠命令为主），无一使用 Ctrl+Esc 做 TUI 快捷键

## 测试

- 新增 `palette-hotkey.test.ts` 6 条契约（原始 stdin 字节 `\x10` 注入，走完整解析链）：打开 / toggle 关闭 / 从其他 overlay 切换 / 不打扰输入框草稿 / InputLine 不再响应 ctrl_p / Ctrl+N 保留
- 更新 `engine-input-line.test.ts` 多行 Ctrl+P 旧契约为新契约
- 引擎域 522 测试 520 通过（1 失败为预存在的 `approval-key.test.ts` Windows 路径判定问题，上游基线同样失败）
- tui 全域失败集合与基线完全一致，零新增失败
- 键位文档同步：`/help` 文本、首屏 tips、README 中英文
