### PR TITLE
feat: 修复会话 Auto 路由并新增星域漂移检测

### DIFF
--- a/src/agent/__tests__/domain-drift-detector.test.ts
+++ b/src/agent/__tests__/domain-drift-detector.test.ts
@@ -1,0 +1,56 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import { DomainDriftDetector } from '../domain-drift-detector.js'
+
+describe('DomainDriftDetector', () => {
+  test('one winning keyword suggests an alternative domain immediately', () => {
+    const detector = new DomainDriftDetector('tianliang')
+
+    const drift = detector.evaluate('请审查')
+
+    assert.equal(drift?.currentId, 'tianliang')
+    assert.equal(drift?.recommendedId, 'tianquan')
+    assert.deepEqual(drift?.matchedKeywords, ['审查'])
+  })
+
+  test('returns winning keywords up to the payload cap', () => {
+    const detector = new DomainDriftDetector('tianliang')
+
+    const drift = detector.evaluate('请审查评估这个架构方案并权衡取舍')
+
+    assert.equal(drift?.recommendedId, 'tianquan')
+    assert.deepEqual(drift?.matchedKeywords, ['审查', '评估', '权衡', '取舍'])
+  })
+
+  test('current-domain winner does not suggest drift', () => {
+    const detector = new DomainDriftDetector('tianliang')
+
+    assert.equal(detector.evaluate('继续实现和交付'), null)
+  })
+
+  test('no keyword match does not suggest drift', () => {
+    const detector = new DomainDriftDetector('tianliang')
+
+    assert.equal(detector.evaluate('继续看看'), null)
+  })
+
+  test('a top-score tie does not suggest drift', () => {
+    const detector = new DomainDriftDetector('tianliang')
+
+    assert.equal(detector.evaluate('审查验证'), null)
+  })
+
+  test('suggests each current-to-recommended direction at most once', () => {
+    const detector = new DomainDriftDetector('tianliang')
+
+    assert.equal(detector.evaluate('审查')?.recommendedId, 'tianquan')
+    assert.equal(detector.evaluate('方案'), null)
+  })
+
+  test('can suggest a different direction after an earlier suggestion', () => {
+    const detector = new DomainDriftDetector('tianliang')
+
+    assert.equal(detector.evaluate('审查')?.recommendedId, 'tianquan')
+    assert.equal(detector.evaluate('验证')?.recommendedId, 'yaoguang')
+  })
+})

--- a/src/agent/__tests__/domain-resolved.test.ts
+++ b/src/agent/__tests__/domain-resolved.test.ts
@@ -10,6 +10,7 @@ import { ToolRegistry } from '../../tools/registry.js'
 import type { StreamCallbacks, StreamClient } from '../../api/stream-client.js'
 import type { ContentBlock } from '../../api/types.js'
 import type { AgentCallbacks } from '../loop-types.js'
+import type { DomainDriftResult } from '../domain-drift-detector.js'
 
 const TEST_CWD = mkdtempSync(join(tmpdir(), 'rivet-domain-resolved-'))
 
@@ -28,6 +29,7 @@ function makeObservedAgent(
   options: { defaultDomain: string; domainKeywordRouting?: boolean },
 ): {
   agent: AgentLoop
+  session: SessionContext
   callbacks: AgentCallbacks
   resolutions: ObservedDomainResolution[]
 } {
@@ -38,6 +40,7 @@ function makeObservedAgent(
       cb.onStopReason('end_turn', { input_tokens: 100, output_tokens: 50 })
     }),
   } as unknown as StreamClient
