### PR TITLE
fix(tui): 命令面板视窗跟随选中项；首屏 ctrl+p 与斜杠命令同色

### DIFF
--- a/src/tui/__tests__/format-overlay.test.ts
+++ b/src/tui/__tests__/format-overlay.test.ts
@@ -100,6 +100,61 @@ describe('renderCommandPalette', () => {
     const lines = renderCommandPalette(data, 60, 15, theme)
     assert.ok(lines.some(l => stripAnsi(l).includes('Ctrl+R')))
   })
+
+  // height=15 → maxItems = 15-5 = 10. Keep-in-view must follow selectedIndex
+  // so a selection past the first page stays on screen (Ctrl+P /resume bug).
+  const manyCommands = Array.from({ length: 40 }, (_, i) => ({
+    label: `/c${String(i).padStart(2, '0')}`,
+    description: `d${i}`,
+  }))
+
+  it('first page shows /c00 and not /c20', () => {
+    const lines = renderCommandPalette(
+      { commands: manyCommands, selectedIndex: 0 },
+      60, 15, theme,
+    ).map(stripAnsi)
+    const body = lines.join('\n')
+    assert.ok(body.includes('/c00'), 'first command visible at top')
+    assert.ok(!body.includes('/c20'), 'command past viewport not shown')
+  })
+
+  it('selectedIndex past viewport stays visible and keeps the cursor', () => {
+    const lines = renderCommandPalette(
+      { commands: manyCommands, selectedIndex: 12 },
+      60, 15, theme,
+    ).map(stripAnsi)
+    const selectedLine = lines.find(l => l.includes('/c12'))
+    assert.ok(selectedLine, 'selected /c12 is in the viewport')
+    assert.ok(selectedLine!.includes('>'), 'cursor sits on the selected row')
+    assert.ok(!lines.some(l => l.includes('/c00')), '/c00 scrolled off')
+  })
+
+  it('selectedIndex at the last item pins the window to the end', () => {
+    const lines = renderCommandPalette(
+      { commands: manyCommands, selectedIndex: 39 },
+      60, 15, theme,
+    ).map(stripAnsi)
+    assert.ok(lines.some(l => l.includes('/c39')), 'last command visible')
+    assert.ok(!lines.some(l => l.includes('/c00')), 'first command scrolled off at end')
+  })
+
+  it('footer shows overflow counts when the list is taller than the viewport', () => {
+    const atTop = renderCommandPalette(
+      { commands: manyCommands, selectedIndex: 0 },
+      60, 15, theme,
+    ).map(stripAnsi)
+    const footerTop = atTop[atTop.length - 2]!
+    assert.ok(/↓:\d+/.test(footerTop), `↓:N overflow when more items below, got ${footerTop}`)
+    assert.ok(!/↑:\d+/.test(footerTop), 'no ↑:N overflow at top')
+
+    const atBottom = renderCommandPalette(
+      { commands: manyCommands, selectedIndex: 39 },
+      60, 15, theme,
+    ).map(stripAnsi)
+    const footerBottom = atBottom[atBottom.length - 2]!
+    assert.ok(/↑:\d+/.test(footerBottom), `↑:N overflow when more items above, got ${footerBottom}`)
+    assert.ok(!/↓:\d+/.test(footerBottom), 'no ↓:N overflow at end')
+  })
 })
 
 describe('renderChronicle', () => {

--- a/src/tui/__tests__/format-overlay.test.ts
+++ b/src/tui/__tests__/format-overlay.test.ts
@@ -155,6 +155,24 @@ describe('renderCommandPalette', () => {
     assert.ok(/↑:\d+/.test(footerBottom), `↑:N overflow when more items above, got ${footerBottom}`)
     assert.ok(!/↓:\d+/.test(footerBottom), 'no ↓:N overflow at end')
   })
+
+  it('out-of-range selectedIndex still highlights the last command', () => {
+    const lines = renderCommandPalette(
+      { commands: manyCommands, selectedIndex: 99 },
+      60, 15, theme,
+    ).map(stripAnsi)
+    const last = lines.find(l => l.includes('/c39'))
+    assert.ok(last?.includes('>'), 'clamps highlight onto the last item')
+  })
+
+  it('empty command list does not throw and has no cursor', () => {
+    const lines = renderCommandPalette(
+      { commands: [], selectedIndex: 0 },
+      60, 15, theme,
+    ).map(stripAnsi)
+    assert.ok(lines.some(l => l.includes('命令面板')))
+    assert.ok(!lines.some(l => /^\s*>/.test(l) || l.includes('> /') || l.trimStart().startsWith('>')), 'no selection cursor')
+  })
 })
 
 describe('renderChronicle', () => {

--- a/src/tui/__tests__/format-overlay.test.ts
+++ b/src/tui/__tests__/format-overlay.test.ts
@@ -156,6 +156,20 @@ describe('renderCommandPalette', () => {
     assert.ok(!/↓:\d+/.test(footerBottom), 'no ↓:N overflow at end')
   })
 
+  it('↑ inside a scrolled viewport keeps the window still', () => {
+    // Window already starts at 10 (items 10..19). selected=12 is inside it, so
+    // ↑ must move the cursor only — not re-pin the selection to the last row.
+    const lines = renderCommandPalette(
+      { commands: manyCommands, selectedIndex: 12, scrollOffset: 10 },
+      60, 15, theme,
+    ).map(stripAnsi)
+    assert.ok(lines.some(l => l.includes('/c10')), 'window stays at previous start')
+    assert.ok(!lines.some(l => l.includes('/c03')), 'does not jump back to pin-to-bottom')
+    const selectedLine = lines.find(l => l.includes('/c12'))
+    assert.ok(selectedLine?.includes('>'), 'cursor stays on /c12')
+    assert.equal(lines.filter(l => l.includes('>')).length, 1, 'exactly one cursor')
+  })
+
   it('out-of-range selectedIndex still highlights the last command', () => {
     const lines = renderCommandPalette(
       { commands: manyCommands, selectedIndex: 99 },

--- a/src/tui/__tests__/format-welcome.test.ts
+++ b/src/tui/__tests__/format-welcome.test.ts
@@ -265,10 +265,18 @@ test('home 下的 cwd 缩写为 ~', () => {
 
 test('上手行按框宽贪心装填，窄框只留装得下的条目', () => {
   const wide = strip(boxOf(render({ columns: 100 }))[7]!)
-  assert.ok(wide.includes('/init') && wide.includes('/domain') && wide.includes('/help'), '宽框三条齐上')
+  assert.ok(wide.includes('/init') && wide.includes('/domain') && wide.includes('/help'), '宽框斜杠命令齐上')
+  assert.ok(wide.includes('ctrl+p'), '宽框露出独立的 ctrl+p 引导')
   const narrow = strip(boxOf(render({ columns: 56 }))[7]!)
   assert.ok(narrow.includes('/init'), '窄框保留第一条')
   assert.ok(!narrow.includes('/help'), '装不下的条目整条略去，不截半句')
+})
+
+test('ctrl+p 与斜杠命令同走 brandColor，说明走 muted', () => {
+  const joined = render({ columns: 120 }).join('\n')
+  assert.ok(joined.includes(color('ctrl+p', theme.brandColor)), 'ctrl+p 用 brandColor，与 /init 同档')
+  assert.ok(joined.includes(color('/init', theme.brandColor)), '/init 用 brandColor')
+  assert.ok(joined.includes(color('命令面板', theme.muted)), '说明文字仍走 muted')
 })
 
 // ── 降级 ────────────────────────────────────────────────────────────

--- a/src/tui/engine/__tests__/overlay-nav.test.ts
+++ b/src/tui/engine/__tests__/overlay-nav.test.ts
@@ -34,13 +34,14 @@ class MockIn {
   pause(): this { return this }
 }
 
-function makeApp() {
+function makeApp(rows = 24) {
   const out = new MockOut()
+  out.rows = rows
   const stdin = new MockIn()
   const app = new TuiApp({
     stdout: out as unknown as WriteStream,
     stdin: stdin as unknown as ReadStream,
-    cols: 80, rows: 24, modelName: 'test',
+    cols: 80, rows, modelName: 'test',
   })
   return { app, out, stdin }
 }
@@ -176,6 +177,26 @@ test('command-palette: ↑/↓ 循环选中，Enter 执行回调并关闭', () =
   press('up')                  // 2 → 1
   press('enter')
   assert.equal(executed, 1, 'Enter 执行选中索引 1（↓↓↑ = 1）的命令')
+})
+
+test('command-palette: ↓ past viewport scrolls so the selected command stays visible', () => {
+  // rows=12 → maxItems = 12-5 = 7. 30 commands; 12 downs lands on /n12, past the first page.
+  const { app, out, stdin } = makeApp(12)
+  const commands = Array.from({ length: 30 }, (_, i) => ({
+    label: `/n${String(i).padStart(2, '0')}`,
+  }))
+  app.registerOverlays({ paletteCommands: () => ({ commands, selectedIndex: 0 }) })
+  app.activateOverlay('command-palette')
+  const press = (k: string) => stdin.dataHandler!(SEQ[k] ?? k)
+  const screen = () => stripAnsi(reconstructScreen(out.chunks.join('')))
+
+  assert.ok(screen().includes('/n00'), 'first page shows /n00')
+  assert.ok(!screen().includes('/n12'), 'first page does not show /n12')
+
+  for (let i = 0; i < 12; i++) press('down')
+  const after = screen()
+  assert.ok(after.includes('/n12'), 'selected /n12 visible after scrolling past the viewport')
+  assert.ok(!after.includes('/n00'), 'first command scrolled off')
 })
 
 test('command-palette: ↓ 循环到末再回 0', () => {

--- a/src/tui/engine/__tests__/overlay-nav.test.ts
+++ b/src/tui/engine/__tests__/overlay-nav.test.ts
@@ -199,6 +199,59 @@ test('command-palette: ↓ past viewport scrolls so the selected command stays v
   assert.ok(!after.includes('/n00'), 'first command scrolled off')
 })
 
+test('command-palette: wrap from last item back to first restores the top of the list', () => {
+  const { app, out, stdin } = makeApp(12)
+  const commands = Array.from({ length: 20 }, (_, i) => ({
+    label: `/w${String(i).padStart(2, '0')}`,
+  }))
+  app.registerOverlays({ paletteCommands: () => ({ commands, selectedIndex: 0 }) })
+  app.activateOverlay('command-palette')
+  const press = (k: string) => stdin.dataHandler!(SEQ[k] ?? k)
+  const screen = () => stripAnsi(reconstructScreen(out.chunks.join('')))
+
+  for (let i = 0; i < 20; i++) press('down') // 20 items: wrap back to 0
+  const after = screen()
+  assert.ok(after.includes('/w00'), 'wrap to start shows the first command')
+  assert.ok(!after.includes('/w19'), 'last command is off-screen after wrap')
+})
+
+test('command-palette: wrap from first item to last shows the end of the list', () => {
+  const { app, out, stdin } = makeApp(12)
+  const commands = Array.from({ length: 20 }, (_, i) => ({
+    label: `/w${String(i).padStart(2, '0')}`,
+  }))
+  app.registerOverlays({ paletteCommands: () => ({ commands, selectedIndex: 0 }) })
+  app.activateOverlay('command-palette')
+  const press = (k: string) => stdin.dataHandler!(SEQ[k] ?? k)
+  const screen = () => stripAnsi(reconstructScreen(out.chunks.join('')))
+
+  press('up')
+  const after = screen()
+  assert.ok(after.includes('/w19'), 'wrap-up shows the last command')
+  assert.ok(!after.includes('/w00'), 'first command is off-screen')
+})
+
+test('command-palette: filtering after scroll resets the window to the top', () => {
+  const { app, out, stdin } = makeApp(12)
+  const commands = Array.from({ length: 30 }, (_, i) => ({
+    label: `/n${String(i).padStart(2, '0')}`,
+  }))
+  const filter = () => {
+    const q = app.getOverlayQuery()
+    return q ? commands.filter(c => c.label.includes(q)) : commands
+  }
+  app.registerOverlays({ paletteCommands: () => ({ commands: filter(), selectedIndex: 0 }) })
+  app.activateOverlay('command-palette')
+  const press = (k: string) => stdin.dataHandler!(SEQ[k] ?? k)
+  const screen = () => stripAnsi(reconstructScreen(out.chunks.join('')))
+
+  for (let i = 0; i < 12; i++) press('down')
+  stdin.dataHandler!('0') // query '0' → /n00, /n10, /n20
+  const after = screen()
+  assert.ok(after.includes('/n00'), 'filter reset shows the first match')
+  assert.ok(!after.includes('/n12'), 'scrolled item is gone after filter')
+})
+
 test('command-palette: ↓ 循环到末再回 0', () => {
   const { app, stdin } = makeApp()
   let executed = -1

--- a/src/tui/engine/__tests__/overlay-nav.test.ts
+++ b/src/tui/engine/__tests__/overlay-nav.test.ts
@@ -199,6 +199,23 @@ test('command-palette: ↓ past viewport scrolls so the selected command stays v
   assert.ok(!after.includes('/n00'), 'first command scrolled off')
 })
 
+test('command-palette: ↑ after scrolling moves the cursor without jumping the window', () => {
+  const { app, out, stdin } = makeApp(12)
+  const commands = Array.from({ length: 30 }, (_, i) => ({
+    label: `/n${String(i).padStart(2, '0')}`,
+  }))
+  app.registerOverlays({ paletteCommands: () => ({ commands, selectedIndex: 0 }) })
+  app.activateOverlay('command-palette')
+  const press = (k: string) => stdin.dataHandler!(SEQ[k] ?? k)
+  const screen = () => stripAnsi(reconstructScreen(out.chunks.join('')))
+
+  for (let i = 0; i < 12; i++) press('down') // selected=12, window start=6 (maxItems=7)
+  for (let i = 0; i < 6; i++) press('up')   // selected=6, top of the same window
+  const after = screen()
+  assert.ok(after.includes('/n06'), 'cursor at the top of the scrolled window')
+  assert.ok(!after.includes('/n00'), 'window does not jump back to the first page')
+})
+
 test('command-palette: wrap from last item back to first restores the top of the list', () => {
   const { app, out, stdin } = makeApp(12)
   const commands = Array.from({ length: 20 }, (_, i) => ({

--- a/src/tui/engine/app.ts
+++ b/src/tui/engine/app.ts
@@ -110,7 +110,7 @@ import { parseMissionDraft, shouldPreviewContract, formatContractPreview, type M
 import { truncateToDisplayWidth, displayWidth, ambiguousWideEnabled } from '../width.js'
 import { boxCharsFor, boxInnerWidth } from '../box-chars.js'
 import { appendHistoryAsync, nextHistoryAfterSubmit } from '../history.js'
-import { renderPager, renderStarmap, renderCommandPalette, renderChronicle, renderTasks, renderDomainPicker, renderDomainGenesisCard, genesisCardMaxScroll, renderModelPicker, renderThemePicker, renderChoicePanel, renderPlanPicker, renderConnect, renderInitFlow } from '../format/overlay.js'
+import { renderPager, renderStarmap, renderCommandPalette, followListWindow, renderChronicle, renderTasks, renderDomainPicker, renderDomainGenesisCard, genesisCardMaxScroll, renderModelPicker, renderThemePicker, renderChoicePanel, renderPlanPicker, renderConnect, renderInitFlow } from '../format/overlay.js'
 import type { PagerData, StarmapData, PaletteData, ChronicleData, TasksData, TasksGroup, TasksWorkerRow, DomainPickerData, ModelPickerData, ThemePickerData, ChoicePanelData, PlanPickerData, ChoiceEntry, ConnectOverlayData, InitOverlayData } from '../format/overlay.js'
 import { ConnectFlow, DIY_PENDING_KEY_REF, type ConnectCommit, type ConnectProviderRef, type ConnectStepResult } from '../connect-flow.js'
 import { VisionOnboardingFlow, type VisionCandidate, type VisionOnboardingRequest, type VisionOnboardingResult } from '../vision-onboarding-flow.js'
@@ -6901,11 +6901,19 @@ export class TuiApp {
       },
     })
 
-    // Command palette — selectedIndex 由 overlayNav 注入
+    // Command palette — selectedIndex / scrollOffset 由 overlayNav 注入，渲染时跟随选中项
     this.overlay.register('command-palette', {
       render: (_w, _h) => {
         const data = overlayData?.paletteCommands?.() ?? { commands: [], selectedIndex: 0 }
-        return renderCommandPalette({ ...data, selectedIndex: this.overlayController.nav().paletteIndex, searchText: this.overlayController.getQuery() || data.searchText }, this.columns, this.rows, this.theme)
+        const nav = this.overlayController.nav()
+        const maxItems = Math.max(0, this.rows - 5)
+        nav.paletteScroll = followListWindow(nav.paletteIndex, data.commands.length, maxItems, nav.paletteScroll)
+        return renderCommandPalette({
+          ...data,
+          selectedIndex: nav.paletteIndex,
+          scrollOffset: nav.paletteScroll,
+          searchText: this.overlayController.getQuery() || data.searchText,
+        }, this.columns, this.rows, this.theme)
       },
     })
 

--- a/src/tui/engine/overlay-controller.ts
+++ b/src/tui/engine/overlay-controller.ts
@@ -15,6 +15,8 @@ export interface OverlayNavState {
   /** verbose 层：pager 显示完整工具输出（transcript 详细视图）。 */
   pagerVerbose: boolean
   paletteIndex: number
+  /** Command-palette viewport start. Reset with paletteIndex on query edit. */
+  paletteScroll: number
   rewindIndex: number
   /** Rewind overlay sub-phase: message list vs restore-granularity chooser. */
   rewindPhase: 'list' | 'action'
@@ -64,7 +66,7 @@ export interface OverlayDataProviders {
  * TuiApp; this class only manages nav state / data providers / exec callbacks.
  */
 export class OverlayController {
-  private overlayNav: OverlayNavState = { pagerPage: 0, pagerMode: 'page', pagerSearchQuery: '', pagerSearchCurrent: 0, pagerSelectedMessage: 0, pagerVerbose: false, paletteIndex: 0, rewindIndex: 0, rewindPhase: 'list', rewindActionIndex: 0, historySearchIndex: 0, chronicleIndex: 0, tasksIndex: 0, tasksFilter: 'running', jobsIndex: 0, domainPickerIndex: 0, modelPickerIndex: 0, themePickerIndex: 0, choicePanelIndex: 0, planPickerIndex: 0, connectIndex: 0, initIndex: 0, cachePeriod: 'today', query: '' }
+  private overlayNav: OverlayNavState = { pagerPage: 0, pagerMode: 'page', pagerSearchQuery: '', pagerSearchCurrent: 0, pagerSelectedMessage: 0, pagerVerbose: false, paletteIndex: 0, paletteScroll: 0, rewindIndex: 0, rewindPhase: 'list', rewindActionIndex: 0, historySearchIndex: 0, chronicleIndex: 0, tasksIndex: 0, tasksFilter: 'running', jobsIndex: 0, domainPickerIndex: 0, modelPickerIndex: 0, themePickerIndex: 0, choicePanelIndex: 0, planPickerIndex: 0, connectIndex: 0, initIndex: 0, cachePeriod: 'today', query: '' }
   private overlayData?: OverlayDataProviders
   private paletteExec?: (index: number) => void
   private rewindExec?: (messageIndex: number, mode: RewindMode) => void
@@ -85,7 +87,7 @@ export class OverlayController {
   /** Direct mutable access to nav state object */
   nav(): OverlayNavState { return this.overlayNav }
   resetNav(): void {
-    this.overlayNav = { pagerPage: 0, pagerMode: 'page' as const, pagerSearchQuery: '', pagerSearchCurrent: 0, pagerSelectedMessage: 0, pagerVerbose: false, paletteIndex: 0, rewindIndex: 0, rewindPhase: 'list' as const, rewindActionIndex: 0, historySearchIndex: 0, chronicleIndex: 0, tasksIndex: 0, tasksFilter: 'running' as const, jobsIndex: 0, domainPickerIndex: 0, modelPickerIndex: 0, themePickerIndex: 0, choicePanelIndex: 0, planPickerIndex: 0, connectIndex: 0, initIndex: 0, cachePeriod: 'today' as const, query: '' }
+    this.overlayNav = { pagerPage: 0, pagerMode: 'page' as const, pagerSearchQuery: '', pagerSearchCurrent: 0, pagerSelectedMessage: 0, pagerVerbose: false, paletteIndex: 0, paletteScroll: 0, rewindIndex: 0, rewindPhase: 'list' as const, rewindActionIndex: 0, historySearchIndex: 0, chronicleIndex: 0, tasksIndex: 0, tasksFilter: 'running' as const, jobsIndex: 0, domainPickerIndex: 0, modelPickerIndex: 0, themePickerIndex: 0, choicePanelIndex: 0, planPickerIndex: 0, connectIndex: 0, initIndex: 0, cachePeriod: 'today' as const, query: '' }
   }
 
   get pagerPage(): number { return this.overlayNav.pagerPage }
@@ -131,6 +133,7 @@ export class OverlayController {
       this.overlayNav.query += ch
     }
     this.overlayNav.paletteIndex = 0
+    this.overlayNav.paletteScroll = 0
     this.overlayNav.historySearchIndex = 0
   }
 

--- a/src/tui/format/overlay.ts
+++ b/src/tui/format/overlay.ts
@@ -350,16 +350,17 @@ export function renderCommandPalette(data: PaletteData, width: number, height: n
     : '命令面板'
   lines.push(formatTitleLeft(title, width, theme))
 
-  const maxItems = height - 5 // border + title + footer + border = 4; +1 safety
+  const maxItems = Math.max(0, height - 5) // border + title + footer + border = 4; +1 safety
   const count = data.commands.length
-  const scrollOffset = listWindowOffset(data.selectedIndex, count, maxItems)
+  const selected = count === 0 ? -1 : Math.max(0, Math.min(data.selectedIndex, count - 1))
+  const scrollOffset = listWindowOffset(Math.max(0, selected), count, maxItems)
   const visible = data.commands.slice(scrollOffset, scrollOffset + maxItems)
   const overflowAbove = scrollOffset
   const overflowBelow = count - scrollOffset - visible.length
 
   for (let i = 0; i < visible.length; i++) {
     const cmd = visible[i]!
-    const isSelected = scrollOffset + i === data.selectedIndex
+    const isSelected = scrollOffset + i === selected
     const prefix = isSelected
       ? color(CURSOR, theme.primary, { bold: true })
       : ' '

--- a/src/tui/format/overlay.ts
+++ b/src/tui/format/overlay.ts
@@ -324,17 +324,23 @@ export interface PaletteData {
   commands: PaletteCommand[]
   selectedIndex: number
   searchText?: string
+  /** Previous viewport start. ↑ moves the cursor inside the window;
+   *  the window only shifts when the selection would leave it. */
+  scrollOffset?: number
 }
 
 /**
- * Keep selectedIndex inside a viewport of maxVisible rows.
- * Stateless: once the selection leaves the first page it sits on the last
- * visible row (Codex ensure_selected_visible / slash-hint follow-selection).
+ * Keep `selected` inside a viewport of `maxVisible` rows, given the previous
+ * window start. Matches Codex `ensure_selected_visible`.
  */
-function listWindowOffset(selected: number, count: number, maxVisible: number): number {
+export function followListWindow(selected: number, count: number, maxVisible: number, scroll = 0): number {
   if (maxVisible <= 0 || count <= maxVisible) return 0
   const sel = Math.max(0, Math.min(selected, count - 1))
-  return Math.max(0, Math.min(sel - maxVisible + 1, count - maxVisible))
+  const maxScroll = count - maxVisible
+  let start = Math.max(0, Math.min(scroll, maxScroll))
+  if (sel < start) start = sel
+  else if (sel >= start + maxVisible) start = sel - maxVisible + 1
+  return Math.max(0, Math.min(start, maxScroll))
 }
 
 /**
@@ -353,7 +359,7 @@ export function renderCommandPalette(data: PaletteData, width: number, height: n
   const maxItems = Math.max(0, height - 5) // border + title + footer + border = 4; +1 safety
   const count = data.commands.length
   const selected = count === 0 ? -1 : Math.max(0, Math.min(data.selectedIndex, count - 1))
-  const scrollOffset = listWindowOffset(Math.max(0, selected), count, maxItems)
+  const scrollOffset = followListWindow(Math.max(0, selected), count, maxItems, data.scrollOffset ?? 0)
   const visible = data.commands.slice(scrollOffset, scrollOffset + maxItems)
   const overflowAbove = scrollOffset
   const overflowBelow = count - scrollOffset - visible.length

--- a/src/tui/format/overlay.ts
+++ b/src/tui/format/overlay.ts
@@ -327,6 +327,17 @@ export interface PaletteData {
 }
 
 /**
+ * Keep selectedIndex inside a viewport of maxVisible rows.
+ * Stateless: once the selection leaves the first page it sits on the last
+ * visible row (Codex ensure_selected_visible / slash-hint follow-selection).
+ */
+function listWindowOffset(selected: number, count: number, maxVisible: number): number {
+  if (maxVisible <= 0 || count <= maxVisible) return 0
+  const sel = Math.max(0, Math.min(selected, count - 1))
+  return Math.max(0, Math.min(sel - maxVisible + 1, count - maxVisible))
+}
+
+/**
  * 渲染 CommandPalette overlay（命令面板）。
  */
 export function renderCommandPalette(data: PaletteData, width: number, height: number, theme: RivetTheme): string[] {
@@ -340,11 +351,15 @@ export function renderCommandPalette(data: PaletteData, width: number, height: n
   lines.push(formatTitleLeft(title, width, theme))
 
   const maxItems = height - 5 // border + title + footer + border = 4; +1 safety
-  const visible = data.commands.slice(0, maxItems)
+  const count = data.commands.length
+  const scrollOffset = listWindowOffset(data.selectedIndex, count, maxItems)
+  const visible = data.commands.slice(scrollOffset, scrollOffset + maxItems)
+  const overflowAbove = scrollOffset
+  const overflowBelow = count - scrollOffset - visible.length
 
   for (let i = 0; i < visible.length; i++) {
     const cmd = visible[i]!
-    const isSelected = i === data.selectedIndex
+    const isSelected = scrollOffset + i === data.selectedIndex
     const prefix = isSelected
       ? color(CURSOR, theme.primary, { bold: true })
       : ' '
@@ -368,7 +383,10 @@ export function renderCommandPalette(data: PaletteData, width: number, height: n
     lines.push(padLine('', width, theme))
   }
 
-  lines.push(formatFooter(compactHints([['↑↓', '选择'], ['Enter', '执行'], ['Esc', '取消']]), width, theme, 'subtle'))
+  const hints: [string, string][] = [['↑↓', '选择'], ['Enter', '执行'], ['Esc', '取消']]
+  if (overflowAbove > 0) hints.unshift(['↑', String(overflowAbove)])
+  if (overflowBelow > 0) hints.push(['↓', String(overflowBelow)])
+  lines.push(formatFooter(compactHints(hints), width, theme, 'subtle'))
   lines.push(formatBottomBorder(width, theme, 'subtle'))
 
   return lines

--- a/src/tui/format/welcome.ts
+++ b/src/tui/format/welcome.ts
@@ -9,7 +9,7 @@
  *   │ deepseek-v4 · ◎high · auto-safe                                  │
  *   │ ~/app/deepseek-tui/opencode-tui · #7281                          │
  *   │                                                                  │
- *   │ /init 生成项目说明   /domain 切换星域   /help 全部命令 · ctrl+p   │
+ *   │ /init 生成项目说明   /domain 切换星域   /help 全部命令   ctrl+p 命令面板   │
  *   │ ⏜ /handoff 上下文 50%–70% 时交接给新会话                          │
  *   ╰──────────────────────────────────────────────────────────────────╯
  *
@@ -95,7 +95,8 @@ const DIPPER_BOWL = [
 const TIPS = [
   { cmd: '/init', desc: '生成项目说明' },
   { cmd: '/domain', desc: '切换星域' },
-  { cmd: '/help', desc: '全部命令 · ctrl+p 命令面板' },
+  { cmd: '/help', desc: '全部命令' },
+  { cmd: 'ctrl+p', desc: '命令面板' },
 ] as const
 
 function truncateToWidth(text: string, maxWidth: number): string {


### PR DESCRIPTION
## 摘要

Ctrl+P 命令面板在命令多于一屏时，选中项会滚出可视区但列表不跟着动。根因是渲染层永远 `slice(0, maxItems)`：全量 77 条里 `/resume` 恰好是下标 24，终端约 30 行时卡在最后一行，再按 ↓ 高亮消失。

同时首屏引导把 `ctrl+p` 写在 `/help` 的说明里，走 `theme.muted`，和 `/init` `/domain` 等 `theme.brandColor` 不一致。

## 改动

1. **视窗跟随选中项**（Codex `ensure_selected_visible`）
   - 光标在视口内移动；只有选中项要离开窗口时才滚动。
   - 记住 `paletteScroll`：↓ 越过底边滚一行；↑ 在视口内只移高亮，不把窗口弹回首页。
   - 循环到开头回到顶部，循环到末条钉在最后一页；过滤时复位滚动。
   - 越界 `selectedIndex` 夹到最后一项；空列表不画游标；Enter 执行前夹紧下标。
   - footer 在有溢出时显示 `↑:N` / `↓:N`。

2. **首屏 `ctrl+p` 独立成条并走 `brandColor`**
   - 从 `/help` 的说明里拆出 `ctrl+p 命令面板`，与斜杠命令同一套主题 token，换主题不会再变成灰色说明文字。

未改 slash 提示算法、Chronicle 等其它 overlay 的 `slice(0, max)`、以及「到底是否循环」的现有行为。

## 复现 / 验证

命令面板：
1. 打开 TUI，按 Ctrl+P。
2. 一直 ↓ 到可见列表底部的 `/resume`。
3. 再按 ↓：下一条应滚进视口，`>` 仍在选中行上。
4. 再按 ↑：高亮上移，窗口不应跳回第一页。
5. 从第一项再按 ↑：应绕到列表末尾。

首屏配色：
1. 新开会话看星阁引导行。
2. `ctrl+p` 应与 `/init` `/domain` `/help` 同一强调色（随主题变），「命令面板」四字仍是说明色。

## 测试

- `npx tsx --test src/tui/__tests__/format-overlay.test.ts src/tui/engine/__tests__/overlay-nav.test.ts src/tui/__tests__/format-welcome.test.ts` — 64/64 通过
- `npx tsx --test src/tui/engine/__tests__/palette-hotkey.test.ts` — 6/6 通过
- `npx tsx scripts/run-node-tests.ts src/tui` — 2452 通过 / 5 失败，失败均为 Windows 路径与审批基线（`mention-parser`、handoff 路径、`approval-key`），与本次改动无关