### PR TITLE
fix(tui): Ctrl+C 退出确认窗口支持 Esc/编辑取消，修复幽灵输入与带输入退出

### DIFF
--- a/src/tui/engine/__tests__/ctrlc-pending-cancel.test.ts
+++ b/src/tui/engine/__tests__/ctrlc-pending-cancel.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Ctrl+C pending-exit 确认窗口的取消契约。
+ *
+ * 背景：空闲 + 空输入第一次 Ctrl+C 进入「(Ctrl+C again to exit)」确认窗口
+ * （2 秒），渲染层隐藏输入框只显示提示行。原实现该窗口只能等 2 秒超时或
+ * 二次 Ctrl+C 退出，存在四个缺陷：
+ *  1. Esc 无法取消——落到 idle 分支只记 lastEscAt，输入框不恢复；400ms 内
+ *     双击 Esc 还会误开 rewind overlay；
+ *  2. 幽灵输入——窗口内打字，文字进 value 但输入框仍被隐藏；
+ *  3. 不可见提交——窗口内打的字（不可见）可被 Enter 提交；
+ *  4. 带输入退出——窗口内打了字再 Ctrl+C 直接退出而非清空输入。
+ *
+ * 契约：Esc / 任意编辑键 / 粘贴 = 用户继续对话 → 取消确认、恢复输入框；
+ * 有输入时二次 Ctrl+C 退化为「清空输入」，不退出。
+ *
+ * 跨平台：Ctrl+C(0x03) / Esc(0x1B lone) 在 Windows / macOS / Linux 终端的
+ * raw mode 下字节送达一致（InputHandler 解析层无平台分支），契约对全平台等效。
+ */
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { makeApp, stripAnsi } from './_harness.js'
+import type { TuiApp } from '../app.js'
+
+function makeStartedApp() {
+  const t = makeApp()
+  let exited = false
+  t.app.onExit(() => { exited = true })
+  const pendingSince = () =>
+    (t.app as unknown as { inputController: { ctrlCPendingSince: number } }).inputController.ctrlCPendingSince
+  const inputText = () =>
+    (t.app as unknown as { inputLine: { value: string } }).inputLine.value
+  const lastEscAt = () =>
+    (t.app as unknown as { inputController: { lastEscAt: number } }).inputController.lastEscAt
+  const plain = () => stripAnsi(t.out.chunks.join(''))
+  return { ...t, exitedRef: () => exited, pendingSince, inputText, lastEscAt, plain }
+}
+type StartedApp = ReturnType<typeof makeStartedApp>
+const CTRL_C = '\x03'
+const ESC = '\x1B'
+const HINT = '(Ctrl+C again to exit)'
+const INPUT_BORDER = /[╭┏┌]/
+const tick = (ms: number) => new Promise(r => setTimeout(r, ms))
+
+test('Esc 取消退出确认：输入框恢复、提示消失、不污染 rewind 计时', async () => {
+  const t = makeStartedApp()
+  t.stdin.dataHandler!(CTRL_C)
+  assert.ok(t.pendingSince() > 0, '第一次 Ctrl+C 进入确认窗口')
+  assert.ok(t.plain().includes(HINT), '提示行显示')
+
+  // MockOut 是累积写入流；「消失」断言只看取消动作之后的新增帧（行级 diff
+  // 只重写变化行，旧帧文本会永远留在 chunks 里）。
+  t.out.clear()
+  t.stdin.dataHandler!(ESC)
+  await tick(120) // lone ESC 经 80ms 超时派发
+  assert.equal(t.pendingSince(), 0, 'Esc 取消确认窗口')
+  assert.ok(!t.plain().includes(HINT), '提示行消失（新增帧不再写提示）')
+  assert.ok(INPUT_BORDER.test(t.plain()), '输入框回归')
+  assert.equal(t.lastEscAt(), 0, '取消用的 Esc 不计入双击 rewind 计时')
+})
+
+test('编辑键取消确认：打字立即可见，不再幽灵输入', async () => {
+  const t = makeStartedApp()
+  t.stdin.dataHandler!(CTRL_C)
+  assert.ok(t.pendingSince() > 0, '进入确认窗口')
+  t.out.clear()
+  t.stdin.dataHandler!('a')
+  await tick(60) // writeBatcher 异步合帧
+  assert.equal(t.pendingSince(), 0, '编辑活动取消确认窗口')
+  assert.equal(t.inputText(), 'a', '字符进输入框')
+  assert.ok(t.plain().includes('a'), '打的字立即可见（输入框渲染）')
+  assert.ok(!t.plain().includes(HINT), '提示行消失（新增帧不再写提示）')
+})
+
+test('确认窗口内打字后二次 Ctrl+C：清空输入而非退出', async () => {
+  const t = makeStartedApp()
+  t.stdin.dataHandler!(CTRL_C)
+  t.stdin.dataHandler!('hi')
+  await tick(60)
+  t.stdin.dataHandler!(CTRL_C)
+  await tick(30)
+  assert.equal(t.exitedRef(), false, '有输入时不退出')
+  assert.equal(t.inputText(), '', '退化为清空输入')
+})
+
+test('空输入时二次 Ctrl+C 仍然退出（原行为防回归）', async () => {
+  const t = makeStartedApp()
+  t.stdin.dataHandler!(CTRL_C)
+  await tick(30)
+  t.stdin.dataHandler!(CTRL_C)
+  await tick(30)
+  assert.equal(t.exitedRef(), true, '空输入确认窗口内二次 Ctrl+C 退出')
+})
+
+test('Esc 取消后可重新进入确认窗口（循环可用）', async () => {
+  const t = makeStartedApp()
+  t.stdin.dataHandler!(CTRL_C)
+  t.stdin.dataHandler!(ESC)
+  await tick(120)
+  t.stdin.dataHandler!(CTRL_C)
+  assert.ok(t.pendingSince() > 0, '取消后再次 Ctrl+C 重新进入确认窗口')
+  assert.ok(t.plain().includes(HINT), '提示行再次显示')
+})

