### PR TITLE
fix(tui): 跨 run 陈旧 todo 清单不再复活显示——「◇ 任务 (5/5) 不更新」的根因与修复

### DIFF
--- a/src/tui/engine/__tests__/todo-stale.test.ts
+++ b/src/tui/engine/__tests__/todo-stale.test.ts
@@ -1,0 +1,121 @@
+/**
+ * 跨 run 陈旧 todo 清单的显示契约。
+ *
+ * 背景：「◇ 任务 (5/5) 有时候不会更新」——同步链路本身健全（todo/plan_task
+ * 工具结果即时刷新 + 120ms ticker 兜底 + 每帧直读 state.todos），真正的机制
+ * 是跨 run 陈旧显示：上一轮**全部完成**的清单在新 run 期间（phase≠idle）原样
+ * 复活，直到 AI 首次写入新 todo 才变化。用户看到新任务已开工、计数却停在
+ * 上一轮的 5/5，观感即「不更新」。
+ *
+ * 契约：
+ *  1. 新 run 未写 todo 前：上一轮全完成清单隐藏（任务面板 + GlanceBar 徽章）
+ *  2. 本 run 写入新 todo 后：新清单正常显示
+ *  3. 本 run 内推进到全完成：仍显示（完成态本身是本 run 的有效信息）
+ *  4. idle + 全完成隐藏（原有行为防回归）
+ *  5. 部分完成清单跨 run 仍显示（AI 大概率续写，不视为陈旧）
+ */
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { makeApp, stripAnsi } from './_harness.js'
+import type { TuiApp } from '../app.js'
+import type { TodoItem } from '../../../tools/todo-store.js'
+
+const mk = (id: string, content: string, status: TodoItem['status']): TodoItem => ({ id, content, status })
+const allDone = (): TodoItem[] => [
+  mk('1', 'task a', 'completed'),
+  mk('2', 'task b', 'completed'),
+  mk('3', 'task c', 'completed'),
+  mk('4', 'task d', 'completed'),
+  mk('5', 'task e', 'completed'),
+]
+
+/** 模拟新 run 启动并开始流式输出（phase → streaming）。
+ *  submitText 的 start()（busy 置位 + todosWrittenThisRun 重置）在
+ *  commitUserPrompt 的微任务后执行——与真实时序对齐，先 await 再发 delta。 */
+async function startStreamingRun(app: TuiApp): Promise<void> {
+  app.submitText('next question')
+  await new Promise(r => setImmediate(r))
+  ;(app as unknown as { handleTextDelta: (t: string) => void }).handleTextDelta('x')
+}
+
+function setup() {
+  const t = makeApp({ cols: 100, rows: 40 })
+  // 上一轮的 5/5 全完成清单（run 内写入后自然结束的终态）
+  t.app.setTodos(allDone())
+  // 模拟 run 结束回到 idle（setPhase 由 isFinal 事件驱动，测试直调同一入口）
+  ;(t.app as unknown as { setPhase: (p: string) => void }).setPhase('idle')
+  return t
+}
+
+const PANEL_TITLE = '◇ 任务'
+// glanceDensity 默认 compact：徽章格式 `◇done/total`（full 档才是 ◐☐☒ 分态）
+const BADGE_DONE5 = '◇5/5'
+const BADGE_DONE1 = '◇1/1'
+const tick = (ms: number) => new Promise(r => setTimeout(r, ms))
+
+test('新 run 未写 todo 前：上一轮全完成清单隐藏（面板 + 徽章）', async () => {
+  const t = setup()
+  await startStreamingRun(t.app)
+  // run 已启动（todosWrittenThisRun 已重置）；取下一帧流式渲染断言——
+  // 避开提交 commit 阶段（重置前一瞬）的旧徽章瞬时帧。
+  t.out.clear()
+  ;(t.app as unknown as { handleTextDelta: (s: string) => void }).handleTextDelta('y')
+  await tick(30) // writeBatcher 异步合帧
+  const plain = stripAnsi(t.out.chunks.join(''))
+  assert.ok(plain.length > 0, '渲染帧到达（防空洞断言）')
+  assert.ok(!plain.includes(PANEL_TITLE), `陈旧面板不显示，got: ${plain.slice(-300)}`)
+  assert.ok(!plain.includes(BADGE_DONE5), '陈旧徽章不显示')
+})
+
+test('本 run 写入新 todo 后：新清单正常显示', async () => {
+  const t = setup()
+  await startStreamingRun(t.app)
+  t.out.clear()
+  t.app.setTodos([mk('n1', 'new task', 'in_progress'), mk('n2', 'another', 'pending')])
+  const plain = stripAnsi(t.out.chunks.join(''))
+  assert.ok(plain.includes(PANEL_TITLE), '新清单面板显示')
+  assert.ok(plain.includes('new task'), '新任务条目可见')
+})
+
+test('本 run 内推进到全完成：仍显示（本 run 有效信息）', async () => {
+  const t = setup()
+  await startStreamingRun(t.app)
+  t.app.setTodos([mk('n1', 'new task', 'in_progress')])
+  t.out.clear()
+  t.app.setTodos([mk('n1', 'new task', 'completed')])
+  const plain = stripAnsi(t.out.chunks.join(''))
+  assert.ok(plain.includes(PANEL_TITLE), '本 run 的全完成清单仍显示')
+  assert.ok(plain.includes(BADGE_DONE1), '本 run 的徽章仍显示')
+})
+
+test('idle + 全完成隐藏（原有行为防回归）', async () => {
+  const t = makeApp({ cols: 100, rows: 40 })
+  t.app.setTodos(allDone())
+  const setPhase = (p: string) => (t.app as unknown as { setPhase: (q: string) => void }).setPhase(p)
+  // 对照帧：streaming 期（非 idle）全完成面板显示——渲染经输入变化驱动，
+  // 避开 LiveEngine「无变化短路」的空帧。
+  setPhase('streaming')
+  t.out.clear()
+  t.app.setInput('a')
+  await tick(10)
+  const shown = stripAnsi(t.out.chunks.join(''))
+  assert.ok(shown.includes(PANEL_TITLE), 'streaming 期全完成面板显示（对照帧）')
+  // 防回归帧：idle 后同一清单隐藏
+  setPhase('idle')
+  t.out.clear()
+  t.app.setInput('ab')
+  await tick(10)
+  const hidden = stripAnsi(t.out.chunks.join(''))
+  assert.ok(hidden.length > 0, '渲染帧到达（防空洞断言）')
+  assert.ok(!hidden.includes(PANEL_TITLE), 'idle 全完成不显示面板（原有行为）')
+})
+
+test('部分完成清单跨 run 仍显示（不视为陈旧）', async () => {
+  const t = makeApp({ cols: 100, rows: 40 })
+  t.app.setTodos([mk('1', 'half done', 'completed'), mk('2', 'rest', 'in_progress')])
+  t.out.clear()
+  await startStreamingRun(t.app)
+  const plain = stripAnsi(t.out.chunks.join(''))
+  assert.ok(plain.includes(PANEL_TITLE), '部分完成清单跨 run 仍显示')
+})

