### PR TITLE
fix(tui): 排队消息在本轮结束后自动发出，并将 ⏳ 条钉在输入框上

### DIFF
--- a/src/tui/__tests__/esc-abort-steer-preserve.test.ts
+++ b/src/tui/__tests__/esc-abort-steer-preserve.test.ts
@@ -11,12 +11,12 @@ import { SteerBuffer } from '../steer-buffer.js'
 // and be consumed (once) only at the next tool-using turn.
 //
 // 补充（2026-08-08，ESC 回填）：用户主动 ESC 的 run settle 之后还有一个
-// 第二消费点——notifyRunSettled → backfillSteerToInput（输入框为空时把排队
-// 原文拉回输入框，Claude Code 风格）。它刻意用 getPendingEntries()+clear()
-// 而不是 drain()：drain 会把文本包进 [User guidance] 注入格式，回填要的是
-// 原文。这不违反上面的 peek-only 契约——契约锁的是 interrupt 路径本身
-// （abort 时 run 还活着，drain 会丢消息）；回填发生在 run 已 settle、队列
-// 再没有工具边界可 drain 之后，此时消费是唯一不丢消息的出路。
+// 第二消费点——notifyRunSettled → 自然结束 shift() 自动作为下一轮发出；
+// 用户主动 ESC 则 backfillSteerToInput（输入框为空时把排队原文拉回输入框）。
+// 两者都刻意不用 drain()：drain 会把文本包进 [User guidance] 注入格式，
+// 新 prompt / 回填要的是原文。这不违反上面的 peek-only 契约——契约锁的是
+// interrupt 路径本身（abort 时 run 还活着，drain 会丢消息）；消费发生在
+// run 已 settle、队列再没有工具边界可 drain 之后。
 describe('SteerBuffer: interrupt preserves messages (peek, not drain)', () => {
   it('getPending() returns queued messages WITHOUT emptying the buffer', () => {
     const buf = new SteerBuffer()

--- a/src/tui/__tests__/steer-buffer.test.ts
+++ b/src/tui/__tests__/steer-buffer.test.ts
@@ -199,4 +199,15 @@ describe('SteerBuffer', () => {
     assert.equal(e.intent, 'redirect')
     assert.equal(e.priority, 'next')
   })
+
+  it('shift 按 FIFO 取出原文，不包 [User guidance]', () => {
+    const buf = new SteerBuffer()
+    buf.push('note 1')
+    buf.push('note 2')
+    assert.equal(buf.shift(), 'note 1')
+    assert.deepEqual([...buf.getPending()], ['note 2'])
+    assert.equal(buf.shift(), 'note 2')
+    assert.equal(buf.shift(), null)
+    assert.equal(buf.hasPending(), false)
+  })
 })

--- a/src/tui/engine/__tests__/steer-queue-confirm.test.ts
+++ b/src/tui/engine/__tests__/steer-queue-confirm.test.ts
@@ -1,23 +1,24 @@
 /**
- * T9 steer 队列确认语义测试（问题1 回归）：
+ * T9 steer 队列语义：
  *
- * 契约（对齐 kimi-cli / codex：普通消息在 AI 输出期间只入队，turn 结束后交还用户）：
- *  1. 工具边界（onSteerDrain）不得注入普通排队消息（later 级）——消息保持排队，
- *     等待 run 结束后回填输入框、由用户再次 Enter 确认发送。
- *  2. 工具边界仍注入紧急意图（halt=now / redirect=next）——用户主动喊停/改方向
- *     的 steer 特性保留。
- *  3. run 正常结束（onTurnComplete isFinal → notifyRunSettled）后，队列残留
- *     回填输入框（⏮ 已把 N 条排队消息拉回输入框），steerBuffer 清空。
- *  4. 回填后用户再次按 Enter → 消息作为新 run 提交（onSubmit 收到）。
- *
- * RED 基线：修复前测试 1/3/4 失败（onSteerDrain 无过滤 drain 全部 + 正常结束不回填）。
+ * 契约（对齐 Claude Code：普通消息在 AI 输出期间只入队，本轮结束后自动作为下一轮发出）：
+ *  1. 工具边界（onSteerDrain）不得注入普通排队消息（later 级）——不混进当前轮的
+ *     [User guidance]，否则界面显示「已排队」实际已注入，是撒谎。
+ *  2. 工具边界仍注入紧急意图（halt=now / redirect=next）。
+ *  3. run 正常结束（onTurnComplete isFinal → notifyRunSettled）后，排队内容
+ *     自动作为新 run 发出，不回填输入框等用户再按 Enter。
+ *     agent.run() 的 finally 可能抢在 isFinal 的 await flush 之前到达，
+ *     仍须自动发出（不得因当时仍 busy 而吞掉队列）。
+ *  4. 支持多条 FIFO：先发第一条，其余留在队列；下一次 settle 再发下一条。
+ *  5. ESC 中断仍回填输入框（用户主动喊停，交还编辑权）。
+ *  6. ⏳ 已排队 条贴在输入框上方（chrome），不夹在 thinking 与工具卡之间随输出跑。
  */
 
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import type { ReadStream, WriteStream } from 'node:tty'
 import { TuiApp } from '../app.js'
-import { MockOut, MockIn, stripAnsi } from './_harness.js'
+import { MockOut, MockIn, stripAnsi, makeApp as makeHarnessApp } from './_harness.js'
 
 function makeApp() {
   const out = new MockOut()
@@ -32,28 +33,29 @@ function makeApp() {
 
 const tick = () => new Promise(r => setTimeout(r, 10))
 
+function lastFrameLines(out: { chunks: string[] }): string[] {
+  const last = out.chunks[out.chunks.length - 1] ?? ''
+  return stripAnsi(last).split('\n').filter(l => l.trim() !== '')
+}
+
 // ── 契约 1: 工具边界不注入普通排队消息 ─────────────────────────
 
 test('工具边界不注入普通排队消息：later 级消息保持排队', async () => {
   const { app, stdin } = makeApp()
   app.onSubmit(() => {})
 
-  // 发起第一个 run → agentBusy = true
   app.setInput('task A')
   stdin.dataHandler!('\r')
   await tick()
   assert.equal(app.busy, true, '前置：agentBusy 应为 true')
 
-  // AI 输出中提交普通消息 → 排队
   app.setInput('note during busy')
   stdin.dataHandler!('\r')
   await tick()
   assert.ok(app.steerBuffer.hasPending(), '前置：消息应在 steer buffer 中排队')
 
-  // 模拟工具边界（agent 回调触发 onSteerDrain）
   const drained = app.callbacks.onSteerDrain?.() ?? null
 
-  // 普通消息不得被注入（保持排队等 run 结束回填）
   assert.equal(drained, null, '普通排队消息不应被格式化为 [User guidance] 注入')
   assert.equal(app.steerBuffer.hasPending(), true, '普通排队消息应留在队列')
 })
@@ -68,7 +70,6 @@ test('工具边界仍注入紧急意图（halt/redirect 即时 steer 保留）',
   stdin.dataHandler!('\r')
   await tick()
 
-  // 用户喊停 → pushNow（halt 意图，优先级 now）
   app.steerBuffer.pushNow('停')
   assert.ok(app.steerBuffer.hasPending())
 
@@ -78,38 +79,125 @@ test('工具边界仍注入紧急意图（halt/redirect 即时 steer 保留）',
   assert.equal(app.steerBuffer.hasPending(), false, 'halt 注入后队列应清空')
 })
 
-// ── 契约 3: run 正常结束后队列回填输入框 ───────────────────────
+// ── 契约 3: run 正常结束后自动发出 ─────────────────────────────
 
-test('run 正常结束后：队列残留回填输入框，steerBuffer 清空', async () => {
+test('run 正常结束后：排队内容自动作为新 run 发出，不回填输入框', async () => {
   const { app, stdin } = makeApp()
-  app.onSubmit(() => {})
+  const runs: string[] = []
+  app.onSubmit((t) => { runs.push(t) })
 
-  // run A：busy 时排队一条普通消息
   app.setInput('task A')
   stdin.dataHandler!('\r')
   await tick()
-  app.setInput('note 1')
+  app.setInput('全权交由你负责！请你继续推进！')
   stdin.dataHandler!('\r')
   await tick()
   assert.ok(app.steerBuffer.hasPending(), '前置：消息应在 steer buffer 中排队')
 
-  // 结束 run A：isFinal → agentBusy 复位（main.ts 随后在 finally 调 notifyRunSettled）
   app.callbacks.onTurnComplete({ input_tokens: 100, output_tokens: 10 }, 1, true)
   await tick()
   assert.equal(app.busy, false, '前置：isFinal 后 agentBusy 应为 false')
   app.notifyRunSettled()
   await tick()
 
-  // 排队消息回填输入框，队列清空
-  assert.equal(app.getInputValue(), 'note 1', '排队消息应回填到输入框')
-  assert.equal(app.steerBuffer.hasPending(), false, '回填后 steerBuffer 应清空')
+  assert.equal(app.getInputValue(), '', '不应回填输入框')
+  assert.equal(app.steerBuffer.hasPending(), false, '发出后队列应清空')
+  assert.equal(runs.length, 2, '排队内容应自动发起新 run')
+  assert.equal(runs[1], '全权交由你负责！请你继续推进！')
   const sb = app.getScrollbackContent()
-  assert.ok(sb.includes('拉回输入框'), `scrollback 应有回填提示，实际: ${sb.slice(-200)}`)
+  assert.equal(sb.includes('拉回输入框'), false, '不应出现回填提示')
 })
 
-// ── 契约 4: 回填后再次 Enter 提交 ──────────────────────────────
+test('promise settle 抢在 isFinal flush 之前：仍自动发出，不回填', async () => {
+  const { app, stdin } = makeApp()
+  const runs: string[] = []
+  app.onSubmit((t) => { runs.push(t) })
 
-test('回填后再次 Enter：排队消息作为新 run 提交', async () => {
+  app.setInput('task A')
+  stdin.dataHandler!('\r')
+  await tick()
+  app.setInput('全权交由你负责！请你继续推进！')
+  stdin.dataHandler!('\r')
+  await tick()
+  assert.ok(app.steerBuffer.hasPending())
+
+  // 生产顺序：onTurnComplete(isFinal) 先 await flush（仍 busy），
+  // agent.run() finally 立刻 notifyRunSettled。
+  app.callbacks.onTurnComplete({ input_tokens: 100, output_tokens: 10 }, 1, true)
+  app.notifyRunSettled()
+  await tick()
+
+  assert.equal(app.getInputValue(), '', '不应回填输入框')
+  assert.equal(app.steerBuffer.hasPending(), false, '发出后队列应清空')
+  assert.equal(runs.length, 2, 'finally 抢跑时排队内容仍应自动发出')
+  assert.equal(runs[1], '全权交由你负责！请你继续推进！')
+})
+
+// ── 契约 4: 多条 FIFO ──────────────────────────────────────────
+
+test('多条排队 FIFO：settle 先发第一条，其余留队等下一轮 settle', async () => {
+  const { app, stdin } = makeApp()
+  const runs: string[] = []
+  app.onSubmit((t) => { runs.push(t) })
+
+  app.setInput('task A')
+  stdin.dataHandler!('\r')
+  await tick()
+  app.setInput('note 1')
+  stdin.dataHandler!('\r')
+  await tick()
+  app.setInput('note 2')
+  stdin.dataHandler!('\r')
+  await tick()
+  assert.equal(app.steerBuffer.getPending().length, 2)
+
+  app.callbacks.onTurnComplete({ input_tokens: 10, output_tokens: 1 }, 1, true)
+  await tick()
+  app.notifyRunSettled()
+  await tick()
+
+  assert.equal(runs[1], 'note 1', '先发第一条')
+  assert.deepEqual([...app.steerBuffer.getPending()], ['note 2'], '第二条留队')
+  assert.equal(app.busy, true, '自动发出后应进入新 run')
+
+  app.callbacks.onTurnComplete({ input_tokens: 10, output_tokens: 1 }, 2, true)
+  await tick()
+  app.notifyRunSettled()
+  await tick()
+
+  assert.equal(runs[2], 'note 2', '下一轮 settle 再发第二条')
+  assert.equal(app.steerBuffer.hasPending(), false)
+})
+
+// ── 契约 5: ESC 仍回填 ─────────────────────────────────────────
+
+test('ESC abort settle：队列回填输入框，不自动发出', async () => {
+  const { app, stdin } = makeApp()
+  const runs: string[] = []
+  app.onSubmit((t) => { runs.push(t) })
+  let agentRunning = false
+  app.setAgentRunningProbe(() => agentRunning)
+
+  app.setInput('task A')
+  stdin.dataHandler!('\r')
+  await tick()
+  agentRunning = true
+  app.setInput('note 1')
+  stdin.dataHandler!('\r')
+  await tick()
+
+  app.callbacks.onAbort()
+  await tick()
+  agentRunning = false
+  app.notifyRunSettled()
+  await tick()
+
+  assert.equal(runs.length, 1, 'ESC 后不应自动发出排队内容')
+  assert.equal(app.getInputValue(), 'note 1', '应回填输入框交还编辑')
+  assert.equal(app.steerBuffer.hasPending(), false)
+})
+
+test('自然结束时输入框有草稿：不自动发出，队列保留', async () => {
   const { app, stdin } = makeApp()
   const runs: string[] = []
   app.onSubmit((t) => { runs.push(t) })
@@ -121,19 +209,58 @@ test('回填后再次 Enter：排队消息作为新 run 提交', async () => {
   stdin.dataHandler!('\r')
   await tick()
 
-  // 结束 run A → 回填
-  app.callbacks.onTurnComplete({ input_tokens: 100, output_tokens: 10 }, 1, true)
+  app.setInput('草稿')
+  app.callbacks.onTurnComplete({ input_tokens: 10, output_tokens: 1 }, 1, true)
   await tick()
   app.notifyRunSettled()
   await tick()
-  assert.equal(app.getInputValue(), 'note 1', '前置：回填已完成')
 
-  // 用户再次 Enter
+  assert.equal(runs.length, 1, '有草稿时不自动发出')
+  assert.equal(app.getInputValue(), '草稿')
+  assert.deepEqual([...app.steerBuffer.getPending()], ['note 1'])
+})
+
+// ── 契约 6: banner 贴输入框 ─────────────────────────────────────
+
+test('⏳ 已排队条贴在输入框上方，不夹在 thinking 与工具卡之间', async () => {
+  const { app, out, stdin } = makeHarnessApp({ cols: 80, rows: 24 })
+  app.onSubmit(() => {})
+
+  app.setInput('task A')
   stdin.dataHandler!('\r')
   await tick()
+  app.callbacks.onThinkingDelta('思考中：分析代码结构。\n')
+  await tick()
+  app.setInput('全权交由你负责！请你继续推进！')
+  stdin.dataHandler!('\r')
+  await tick()
+  app.setInput('第二条排队')
+  stdin.dataHandler!('\r')
+  await tick()
+  app.callbacks.onToolUse('t1', 'apply_edit', { path: 'src/a.ts', replacement: 'foo' })
+  await tick()
 
-  assert.equal(runs.length, 2, '回填内容应作为新 run 提交')
-  assert.equal(runs[1], 'note 1', '提交内容应为排队消息')
-  const sb = app.getScrollbackContent()
-  assert.ok(stripAnsi(sb).includes('note 1'), 'scrollback 应包含回填消息气泡')
+  const lines = lastFrameLines(out)
+  const bannerIdx = lines.findIndex(l => l.includes('已排队'))
+  const toolIdx = lines.findIndex(l => /(?:^|\s)-\s*Tool\b|apply_edit|src\/a\.ts/.test(l))
+  const topIdx = lines.findIndex(l => /^[╭┌]/.test(l))
+  assert.ok(bannerIdx >= 0, `应渲染已排队条，帧: ${lines.join(' | ')}`)
+  assert.ok(toolIdx >= 0, `应渲染工具卡，帧: ${lines.join(' | ')}`)
+  assert.ok(topIdx >= 0, `应有输入框顶边，帧: ${lines.join(' | ')}`)
+  assert.ok(bannerIdx < topIdx, '已排队条应在输入框上方')
+  assert.ok(
+    lines[bannerIdx]!.includes('全权交由你负责'),
+    `预览应是 FIFO 下一条（第一条），帧: ${lines[bannerIdx]}`,
+  )
+  assert.ok(lines[bannerIdx]!.includes('+1'), `多条应显示 +N，帧: ${lines[bannerIdx]}`)
+  if (toolIdx >= 0) {
+    assert.ok(
+      bannerIdx > toolIdx,
+      `已排队条不应夹在工具卡之上（banner=${bannerIdx} tool=${toolIdx}）：${lines.join(' | ')}`,
+    )
+  }
+  assert.ok(
+    topIdx - bannerIdx <= 3,
+    `已排队条应贴着输入框（gap=${topIdx - bannerIdx}）：${lines.join(' | ')}`,
+  )
 })

--- a/src/tui/engine/app.ts
+++ b/src/tui/engine/app.ts
@@ -480,12 +480,19 @@ export class TuiApp {
   /**
    * ESC 回填资格：仅用户主动中断（ESC/Ctrl+C，非 watchdog/convergence 守护）
    * 开启的收尾窗口才置位。settle 时若 steer 队列仍有排队指引且输入框为空，
-   * 把排队内容拉回输入框交还用户（Claude Code 风格，见 notifyRunSettled）。
+   * 把排队内容拉回输入框交还用户（仅用户主动 ESC；自然结束走自动发出）。
    */
   private abortSteerBackfill = false
   /** 守护中断（watchdog/convergence）pending 标志：settle 时消费，用于区分
    *  「run 自然结束」与「守护中断自动续跑」——后者不回填排队队列。 */
   private guardianAbortPending = false
+  /**
+   * handleTurnComplete 在飞计数。isFinal 先 await flush，agent.run() 的 finally
+   * 会抢先 notifyRunSettled；此时不能立刻开新 run，否则会冲掉尚未 finalize 的
+   * writer。settle 只置 pendingQueueDispatch，等 complete 收尾后再发出。
+   */
+  private turnCompleteInFlight = 0
+  private pendingQueueDispatch = false
   /**
    * 查询 agent 是否仍有未 settle 的 run（main.ts 注入 → `ctx.agent.isRunning()`）。
    *
@@ -1390,10 +1397,8 @@ export class TuiApp {
       },
       onIntentNote: (intent) => this.handleIntentNote(intent),
       onAutonomyCheckpoint: (info) => this.handleAutonomyCheckpoint(info),
-      // 工具边界只注入紧急意图（halt=now / redirect=next）：普通消息（later：
-      // guidance/question/augment/ack）留在队列等 run 结束后回填输入框、由用户
-      // 再次 Enter 确认发送——与「⏳ 已排队」文案一致（此前无过滤 drain 会把
-      // 排队中的普通消息自动注入给 AI，界面显示排队、实际已发出，是撒谎）。
+      // 工具边界只注入紧急意图（halt=now / redirect=next）：普通消息（later）
+      // 留在队列，等本轮结束后自动作为下一轮发出——不混进当前轮 [User guidance]。
       onSteerDrain: () => this.steerBuffer.drain('next'),
       onDelegationActivity: (activity) => this.handleDelegationActivity(activity),
     }
@@ -1702,17 +1707,14 @@ export class TuiApp {
     const pending = this.pendingSubmitAfterAbort
     if (!pending) {
       // 无补发消息的 settle：
-      //  - 用户主动 ESC 的收尾回填（Claude Code 风格）；
-      //  - run 自然结束（isFinal 已复位 busy）同样回填——AI 输出期间排队的普通
-      //    消息不再在工具边界自动注入（onSteerDrain 只 drain 紧急意图），run
-      //    结束即交还用户确认（再次 Enter 发送），与 ESC 路径同语义；
-      //  - 守护中断（watchdog/convergence）自动续跑：guardian 时不回填，队列
-      //    保留等续跑 run 结束后的 settle 再回填，或下次提交归并。
-      // 有补发消息时新 run 即将发起，队列随它在工具边界 drain，不动。
+      //  - 用户主动 ESC：回填输入框交还编辑（不自动发出）；
+      //  - run 自然结束：排队内容自动作为下一轮发出（Claude Code 队列）；
+      //  - 守护中断（watchdog/convergence）自动续跑：不消费队列。
       if (backfill) {
         this.backfillSteerToInput()
-      } else if (!guardian && !this.agentBusy) {
-        this.backfillSteerToInput()
+      } else if (!guardian) {
+        this.pendingQueueDispatch = true
+        this.flushPendingQueueDispatch()
       }
       return
     }
@@ -1730,8 +1732,7 @@ export class TuiApp {
   }
 
   /**
-   * ESC settle 回填（Claude Code 风格）：run 已终结，steer 队列再没有活跃
-   * run 能在工具边界 drain 它——把排队指引按序拼回输入框，交还用户改发/重发。
+   * ESC settle：run 已终结，把排队指引按序拼回输入框，交还用户改发/重发。
    * 输入框已有草稿则不动（不抢用户正在敲的内容），队列留待下次提交归并。
    * 消费用 getPendingEntries()+clear() 而非 drain()：drain 会把文本包进
    * [User guidance] 注入格式，这里要的是原文（契约见 esc-abort-steer-preserve 测试）。
@@ -1749,6 +1750,36 @@ export class TuiApp {
       })
       this.state.committedCount++
     })
+    this.renderLive()
+  }
+
+  /**
+   * 自然结束 settle：把队列头部一条作为新 run 发出（气泡在入队时已 commit）。
+   * 多条 FIFO 留在 buffer，等这一轮再 settle。输入框有草稿则不动，避免抢输入。
+   *
+   * 必须等 handleTurnComplete 收尾且 TUI 已 idle：isFinal 的 await flush
+   * 与 agent.run() finally 存在竞态，中途开新 run 会冲掉 writer/renderer。
+   */
+  private flushPendingQueueDispatch(): void {
+    if (!this.pendingQueueDispatch) return
+    if (this.turnCompleteInFlight > 0) return
+    if (this.agentBusy) return
+    this.pendingQueueDispatch = false
+    this.dispatchQueuedAfterSettle()
+  }
+
+  private dispatchQueuedAfterSettle(): void {
+    if (this.inputLine.value.trim().length > 0) return
+    const text = this.steerBuffer.shift()
+    if (!text) return
+    this.blockWriter.discard()
+    this.streamRenderer.reset()
+    this.streamRenderController.assistantHeaderDone = false
+    this.agentBusy = true
+    this.todosWrittenThisRun = false
+    this.state.turnStartMs = Date.now()
+    this.streamRenderController.lastActivityMs = Date.now()
+    this.onSubmitCallback?.(text)
     this.renderLive()
   }
 
@@ -5201,6 +5232,8 @@ export class TuiApp {
   }
 
   private async handleTurnComplete(usage: Partial<Usage>, turnNumber: number, isFinal: boolean): Promise<void> {
+    this.turnCompleteInFlight++
+    try {
     this.state.turnNumber = turnNumber
 
     // A completed turn (even intermediate) is forward progress: the stream
@@ -5280,6 +5313,10 @@ export class TuiApp {
       this.setPhase('waiting')
       this.writeBatcher.flushNow()
     }
+    } finally {
+      this.turnCompleteInFlight--
+      this.flushPendingQueueDispatch()
+    }
   }
 
   /**
@@ -5330,6 +5367,7 @@ export class TuiApp {
         trailingNewline: true,
       })
     })
+    this.flushPendingQueueDispatch()
   }
 
   /**
@@ -5990,25 +6028,7 @@ export class TuiApp {
       lines.push({ text: line })
     }
 
-    // 2b. 队列预览：⏳ 已排队: "最后一条前 60 字符"（↑ 取回编辑）。
-    //     全宽反色条（CC 对标）：排队 prompt 是「已提交但未生效」的用户输入，
-    //     单行 muted 提示存在感不足，容易被误认为已丢失。
-    //
-    //     「已排队」只在真有活跃 run 时才成立——steer 队列靠工具边界 drain，没有
-    //     活跃 run 就永远注入不了。此时仍显示「已排队」是界面在撒谎，用户会以为
-    //     消息已送达而一直等。无 run 时如实说它还没发出，并给出可操作的下一步。
-    if (this.steerBuffer.hasPending()) {
-      const pending = this.steerBuffer.getPending()
-      const last = pending[pending.length - 1]!
-      const preview = last.length > 60 ? `${last.slice(0, 60)}…` : last
-      const more = pending.length > 1 ? `（+${pending.length - 1} 条）` : ''
-      const deliverable = this.agentBusy && !this.isAgentRunSettling()
-      lines.push({
-        text: this.clampLine(deliverable
-          ? this.renderBanner(`⏳ 已排队: "${preview}"${more} · ↑ 取回编辑`, this.theme.secondary)
-          : this.renderBanner(`⏸ 未发出: "${preview}"${more} · 回车随下条一并发送 · ↑ 取回编辑`, this.theme.warning)),
-      })
-    }
+    // 2b. 队列预览已下移到输入框 chrome（贴底，不夹在 thinking/工具卡之间）。
 
     // 2b2. 活动源归一：fleet / council / team / todo 四源投影到 ActivityStore，
     //      经 formatActivityBand 输出 chrome 段统一 band（替代之前散落三处的 push）。
@@ -6464,6 +6484,21 @@ export class TuiApp {
           lines.push({ text: this.clampLine(`${marker}${name}`) })
         }
         lines.push({ text: this.clampLine(color('tab to cycle', this.theme.dim)) })
+      }
+
+      // ⏳ 已排队：贴在输入框顶边正上方（chrome），不放进动态段——否则会夹在
+      // thinking / 工具卡之间随输出上漂。多条时 footer 显示 +N。
+      if (this.steerBuffer.hasPending()) {
+        const next = this.steerBuffer.getPendingEntries()[0]!
+        const pendingCount = this.steerBuffer.getPending().length
+        const preview = next.text.length > 60 ? `${next.text.slice(0, 60)}…` : next.text
+        const more = pendingCount > 1 ? `（+${pendingCount - 1} 条）` : ''
+        const deliverable = this.agentBusy && !this.isAgentRunSettling()
+        lines.push({
+          text: this.clampLine(deliverable
+            ? this.renderBanner(`⏳ 已排队: "${preview}"${more} · ↑ 取回编辑`, this.theme.secondary)
+            : this.renderBanner(`⏸ 未发出: "${preview}"${more} · 将在本轮结束后自动发出 · ↑ 取回编辑`, this.theme.warning)),
+        })
       }
 
       // 输入框：chrome 段最后一行（滚动到底时贴屏幕底部，Claude Code 风格）。

--- a/src/tui/steer-buffer.ts
+++ b/src/tui/steer-buffer.ts
@@ -171,6 +171,18 @@ export class SteerBuffer {
     return entry?.text ?? null
   }
 
+  /**
+   * 取出队列头部一条的原文（drain 序：优先级再 FIFO），不包 [User guidance]。
+   * 给 run 结束后自动发出下一条用——drain() 的注入格式不能当新 prompt。
+   */
+  shift(): string | null {
+    if (this.pending.length === 0) return null
+    const first = this.sorted()[0]!
+    this.pending = this.pending.filter(entry => entry.id !== first.id)
+    this.notify()
+    return first.text
+  }
+
   /** Take back the most recently queued message (Up-arrow recall). */
   popLast(): string | null {
     if (this.pending.length === 0) return null


### PR DESCRIPTION
## 摘要
- 上一轮结束后，`⏳ 已排队` 的内容会自动作为下一轮发出，不再拉回输入框等用户再按 Enter。
- 支持多条排队：按 FIFO 每次 settle 只发一条，其余留队等下一轮。
- `⏳ 已排队` 从动态输出区挪到输入框正上方（chrome），不再夹在 thinking / 工具卡之间随输出上漂。
- ESC 仍回填输入框交还编辑；输入框有草稿时不自动发出，避免抢输入。
- 覆盖 `agent.run()` finally 抢在 isFinal flush 之前到达的生产竞态。

## 测试计划
- [x] `src/tui/engine/__tests__/steer-queue-confirm.test.ts`（含 FIFO、ESC 回填、草稿拦截、banner 位置、settle 竞态）
- [x] `src/tui/__tests__/steer-buffer.test.ts`（`shift()` 原文 FIFO）
- [x] 相关 steer / queue-lane / abort-resubmit / input-bottom-line 回归
- [ ] 实机：busy 时 Enter 排队 → 等本轮结束应自动开新 run；多条应逐条发；banner 应贴在输入框上方不随工具卡移动；ESC 仍拉回输入框