--- a/src/tui/engine/app.ts
+++ b/src/tui/engine/app.ts
@@ -892,6 +892,12 @@ export class TuiApp {
       }
       // Other overlays active → don't paste into main input
       if (this.overlay.isActive()) return
+      // 确认窗口内粘贴 = 继续对话：取消 pending-exit 再插入文本
+      // （与打字路径的取消同一状态位，见 handleKey 的 Normal input processing）。
+      if (this.inputController.ctrlCPendingSince > 0) {
+        this.inputController.ctrlCPendingSince = 0
+        this.renderLive()
+      }
 
       // 右键粘贴/终端菜单粘贴走 bracketed paste 文本通道，不触发 ctrl_v 按键，
       // 因此不会调 handleCtrlV → readImageFromClipboard。若剪贴板当前是图片，
@@ -1034,8 +1040,9 @@ export class TuiApp {
         if (this.isAgentActive()) {
           // Agent active (含首 token 前/纯工具窗口): abort current agent run
           this.handleAbort()
-        } else if (this.inputController.ctrlCPendingSince > 0) {
-          // Second Ctrl+C within window → exit
+        } else if (this.inputController.ctrlCPendingSince > 0 && !this.inputLine.value.trim()) {
+          // Second Ctrl+C within window → exit（有输入时不退出——窗口内
+          // 打过字说明用户在继续对话，退化为清空输入，见下方分支）
           this.inputController.ctrlCPendingSince = 0
           this.dispose()
           if (this.onExitCallback) {
@@ -1044,8 +1051,10 @@ export class TuiApp {
             process.exit(0)
           }
         } else if (this.inputLine.value.trim()) {
-          // Idle with input: clear input line, don't exit
+          // Idle with input: clear input line, don't exit（同时取消可能
+          // 残留的确认窗口——清空输入后提示行没有理由继续显示）
           this.inputLine.setValue('')
+          this.inputController.ctrlCPendingSince = 0
           this.renderLive()
         } else {
           // Idle with empty input: first Ctrl+C → show hint, start 2s window
@@ -1062,6 +1071,18 @@ export class TuiApp {
         return
       }
       if (key.name === 'escape') {
+        // Ctrl+C pending-exit 确认窗口内：Esc = 取消退出、恢复输入框。优先于
+        // vim 切换 / 双击 rewind / overlay 关闭——屏幕处于退出提示态（输入框
+        // 被隐藏），用户此刻按 Esc 的意图是「回到对话」。overlay 激活时的 Esc
+        // 已在上方 handleOverlayKey 消费（先关 overlay），不会走到这里。
+        if (this.inputController.ctrlCPendingSince > 0) {
+          this.inputController.ctrlCPendingSince = 0
+          // 取消用的 Esc 不计入双击 rewind 计时，避免「取消后立刻双击 Esc」
+          // 误开 rewind overlay。
+          this.inputController.lastEscAt = 0
+          this.renderLive()
+          return
+        }
         // Vim 模式下：overlay/agent 激活时 ESC 关闭 overlay 或中断 agent，
         // 空闲时 ESC 落入输入框的 vim normal/insert 切换（保持原行为）。
         if (this.inputLine.vimEnabled) {
@@ -1216,6 +1237,12 @@ export class TuiApp {
         return
       }
       // ── Normal input processing ─────────────────────────────
+      // 确认窗口内的任何编辑键 = 用户继续对话：取消 pending-exit，恢复输入框。
+      // 否则字符进 value 但输入框仍被隐藏（幽灵输入），Enter 还会提交不可见内容。
+      if (this.inputController.ctrlCPendingSince > 0) {
+        this.inputController.ctrlCPendingSince = 0
+        this.renderLive()
+      }
       const event = this.inputLine.handleKey(key.name, key.char, key.ctrl, key.meta, key.shift)
       // 选区剪切/复制的 OSC52 drain（终端支持时写系统剪贴板，不支持者无害忽略）
       const clip = this.inputLine.takeClipboardOut()
@@ -5698,7 +5725,9 @@ export class TuiApp {
     }
 
     // 5. Input line / Ctrl+C hint（多行输入：每行单独 push）
-    if (this.inputController.ctrlCPendingSince > 0) {
+    // 渲染防御：输入框有内容时永远显示输入框——提示行只在空输入时取代它，
+    // 兜住一切未取消 pending 的漏网路径（粘贴竞态等），杜绝幽灵输入。
+    if (this.inputController.ctrlCPendingSince > 0 && !this.inputLine.value) {
       lines.push({ text: '(Ctrl+C again to exit)' })
     } else {
       const inputVal = this.inputLine.value


### PR DESCRIPTION
## 问题

空闲 + 空输入时第一次 `Ctrl+C` 进入「`(Ctrl+C again to exit)`」退出确认窗口（2 秒），渲染层**隐藏输入框**只显示提示行。审查发现该窗口存在四个缺陷：

| # | 缺陷 | 原行为 |
|---|------|--------|
| 1 | **Esc 无法取消**（用户报告） | Esc 落到 idle 分支只记 `lastEscAt` 时间戳，输入框不恢复；400ms 内双击 Esc 还会误开 rewind overlay |
| 2 | **幽灵输入** | 窗口内打字，文字进 `inputLine.value` 但输入框仍被隐藏，2 秒后文字「突然出现」 |
| 3 | **粘贴同样幽灵** | 窗口内粘贴文本，同 2 |
| 4 | **带输入退出** | 窗口内打了字再 `Ctrl+C` 直接退出，而非按「有输入 → 清空输入」语义处理 |

## 方案

**确认窗口内任何「继续对话」信号都取消确认、恢复输入框**：

- **Esc**：`escape` 链最前消费（优先于 vim 切换 / 双击 rewind / overlay 关闭——屏幕处于退出提示态，用户意图是「回到对话」）；取消时同步清 `lastEscAt`，避免取消用的 Esc 计入双击 rewind 计时
- **编辑键**：`Normal input processing` 入口（所有到达输入框的键）检测 pending 即取消——打的字立即可见
- **粘贴**：`onPaste` 主输入路径同样取消
- **防御**：退出分支要求空输入（`pending && !value.trim()`），有输入退化为「清空输入」；「清空输入」分支顺手清 pending；渲染条件加 `!inputLine.value`——输入框有内容时永远渲染输入框，兜住一切漏网路径

原行为保持不变：空输入时二次 `Ctrl+C` 仍退出；确认窗口 2 秒超时自动复位；agent 活跃时 `Ctrl+C` 仍中断当前 run。

## 跨平台审查

- `Ctrl+C`（`0x03`）与 Esc（`0x1B` lone，80ms 超时派发）在 Windows Terminal/conhost、macOS Terminal.app/iTerm2/kitty/Ghostdy/WezTerm、Linux 主流终端的 raw mode 下**字节送达完全一致**
- `InputHandler` 解析层无任何平台分支（`process.platform` / `win32` / `darwin` 零匹配）——修复对全平台等效
- raw mode 下 `Ctrl+C` 不产生 SIGINT（作为数据字节读入），与 `main.ts` 的 SIGINT handler（外部信号源）无冲突
- Windows conhost QuickEdit 选中态下 Ctrl+C 被终端吞为「复制」是终端层行为，不在本修复范围

## 测试

新增 `ctrlc-pending-cancel.test.ts` 5 条契约（原始 stdin 字节注入，走完整解析链）：

- Esc 取消：输入框恢复、提示消失、不污染 rewind 计时
- 编辑取消：打字立即可见（不再幽灵输入）
- 窗口内打字后二次 Ctrl+C：清空输入而非退出
- 空输入二次 Ctrl+C 仍退出（原行为防回归锚点）
- 取消后可重新进入确认窗口（循环可用）

验证：干净基线 4 RED（复现缺陷）/ 修复后 5 GREEN；引擎域 521 测试 519 通过（1 失败为预存在的 `approval-key.test.ts` Windows 路径判定问题，上游基线同样失败）；改动域 typecheck 零错误。