--- a/src/tui/engine/app.ts
+++ b/src/tui/engine/app.ts
@@ -699,6 +699,12 @@ export class TuiApp {
   private sidePanelLeaderTimer: ReturnType<typeof setTimeout> | null = null
   /** todo 徽章高亮熄灭定时器（活动期外 ticker 停转，靠它在 1s 后重绘恢复正常色） */
   private todoFlashTimer: ReturnType<typeof setTimeout> | null = null
+  /** 本 run 是否写入过 todo（用户提交重置，updateTodos 检测到清单签名变化置位）。
+   *  用于跨 run 陈旧显示 gate：新 run 未写 todo 前，上一轮**全部完成**的清单
+   *  不再占用任务面板与 GlanceBar 徽章（观感即「◇ 任务 (5/5) 不更新」——旧值
+   *  复活挂在新 run 头上，直到 AI 首次 todo write）。部分完成清单不受影响
+   *  （AI 大概率续写）；守护中断的自动续跑视为同一任务的延续，不重置。 */
+  private todosWrittenThisRun = false
   /** 监控型 overlay（激活期间随数据/tick 实时重绘，而非打开瞬间的快照） */
   private static readonly LIVE_OVERLAY_IDS: ReadonlySet<string> = new Set(['tasks', 'cockpit', 'jobs'])
   /** live overlay 上次重绘时间戳（节流 ≥400ms） */
@@ -1499,6 +1505,7 @@ export class TuiApp {
       this.streamRenderer.reset()
       this.streamRenderController.assistantHeaderDone = false
       this.agentBusy = true
+      this.todosWrittenThisRun = false
     }
     // Reset turn timer for the new turn
     this.state.turnStartMs = Date.now()
@@ -1613,6 +1620,7 @@ export class TuiApp {
     this.streamRenderer.reset()
     this.streamRenderController.assistantHeaderDone = false
     this.agentBusy = true
+    this.todosWrittenThisRun = false
     this.state.turnStartMs = Date.now()
     this.streamRenderController.lastActivityMs = Date.now()
     this.onSubmitCallback?.(pending.text, pending.images)
@@ -3497,6 +3505,7 @@ export class TuiApp {
       this.streamRenderer.reset()
       this.streamRenderController.assistantHeaderDone = false
       this.agentBusy = true
+      this.todosWrittenThisRun = false
       this.state.turnStartMs = Date.now()
       this.streamRenderController.lastActivityMs = Date.now()
       this.onSubmitCallback?.(text, images)
@@ -4133,6 +4142,11 @@ export class TuiApp {
     const prevDone = prev.reduce((n, x) => n + (x.status === 'completed' ? 1 : 0), 0)
     const nextDone = items.reduce((n, x) => n + (x.status === 'completed' ? 1 : 0), 0)
     this.state.todos = items
+    // 本 run 写入检测（清单身份签名变化 = 新写入）：签名覆盖 id/status/内容，
+    // 与 provider 轮询的同值拉取（ticker 每 120ms 拉一次）区分——只有 AI 真正
+    // 写了新清单才算「本 run 有 todo」，见 todosWrittenThisRun 注释。
+    const sig = (xs: readonly TodoItem[]): string => xs.map(x => `${x.id}:${x.status}:${x.content}`).join('|')
+    if (sig(items) !== sig(prev)) this.todosWrittenThisRun = true
     if (!isReducedMotion() && (nextDone > prevDone || items.length !== prev.length)) {
       this.state.todoFlashUntil = Date.now() + 1000
       if (this.todoFlashTimer) clearTimeout(this.todoFlashTimer)
@@ -5369,6 +5383,9 @@ export class TuiApp {
       const t = this.state.todos
       const total = t.length
       if (total === 0) return undefined
+      // 跨 run 陈旧 gate（同 shouldShowTaskPanel）：全完成 + 本 run 未写 →
+      // 徽章不显示，避免旧 5/5 复活挂在新 run 头上冒充当前进度。
+      if (!this.todosWrittenThisRun && t.every(x => x.status === 'completed')) return undefined
       return {
         total,
         done: t.filter(x => x.status === 'completed').length,
@@ -5666,7 +5683,7 @@ export class TuiApp {
     // 3b. 常驻任务面板（todo 列表）——空列表不渲染；run 空闲且全部完成时隐藏
     //    （shouldShowTaskPanel；todoExpanded 展开态强制显示以回看 completed）。
     //    宽屏时已由 side panel 承载。
-    if (!showSidePanel && this.state.todos.length > 0 && (this.state.todoExpanded || shouldShowTaskPanel(this.state.todos, this.state.phase))) {
+    if (!showSidePanel && this.state.todos.length > 0 && (this.state.todoExpanded || shouldShowTaskPanel(this.state.todos, this.state.phase, !this.todosWrittenThisRun))) {
       const taskLines = formatTaskList(this.state.todos, this.theme, {
         width: cols,
         maxRows: this.state.todoExpanded ? 15 : 6,
@@ -6001,6 +6018,7 @@ export class TuiApp {
         columns: sidePanelWidth,
         todos: this.state.todos,
         phase: this.state.phase,
+        todosStale: !this.todosWrittenThisRun,
         todoExpanded: this.state.todoExpanded,
         workers: this.fleetFrame(cols, false).activeWorkers,
         teamModel: this.liveTeamModel ? this.teamModelWithLiveStatus(this.liveTeamModel) : null,
@@ -6274,6 +6292,7 @@ export class TuiApp {
       this.streamRenderer.reset()
       this.streamRenderController.assistantHeaderDone = false
       this.agentBusy = true
+      this.todosWrittenThisRun = false
       this.state.turnStartMs = Date.now()
       this.streamRenderController.lastActivityMs = Date.now()
       this.onSubmitCallback?.(input)

--- a/src/tui/format/task-list.ts
+++ b/src/tui/format/task-list.ts
@@ -44,9 +44,12 @@ export interface TaskListOptions {
  * 永久渲染，并作为 chrome 首元素在超屏/行宽少算时被反复挤入 scrollback，
  * 形成同一块的多份副本）。运行中或仍有未完成项时显示。
  */
-export function shouldShowTaskPanel(items: readonly TodoItem[], phase: string): boolean {
+export function shouldShowTaskPanel(items: readonly TodoItem[], phase: string, todosStale = false): boolean {
   if (items.length === 0) return false
-  if (phase === 'idle' && items.every(t => t.status === 'completed')) return false
+  // 全完成清单在两种情况下收起：run 已结束（idle），或清单属于更早的 run
+  // （todosStale：当前 run 尚未写过 todo——旧 5/5 复活挂在新 run 头上，观感
+  // 即「任务计数不更新」）。todoExpanded 强制回看由调用方短路，不进这里。
+  if (items.every(t => t.status === 'completed') && (phase === 'idle' || todosStale)) return false
   return true
 }
 

--- a/src/tui/side-panel.ts
+++ b/src/tui/side-panel.ts
@@ -22,6 +22,9 @@ export interface SidePanelInput {
   /** 面板总宽度（含边框），通常 24-32 列 */
   columns: number
   todos: TodoItem[]
+  /** 跨 run 陈旧标记：当前 run 未写过 todo 且清单全完成 → 侧栏任务段收起
+   *  （与主区门禁同语义，见 shouldShowTaskPanel）。 */
+  todosStale?: boolean
   workers: FleetWorkerView[]
   currentTool?: { name: string; elapsedMs: number }
   currentToolName?: string
@@ -135,7 +138,7 @@ export function renderSidePanel(input: SidePanelInput, theme: RivetTheme): strin
   //    todoExpanded 展开态强制显示且放宽行数，completed 逐条可回看）──
   lines.push(sectionDivider())
   const todosExpanded = input.todoExpanded === true
-  const taskLines = (todosExpanded || shouldShowTaskPanel(input.todos, input.phase ?? ''))
+  const taskLines = (todosExpanded || shouldShowTaskPanel(input.todos, input.phase ?? '', input.todosStale === true))
     ? formatTaskList(input.todos, theme, {
       width: contentW,
       maxRows: todosExpanded ? 15 : MAX_TASK_ROWS,


### PR DESCRIPTION
## 问题

「◇ 任务 (5/5) 有时候不会更新」。

## 根因分析（先排除同步问题）

同步链路本身健全，逐项核验：

| 环节 | 机制 | 状态 |
|------|------|------|
| todo/plan_task 工具结果 | `handleToolResult` 即时 `refreshTodos` + `flushNow` | ✅ |
| 长 run 兜底 | 120ms ticker 每 tick `refreshTodos`（agent 活跃期间） | ✅ |
| 回合结束 | `isFinal` 前兜底 `refreshTodos`，收尾 commit 触发渲染 | ✅ |
| 渲染数据源 | 任务面板（主区/侧栏）与 GlanceBar 徽章每帧直读 `state.todos`，无缓存 | ✅ |

「输出太快导致丢同步」不成立（事件驱动 + 轮询双保险，渲染合并不丢终态）。

真正的机制是**跨 run 陈旧显示**：`shouldShowTaskPanel` 的隐藏条件只看 `phase === 'idle'`——上一轮**全部完成**的清单在 run 结束后被隐藏，但新 run 一开始 phase 抬离 idle，旧清单（如 5/5）**重新挂载**，直到 AI 首次写入新 todo 才变化。用户看到新任务已开工、计数却停在上一轮终态，观感即「不更新」。

## 方案

`todosWrittenThisRun` 生命周期标志：

- **重置**：用户提交的四处 run 启动点（`handleInputSubmit` / `notifyRunSettled` 补发 / `submitText` / slash 透传）。守护中断（watchdog/convergence）的自动续跑**不重置**——续跑是同一任务的延续，旧清单继续显示是正确语义
- **置位**：`updateTodos` 以清单签名（`id:status:content` 拼接）区分「AI 真写入」与 ticker 同值轮询拉取，签名变化才置位
- **Gate**：全完成清单 + 本 run 未写 → 任务面板（主区 + 侧栏）与 GlanceBar 徽章均不显示。三个不受影响的情形：
  - 部分完成清单跨 run 仍显示（AI 大概率续写）
  - 本 run 内推进到全完成仍显示（完成态是本 run 的有效信息）
  - `todoExpanded`（ctrl+x t）强制回看不变

## 测试

新增 `todo-stale.test.ts` 5 条契约（含防空洞断言与对照帧设计，规避 LiveEngine「无变化短路」的空帧假绿）：

1. 新 run 未写 todo 前：陈旧面板 + 徽章隐藏（干净基线 RED，复现问题）
2. 本 run 写入新 todo 后：新清单正常显示
3. 本 run 内推进到全完成：仍显示
4. idle + 全完成隐藏（原有行为防回归，含 streaming 对照帧）
5. 部分完成清单跨 run 仍显示

验证：干净基线 1 RED / 修复后 5 GREEN；引擎域 521 测试 519 通过（1 失败为预存在的 `approval-key.test.ts` Windows 路径问题，上游基线同样失败）；既有 `todo-panel.test.ts` 4 条契约无回归；改动域 typecheck 零错误。