+  const session = new SessionContext()
   const agent = new AgentLoop({
     client,
     promptEngine: new PromptEngine({
@@ -55,7 +58,7 @@ function makeObservedAgent(
       : { domainKeywordRouting: options.domainKeywordRouting }),
     fsWatcherEnabled: false,
     compact: { enabled: false, autoThreshold: 800_000, autoFloor: 500_000, model: 'flash' },
-  }, new SessionContext(), TEST_CWD)
+  }, session, TEST_CWD)
   const resolutions: ObservedDomainResolution[] = []
   const callbacks: AgentCallbacks = {
     onTextDelta: () => {},
@@ -68,7 +71,7 @@ function makeObservedAgent(
     onApprovalRequired: async () => false,
     onDomainResolved: (resolution: ObservedDomainResolution) => { resolutions.push(resolution) },
   }
-  return { agent, callbacks, resolutions }
+  return { agent, session, callbacks, resolutions }
 }
 
 async function observeDomainResolution(
@@ -126,6 +129,35 @@ test('explicitly pinned domains do not emit an Auto resolution', async () => {
   assert.deepEqual(resolutions, [])
 })
 
+test('explicit session Auto overrides a pinned persistent default', () => {
+  const { agent, callbacks, resolutions } = makeObservedAgent({
+    defaultDomain: 'qiming',
+    domainKeywordRouting: true,
+  })
+
+  agent.resetSessionDomain()
+  agent.bindSessionDomain('请实现一个用户注册的功能，用很短很短的代码就行。', callbacks)
+
+  assert.equal(agent.getSessionDomain()?.id, 'tianliang')
+  assert.equal(agent.domainWasAutoResolved, true)
+  assert.ok(agent.driftDetector)
+  assert.equal(resolutions.at(0)?.key, 'tianliang')
+})
+
+test('an untouched session still follows its persistent default', () => {
+  const { agent, callbacks, resolutions } = makeObservedAgent({
+    defaultDomain: 'qiming',
+    domainKeywordRouting: true,
+  })
+
+  agent.bindSessionDomain('请实现一个用户注册的功能', callbacks)
+
+  assert.equal(agent.getSessionDomain()?.id, 'qiming')
+  assert.equal(agent.domainWasAutoResolved, false)
+  assert.equal(agent.driftDetector, null)
+  assert.deepEqual(resolutions, [])
+})
+
 test('the same AgentLoop emits at most once across consecutive domain binds', () => {
   const { agent, callbacks, resolutions } = makeObservedAgent({
     defaultDomain: 'auto',
@@ -136,6 +168,69 @@ test('the same AgentLoop emits at most once across consecutive domain binds', ()
 
   assert.equal(resolutions.length, 1)
   assert.equal(resolutions[0]!.key, 'kaiyang')
+  assert.equal(agent.domainWasAutoResolved, true)
+  assert.ok(agent.driftDetector)
+})
+
+test('manual domain selection disables drift detection', () => {
+  const { agent, callbacks } = makeObservedAgent({
+    defaultDomain: 'auto',
+    domainKeywordRouting: true,
+  })
+  agent.bindSessionDomain('按计划实现用户注册', callbacks)
+  assert.equal(agent.domainWasAutoResolved, true)
+
+  const domain = agent.getSessionDomain()
+  assert.ok(domain)
+  agent.setSessionDomain(domain)
+
+  assert.equal(agent.domainWasAutoResolved, false)
+  assert.equal(agent.driftDetector, null)
+})
+
+test('restoring a persisted Auto resolution keeps drift detection active', () => {
+  const { agent, callbacks } = makeObservedAgent({
+    defaultDomain: 'auto',
+    domainKeywordRouting: true,
+  })
+  agent.bindSessionDomain('请实现一个用户注册功能', callbacks)
+  const domain = agent.getSessionDomain()
+  assert.ok(domain)
+
+  agent.setSessionDomain(domain)
+  agent.restoreAutoResolvedDomain(domain)
+
+  assert.equal(agent.getSessionDomain()?.id, 'tianliang')
+  assert.equal(agent.domainWasAutoResolved, true)
+  assert.ok(agent.driftDetector)
+})
+
+test('Auto drift emits on one uniquely winning later turn and keeps the active domain', async () => {
+  const { agent, session, callbacks } = makeObservedAgent({
+    defaultDomain: 'qiming',
+    domainKeywordRouting: true,
+  })
+  const drifts: DomainDriftResult[] = []
+  callbacks.onDomainDrift = (drift) => { drifts.push(drift) }
+
+  agent.resetSessionDomain()
+  await agent.run('请实现一个用户注册的功能，用很短很短的代码就行。', callbacks)
+  assert.equal(agent.getSessionDomain()?.id, 'tianliang')
+  assert.equal(agent.domainWasAutoResolved, true)
+  assert.ok(agent.driftDetector)
+
+  await agent.run('请审查评估这个方案', callbacks)
+  assert.equal(drifts.length, 1)
+  const drift = drifts.at(0)
+  assert.ok(drift)
+  assert.equal(drift.recommendedId, 'tianquan')
+  assert.equal(agent.getSessionDomain()?.id, 'tianliang')
+  assert.equal(JSON.stringify(session.getMessages()).includes('星域漂移'), false)
+
+  // Same direction is session-deduplicated even when it wins again.
+  await agent.run('继续审查', callbacks)
+  assert.equal(drifts.length, 1)
+  assert.equal(agent.getSessionDomain()?.id, 'tianliang')
 })
 
 test('STAR_SOUL=0 does not emit a resolved domain', { concurrency: false }, () => {

--- a/src/agent/__tests__/event-tap.test.ts
+++ b/src/agent/__tests__/event-tap.test.ts
@@ -314,6 +314,26 @@ describe('event-tap — 可选回调不被凭空具现', () => {
     assert.equal(tap.onPhaseChange, undefined)
     assert.equal(tap.onDelegationActivity, undefined)
     assert.equal(tap.onIntentNote, undefined)
+    assert.equal(tap.onDomainDrift, undefined)
+  })
+
+  test('domain drift 只在内层定义时投影为同名事件', () => {
+    const seen: string[] = []
+    const { tap, rec } = harness({
+      onDomainDrift: (drift) => { seen.push(drift.recommendedId) },
+    })
+
+    tap.onDomainDrift!({
+      currentId: 'tianliang',
+      currentName: '天梁',
+      recommendedId: 'tianquan',
+      recommendedName: '天权',
+      matchedKeywords: ['审查', '方案'],
+    })
+
+    assert.deepEqual(seen, ['tianquan'])
+    assert.equal(at(rec, 0).type, 'domain_drift')
+    assert.equal(at(rec, 0).data.recommendedId, 'tianquan')
   })
 
   test('内层定义了才包裹，并发出对应事件', () => {

--- a/src/agent/create-agent-config.ts
+++ b/src/agent/create-agent-config.ts
@@ -62,7 +62,8 @@ export interface AgentConfigInput {
   crossSessionEnabled?: boolean
   /** Session Auto keyword routing; default true（auto 池内匹配，未命中回退天权）. */
   domainKeywordRouting?: boolean
-  /** 默认星域（qiming | … | auto）。非 auto 时 bindSessionDomain 首次钉定，auto 时走关键词路由。 */
+  /** 默认星域（qiming | … | auto）。未作会话选择时非 auto 默认首次钉定；
+   * 默认或会话选择为 Auto 时走关键词路由。 */
   defaultDomain?: string
   goalJudge?: { enabled?: boolean; maxRuns?: number; browser?: boolean }
   auth?: AuthProvider

--- a/src/agent/domain-drift-detector.ts
+++ b/src/agent/domain-drift-detector.ts
@@ -1,0 +1,54 @@
+import { DOMAIN_AUTO_POOL, type StarDomainId } from './star-domain.js'
+import { starDomainRegistry } from './star-domain-registry.js'
+
+export interface DomainDriftResult {
+  recommendedId: StarDomainId
+  recommendedName: string
+  currentId: StarDomainId
+  currentName: string
+  matchedKeywords: string[]
+}
+
+/**
+ * Tracks intent drift for one Auto-resolved session. Detection is
+ * observational only: it never changes the active domain or prompt state.
+ */
+export class DomainDriftDetector {
+  private readonly suggested = new Set<string>()
+
+  constructor(private readonly currentDomainId: StarDomainId) {}
+
+  /**
+   * Suggest immediately when another Auto-pool domain uniquely wins with at
+   * least one keyword. Repeated suggestions for the same direction are muted.
+   */
+  evaluate(userMessage: string): DomainDriftResult | null {
+    const detail = starDomainRegistry.matchDomainDetailed(userMessage, DOMAIN_AUTO_POOL)
+
+    if (
+      detail.verdict !== 'hit' ||
+      detail.id === null ||
+      detail.id === this.currentDomainId ||
+      detail.matchedKeywords.length < 1
+    ) {
+      return null
+    }
+
+    const matchedId = detail.id as StarDomainId
+    const suggestionKey = `${this.currentDomainId}->${matchedId}`
+    if (this.suggested.has(suggestionKey)) return null
+
+    const recommended = starDomainRegistry.get(matchedId)
+    const current = starDomainRegistry.get(this.currentDomainId)
+    if (!recommended || !current) return null
+
+    this.suggested.add(suggestionKey)
+    return {
+      recommendedId: matchedId,
+      recommendedName: recommended.name,
+      currentId: this.currentDomainId,
+      currentName: current.name,
+      matchedKeywords: detail.matchedKeywords.slice(0, 4),
+    }
+  }
+}

--- a/src/agent/event-tap.ts
+++ b/src/agent/event-tap.ts
@@ -154,6 +154,13 @@ export function tapAgentCallbacks(
       fn(shift)
     }
   }
+  if (inner.onDomainDrift) {
+    const fn = inner.onDomainDrift.bind(inner)
+    tapped.onDomainDrift = (drift) => {
+      emit('domain_drift', redactValue(drift) as Record<string, unknown>)
+      fn(drift)
+    }
+  }
   if (inner.onDelegationActivity) {
     const fn = inner.onDelegationActivity.bind(inner)
     // 投影与 session-manager.appendDelegation 逐字段对齐（含 workerId/parentId

--- a/src/agent/loop-types.ts
+++ b/src/agent/loop-types.ts
@@ -22,6 +22,7 @@ import type { IntentPreview } from './intent-preview.js'
 import type { DomainKnowledgeStore } from './domain-knowledge-store.js'
 import type { DelegationActivity } from '../tools/types.js'
 import type { EvidenceSummary } from './evidence.js'
+import type { DomainDriftResult } from './domain-drift-detector.js'
 
 export type ApprovalMode = 'auto-accept' | 'auto-safe' | 'manual' | 'dangerously-skip-permissions'
 
@@ -171,7 +172,8 @@ export interface AgentConfig {
    *  收敛检测以 v2 状态为准；缺省回退 v1（EvidenceState 推导）。 */
   deliveryGateV2?: (currentDirtyFiles?: string[]) => import('./delivery-gate-v2.js').DeliveryGateResult
   /**
-   * 会话 Auto 是否按消息关键词匹配换域（仅 defaultDomain='auto' 时生效）。
+   * 会话 Auto 是否按消息关键词匹配换域（defaultDomain='auto' 或当前会话
+   * 显式选择 Auto 时生效）。
    * 默认 true：按首条消息在 auto 池（DOMAIN_AUTO_POOL 四个均衡工程域 +
    * 自定义域）内 matchDomain，未命中回退天权。显式 false 时 Auto 固定落到
    * DEFAULT_DOMAIN（天权）。
@@ -340,6 +342,8 @@ export interface AgentCallbacks {
   onPhaseChange?: (phase: string, detail?: { tool?: string; reason?: string; suggestion?: string; voluntary?: boolean; source?: string }) => void
   /** Auto session domain resolved at the first bind; observability only. */
   onDomainResolved?: (payload: DomainResolvedPayload) => void
+  /** Auto domain drift is user-facing observability only; it never changes model state. */
+  onDomainDrift?: (drift: DomainDriftResult) => void
   /** R4 — structured course-correction signal surfaced to the desktop conversation. */
   onDecisionShift?: (shift: DecisionShift) => void
   /**

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -62,6 +62,7 @@ import { ContextInjectionController } from './context-injection.js'
 import { CompactionController } from './compaction-controller.js'
 import { resolveActiveDomain, type ActiveStarDomain, type StarDomainId } from './star-domain.js'
 import { starDomainRegistry } from './star-domain-registry.js'
+import { DomainDriftDetector } from './domain-drift-detector.js'
 import { buildDomainKnowledgeBlock } from './domain-knowledge-block.js'
 import { mintNumericId, buildAgentMark, VOID_SYMBOL } from './void-identity.js'
 import { buildDepartureMilestone } from '../constellation/milestone.js'
@@ -282,6 +283,12 @@ export class AgentLoop {
   lastConflictCheckCount = 0
   predictionAccumulator: PredictionAccumulator = createPredictionAccumulator()
   sessionDomain: ActiveStarDomain | null | undefined
+  /** Distinguishes an untouched session from an explicit per-session Auto
+   * selection while both still expose `sessionDomain === undefined` before
+   * the first bind. */
+  private sessionDomainSelection: 'default' | 'auto' | 'manual' = 'default'
+  private _domainWasAutoResolved = false
+  private _driftDetector: DomainDriftDetector | null = null
   /** Agent's self-chosen departure mark (leave_mark tool); sealed by the
    *  constellation post-session hook. Null until the agent leaves a mark. */
   pendingLeaveMark: import('../tools/types.js').LeaveMarkInput | null = null
@@ -1164,10 +1171,10 @@ export class AgentLoop {
 
   bindSessionDomain(taskDescription: string, callbacks?: AgentCallbacks): void {
     if (this.sessionDomain !== undefined) return
-    // 首次绑定前检查 defaultDomain 配置——非 auto 时钉定，让所有入口
-    //（TUI/headless/server/外部）统一在此钉定，不再依赖入口层各显神通。
+    // 未作会话级选择时才消费持久 defaultDomain。显式 Auto 同样以
+    // sessionDomain=undefined 等待首条任务，但必须越过这里进入关键词路由。
     const starSoulEnabled = isStarSoulEnabled()
-    if (starSoulEnabled) {
+    if (starSoulEnabled && this.sessionDomainSelection !== 'auto') {
       const key = this.config.defaultDomain ?? 'qiming'
       if (key !== 'auto') {
         const pinned = starDomainRegistry.get(key) ?? starDomainRegistry.get('qiming')
@@ -1188,13 +1195,16 @@ export class AgentLoop {
     // domainKeywordRouting 默认 true：Auto 按消息在 DOMAIN_AUTO_POOL（四个均衡
     // 工程域 + 自定义域）内 matchDomain，未命中回退天权（DEFAULT_DOMAIN）；
     // 显式 false 时固定落到 DEFAULT_DOMAIN。池外特化域（含华盖）仅手动/钉定/
-    // 委派进入。仅 defaultDomain='auto' 的会话走到这里，其余已被钉定。
+    // 委派进入。defaultDomain='auto' 或会话显式 Auto 走到这里，其余已钉定。
     const resolution = starSoulEnabled
       ? resolveActiveDomain(taskDescription, {
           keywordRouting: this.config.domainKeywordRouting !== false,
         })
       : null
     this.sessionDomain = resolution?.domain ?? null
+    this._domainWasAutoResolved = resolution !== null
+    this._driftDetector = resolution ? new DomainDriftDetector(resolution.domain.id) : null
+    if (resolution) this.sessionDomainSelection = 'auto'
     this.config.promptEngine.setActiveDomain(this.withDomainKnowledge(this.sessionDomain))
     this.persistSessionDomain()
     if (resolution) {
@@ -1534,13 +1544,17 @@ export class AgentLoop {
     return 'task'
   }
 
-  /** Get the currently active star domain (null = no domain, undefined = not yet resolved). */
+  /** Get the active domain (null = disabled/unavailable, undefined = not yet
+   * resolved, including an explicit Auto selection waiting for its next task). */
   getSessionDomain(): ActiveStarDomain | null | undefined {
     return this.sessionDomain
   }
 
   /** Manually set the active star domain. Pass null to disable, or a valid ActiveStarDomain. */
   setSessionDomain(domain: ActiveStarDomain | null): void {
+    this.sessionDomainSelection = 'manual'
+    this._domainWasAutoResolved = false
+    this._driftDetector = null
     this.sessionDomain = domain
     this.config.promptEngine.setActiveDomain(this.withDomainKnowledge(domain))
     this.persistSessionDomain()
@@ -1548,8 +1562,23 @@ export class AgentLoop {
 
   /** Reset domain to undefined so the next run() will auto-detect from user input. */
   resetSessionDomain(): void {
+    this.sessionDomainSelection = 'auto'
+    this._domainWasAutoResolved = false
+    this._driftDetector = null
     this.sessionDomain = undefined
     this.config.promptEngine.setActiveDomain(undefined)
+    this.persistSessionDomain()
+  }
+
+  /** Restore a previously resolved Auto session without re-routing or
+   * re-emitting onDomainResolved. Unlike manual selection, drift observation
+   * remains active for subsequent turns. */
+  restoreAutoResolvedDomain(domain: ActiveStarDomain): void {
+    this.sessionDomainSelection = 'auto'
+    this._domainWasAutoResolved = true
+    this._driftDetector = new DomainDriftDetector(domain.id)
+    this.sessionDomain = domain
+    this.config.promptEngine.setActiveDomain(this.withDomainKnowledge(domain))
     this.persistSessionDomain()
   }
 
@@ -1560,6 +1589,14 @@ export class AgentLoop {
    */
   getSessionTurnCount(): number {
     return this.session.getTurnCount()
+  }
+
+  get domainWasAutoResolved(): boolean {
+    return this._domainWasAutoResolved
+  }
+
+  get driftDetector(): DomainDriftDetector | null {
+    return this._driftDetector
   }
 
   /**

--- a/src/agent/turn-step-producer.ts
+++ b/src/agent/turn-step-producer.ts
@@ -274,6 +274,14 @@ export class TurnStepProducer {
     }
 
     this.self.bindSessionDomain(userInput, callbacks)
+    if (
+      this.self.domainWasAutoResolved &&
+      this.self.getSessionTurnCount() > 0 &&
+      this.self.driftDetector
+    ) {
+      const drift = this.self.driftDetector.evaluate(userInput)
+      if (drift) callbacks.onDomainDrift?.(drift)
+    }
     this.self.contextInjection.recordUserInputClaims(userInput)
     this.self.contextInjection.refreshPlaybookLessons(userInput)
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -380,7 +380,8 @@ export const agentSchema = z.object({
    * 格式校验在 setDefaultModelConfig 层完成（需要校验 provider + model 存在性）。 */
   defaultModel: z.string().optional(),
   /**
-   * 会话 Auto 星域是否按消息关键词匹配换域（仅 defaultDomain='auto' 时生效）。
+   * 会话 Auto 星域是否按消息关键词匹配换域（defaultDomain='auto' 或当前
+   * 会话显式选择 Auto 时生效）。
    * 默认 true：Auto 按首条消息在 auto 池（天权/开阳/瑶光/天梁 + 自定义域）
    * 内 matchDomain，未命中回退 DEFAULT_DOMAIN（天权）。池外特化域（含华盖）
    * 经 defaultDomain 钉定或 /domain 手工切换进入。显式 false 时 Auto 固定落到

--- a/src/main.ts
+++ b/src/main.ts
@@ -52,6 +52,7 @@ import { readFileSync, statSync } from 'node:fs'
 import { join as pathJoin } from 'node:path'
 import { formatWelcome } from './tui/format/welcome.js'
 import { HANDOFF_NUDGE_RATIO, formatHandoffNudge } from './tui/handoff.js'
+import { formatDomainDriftNudge } from './tui/domain-drift-nudge.js'
 import { color } from './tui/engine/ansi.js'
 import type { RewindMode } from './tui/format/rewind.js'
 import { buildDisconnectEntries, toChoiceEntries, buildConfirmTitle, buildDisconnectImpactText, buildPostDeleteMessage, buildRetargetEntries, toRetargetChoiceEntries, buildRetargetTitle, type DisconnectEntry, type PostDeleteRuntimeOutcome } from './tui/disconnect-flow.js'
@@ -1967,7 +1968,9 @@ async function main() {
     // 判定空闲时触发（busy 时输入已被 TuiApp 入队 steerBuffer），故此处无需再自管
     // isStreaming 标志——正是「双门异步清除时机不同」造成 Esc 后死会话的根因。
     // run 生命周期回调（完成/错误/中止）由 bridge 桥接到 TuiApp，并带世代守卫。
-    const base = wrapCallbacksWithTuiApp(app!)
+    const base = wrapCallbacksWithTuiApp(app!, {
+      onDomainDrift: (drift) => app!.commitStatic(formatDomainDriftNudge(drift)),
+    })
     // The tap wraps the OUTSIDE of the bridge rather than riding its `original`
     // parameter: bridge.ts lets `original.onApprovalRequired` *replace* the
     // app's handler (bridge.ts:77-80), so passing an observer in there would

--- a/src/server/__tests__/session-manager.test.ts
+++ b/src/server/__tests__/session-manager.test.ts
@@ -219,6 +219,29 @@ test('domain resolution callback appends a redacted replayable event', () => {
   assert.equal(manager.getSession(s.id)!.domain, 'auto', 'observability must not replace the Auto selection key')
 })
 
+test('domain drift callback appends a redacted replayable SSE event', () => {
+  const { manager, agents } = makeManager()
+  const s = manager.createSession({ prompt: 'go', domain: 'auto' })
+
+  agents[0]!.callbacks!.onDomainDrift!({
+    currentId: 'tianliang',
+    currentName: '天梁 token=current-secret',
+    recommendedId: 'tianquan',
+    recommendedName: '天权 token=recommended-secret',
+    matchedKeywords: ['审查', 'token=keyword-secret', '方案', '评估', '不得保留'],
+  })
+
+  const event = manager.getEvents(s.id, 0)!.events.find((candidate) => candidate.type === 'domain_drift')
+  assert.ok(event)
+  assert.deepEqual(event.data, {
+    currentId: 'tianliang',
+    currentName: '天梁 token=[REDACTED]',
+    recommendedId: 'tianquan',
+    recommendedName: '天权 token=[REDACTED]',
+    matchedKeywords: ['审查', 'token=[REDACTED]', '方案', '评估'],
+  })
+})
+
 // Redaction now lives ONLY here (the legacy /prompt route forwards manager
 // events verbatim since its session rebase) — this is the single trust boundary
 // keeping secrets out of event logs and every SSE stream.
@@ -915,6 +938,8 @@ class PlusFakeAgent implements ManagedAgent {
   domain: ActiveStarDomain | null | undefined = undefined
   disabled = new Set<string>()
   model = 'model-a'
+  resetDomainCalls = 0
+  restoredAutoDomainCalls = 0
   private resolveRun?: () => void
   run(_p: string, cb: AgentCallbacks): Promise<void> { this.callbacks = cb; return new Promise<void>((r) => { this.resolveRun = r }) }
   finish(): void { this.resolveRun?.() }
@@ -925,7 +950,8 @@ class PlusFakeAgent implements ManagedAgent {
   replaceMessages(m: OaiMessage[]): void { this.messages = m }
   rewindToMessages(m: OaiMessage[]): void { this.messages = m }
   setSessionDomain(d: ActiveStarDomain | null): void { this.domain = d }
-  resetSessionDomain(): void { this.domain = undefined }
+  resetSessionDomain(): void { this.resetDomainCalls++; this.domain = undefined }
+  restoreAutoResolvedDomain(d: ActiveStarDomain): void { this.restoredAutoDomainCalls++; this.domain = d }
   getSessionDomain(): ActiveStarDomain | null | undefined { return this.domain }
   setDisabledSkills(names: Set<string>): void { this.disabled = new Set(names) }
   switchModel(modelId: string): string | null {
@@ -1002,6 +1028,16 @@ test('PlusMenu: domain selection applies to a lazily-built agent', async () => {
   assert.equal(agents[0]!.domain?.id, 'tianshu')
 })
 
+test('PlusMenu: explicit Auto is replayed to a lazily-built agent', async () => {
+  const { manager, agents } = makePlusManager()
+  const s = manager.createSession({ domain: 'auto' })
+
+  manager.run(s.id, '请实现、交付、编写并测试一个用户注册功能')
+
+  assert.equal(agents[0]!.resetDomainCalls, 1)
+  assert.equal(agents[0]!.domain, undefined)
+})
+
 test('Auto resolution survives agent rebuild without a second domain_resolved event', async () => {
   const agents: AutoResolvingFakeAgent[] = []
   const saved: SessionRecord[] = []
@@ -1043,6 +1079,7 @@ test('Auto resolution survives agent rebuild without a second domain_resolved ev
   assert.equal(manager.run(session.id, '重建后的新消息'), true)
 
   assert.equal(agents[1]!.domain?.id, 'kaiyang', 'rebuild must restore the first resolved domain')
+  assert.equal(agents[1]!.restoredAutoDomainCalls, 1, 'rebuild must retain Auto lifecycle semantics')
   assert.equal(
     manager.getEvents(session.id, 0)!.events.filter((event) => event.type === 'domain_resolved').length,
     1,

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -93,6 +93,7 @@ export type SessionEventType =
   | 'model_switched'
   | 'domain_changed'
   | 'domain_resolved'
+  | 'domain_drift'
   | 'skills_changed'
   // I4 — user-defined .rivet/hooks.json script results.
   | 'hook_result'

--- a/src/server/serve-agent.ts
+++ b/src/server/serve-agent.ts
@@ -768,6 +768,7 @@ export function buildManagedAgent(
     // PlusMenu — star domain (delegate to the live agent).
     setSessionDomain: (domain) => agent.setSessionDomain(domain),
     resetSessionDomain: () => agent.resetSessionDomain(),
+    restoreAutoResolvedDomain: (domain) => agent.restoreAutoResolvedDomain(domain),
     getSessionDomain: () => agent.getSessionDomain(),
     // PlusMenu — skills (per-session discovery filter on the live agent).
     setDisabledSkills: (names) => agent.setDisabledSkills(names),

--- a/src/server/session-manager.ts
+++ b/src/server/session-manager.ts
@@ -364,6 +364,8 @@ export interface ManagedAgent {
   setSessionDomain?(domain: ActiveStarDomain | null): void
   /** PlusMenu (domain) — reset to Auto (next run auto-detects from input). */
   resetSessionDomain?(): void
+  /** Restore a persisted Auto resolution while retaining drift observation. */
+  restoreAutoResolvedDomain?(domain: ActiveStarDomain): void
   /** PlusMenu (domain) — read the current selection (Auto when undefined). */
   getSessionDomain?(): ActiveStarDomain | null | undefined
   /**
@@ -2646,8 +2648,9 @@ export class RuntimeSessionManager {
    * Re-apply the session's PlusMenu selections (star domain, disabled skills) to
    * its live agent. Idempotent — called both after a lazy build (ensureAgent)
    * and after a model rebuild (switchModel) so the selections survive a fresh
-   * AgentLoop. A domainState of undefined means Auto → leave the agent's own
-   * auto-detection untouched.
+   * AgentLoop. A domainState of undefined means an explicit session Auto and
+   * must be replayed: a fresh AgentLoop otherwise mistakes it for "unselected"
+   * and re-applies its persistent defaultDomain.
    */
   private applySelections(session: InternalSession): void {
     const agent = session.agent
@@ -2660,9 +2663,18 @@ export class RuntimeSessionManager {
     try {
       if (session.domainState === null) agent.setSessionDomain?.(null)
       else if (session.domainState !== undefined) agent.setSessionDomain?.(session.domainState)
-      else if (session.record.domain === 'auto' && session.record.resolvedDomain) {
-        const restored = resolveDomainState(session.record.resolvedDomain.key)
-        if (restored?.state) agent.setSessionDomain?.(restored.state)
+      else if (session.record.domain === 'auto') {
+        if (session.record.resolvedDomain) {
+          const restored = resolveDomainState(session.record.resolvedDomain.key)
+          if (restored?.state) {
+            if (agent.restoreAutoResolvedDomain) agent.restoreAutoResolvedDomain(restored.state)
+            else agent.setSessionDomain?.(restored.state)
+          } else {
+            agent.resetSessionDomain?.()
+          }
+        } else {
+          agent.resetSessionDomain?.()
+        }
       }
     } catch { /* non-fatal */ }
     try {
@@ -4840,6 +4852,18 @@ export class RuntimeSessionManager {
         }
         this.append(session, 'domain_resolved', { ...eventPayload })
         this.persistRecord(session)
+      },
+      onDomainDrift: (drift) => {
+        if (!isActive()) return
+        this.append(session, 'domain_drift', {
+          currentId: redactText(drift.currentId),
+          currentName: truncateUtf16Safe(redactText(drift.currentName), 160),
+          recommendedId: redactText(drift.recommendedId),
+          recommendedName: truncateUtf16Safe(redactText(drift.recommendedName), 160),
+          matchedKeywords: drift.matchedKeywords
+            .slice(0, 4)
+            .map((keyword) => truncateUtf16Safe(redactText(keyword), 80)),
+        })
       },
       onTextDelta: (text) => {
         if (!isActive()) return

--- a/src/tui/__tests__/domain-drift-nudge.test.ts
+++ b/src/tui/__tests__/domain-drift-nudge.test.ts
@@ -1,0 +1,19 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { formatDomainDriftNudge } from '../domain-drift-nudge.js'
+
+test('domain drift nudge explains cache safety and the handoff path', () => {
+  const message = formatDomainDriftNudge({
+    currentId: 'tianliang',
+    currentName: '天梁',
+    recommendedId: 'tianquan',
+    recommendedName: '天权',
+    matchedKeywords: ['审查', '方案'],
+  })
+
+  assert.match(message, /从「天梁」转为「天权」/)
+  assert.match(message, /当前会话保持不变/)
+  assert.match(message, /重建前缀缓存/)
+  assert.match(message, /\/handoff/)
+  assert.match(message, /新开会话/)
+})

--- a/src/tui/domain-drift-nudge.ts
+++ b/src/tui/domain-drift-nudge.ts
@@ -1,0 +1,10 @@
+import type { DomainDriftResult } from '../agent/domain-drift-detector.js'
+
+/** User-visible only; callers must keep this out of the model message history. */
+export function formatDomainDriftNudge(drift: DomainDriftResult): string {
+  return (
+    `⚡ 检测到任务重心可能已从「${drift.currentName}」转为「${drift.recommendedName}」方向。` +
+    '当前会话保持不变（会话内切换星域会重建前缀缓存）。' +
+    `建议先 /handoff 写交接摘要，再新开会话选择 Auto 或 ${drift.recommendedName}。`
+  )
+}

--- a/src/tui/engine/app.ts
+++ b/src/tui/engine/app.ts
@@ -307,6 +307,7 @@ import { describeIntentNote } from '../../agent/intent-preview.js'
 import type { ApprovalResult } from '../../agent/approval-edit.js'
 import type { DelegationActivity } from '../../tools/types.js'
 import type { AutonomyCheckpointInfo } from '../../agent/loop-types.js'
+import type { DomainDriftResult } from '../../agent/domain-drift-detector.js'
 import { FleetRegistry } from '../fleet-registry.js'
 import { JobRegistry, type JobRow } from '../job-registry.js'
 import { renderJobsOverlay } from '../format/jobs-panel.js'
@@ -333,6 +334,7 @@ export interface AgentCallbacks {
   onCheckpoint?: (hash: string) => void
   onPhaseChange?: (phase: string, detail?: { tool?: string; reason?: string; voluntary?: boolean; source?: string }) => void
   onIntentNote?: (intent: IntentPreview) => void
+  onDomainDrift?: (drift: DomainDriftResult) => void
   onSteerDrain?: () => string | null
   /** C3 — autonomy checkpoint pause (cruise) / progress ping (unleashed). */
   onAutonomyCheckpoint?: (info: AutonomyCheckpointInfo) => void

--- a/src/tui/engine/bridge.ts
+++ b/src/tui/engine/bridge.ts
@@ -89,6 +89,10 @@ export function wrapCallbacksWithTuiApp(
       app.callbacks.onPhaseChange?.(phase, detail)
       original.onPhaseChange?.(phase, detail)
     },
+    onDomainDrift: (drift) => {
+      if (!live()) return
+      original.onDomainDrift?.(drift)
+    },
     onIntentNote: (intent) => {
       // 迟到的旧 run 方向提示 → 丢弃，不为已死的 run 追加时间线卡片。
       if (!live()) return


### PR DESCRIPTION
## Summary

本 PR 包含两项 Auto 星域改进：修复会话级 Auto 接线问题，并新增 Auto 星域漂移检测功能。

### 1. 修复会话级 Auto 选择被默认星域覆盖

此前，即使用户在当前会话中明确选择了 Auto，下一条消息仍可能重新读取持久配置中的 `defaultDomain`，导致 Auto 被启明等默认星域覆盖，实际没有进入关键词路由。

根因是此前 undefined 同时表示“会话尚未选择星域”和“用户已明确选择 Auto”。resetSessionDomain() 选择 Auto 后会将会话星域设为 undefined，但下一条消息进入 bindSessionDomain() 时，系统无法判断这是显式 Auto，因而再次读取持久化的 defaultDomain。当默认值为 qiming 时，会话便被重新固定到启明，Auto 关键词路由及后续漂移检测都不会启动。

本次修复后：

- 当前会话明确选择 Auto 时，优先执行 Auto 关键词路由
- 未手动选择 Auto 的普通新会话，仍遵循持久默认星域
- 区分未作选择、显式 Auto 和手动星域三种会话状态
- Agent 恢复或重建后，保留已解析的 Auto 星域及其漂移检测能力
- 手动选择具体星域后，停止 Auto 漂移检测

### 2. 新增 Auto 星域漂移检测

Auto 会根据首条任务消息选择一个星域，并在当前会话中保持固定。但随着多轮对话推进，用户的主要任务方向可能发生变化。

例如，首轮任务是“实现并测试一个功能”，Auto 选择天梁；后续任务变为“审查并评估方案”时，天权可能更适合当前方向。

为了避免在会话中直接切换星域并重建前缀缓存，本次增加了用户可见的漂移提示。

检测规则：

- 仅对 Auto 解析的会话生效
- 从第二轮用户消息开始检测
- 只扫描消息前 500 个字符
- 在天权、开阳、瑶光、天梁四个 Auto 内置域中进行关键词计分
- 每命中一个不同关键词加 1 分
- 当另一星域至少命中一个关键词并唯一最高分时，立即提示
- 最高分平手、无关键词命中或当前星域胜出时不提示
- 同一漂移方向每个会话只提示一次，不同方向可分别提示

该功能只提供用户可见建议：

- 不自动切换当前星域
- 不修改模型消息历史
- 不改变当前提示词前缀
- 不触发前缀缓存重建
- 建议用户先执行 `/handoff`，再新开会话选择 Auto 或推荐星域

## TUI 效果

下图展示了 Auto 首轮选择天梁后，后续审查任务触发“天梁 → 天权”漂移提示的实际效果。提示出现后，当前会话仍保持天梁，不会在会话内自动切换到天权。

目前，星域漂移检测仅在用户选择 Auto 时生效。对于默认或手动选择的具体星域，系统视为用户已经明确任务意图，因此不会进行漂移检测或提示。后续如果有需要，也可以进一步扩展规则，让非 Auto 星域支持可选的漂移检测。

<img width="1226" height="662" alt="Auto 星域漂移提示：天梁 → 天权" src="https://github.com/user-attachments/assets/7747de21-ac5b-4d44-80ae-527f7baa435b" />

## Tests

新增和补充的测试覆盖：

- 当前会话显式 Auto 覆盖持久默认星域
- 未显式选择 Auto 的新会话继续遵循持久默认
- 首次 Auto 关键词路由结果正确
- Agent 重建后恢复 Auto 解析结果和漂移检测状态
- 单个关键词唯一胜出即可提示
- 最高分平手、无关键词命中或当前域胜出时不提示
- 同一漂移方向只提示一次，不同方向可以分别提示
- 手动切换星域后停止检测
- 漂移提示不进入模型消息历史
- `domain_drift` SSE 事件可以回放并正确脱敏
- TUI 提示包含缓存影响说明和 `/handoff` 建议

## Verification

- Auto/Domain 聚焦回归：25/25 通过
- 相关单元与集成测试：44/44 通过
- `npm run typecheck:direct`：通过
- `npm run build:bundle`：通过
- pre-push TypeScript 检查：通过
- `git diff --check`：通过

## Scope

当前漂移检测只比较天权、开阳、瑶光、天梁四个内置 Auto 星域，暂不根据漂移消息推荐自定义星域。
