### PR TITLE
chore: .gitignore 加 .env/.env.*/!.env.example 防护（安全：API key 永不进 git）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,3 +155,8 @@ src/**/__tests__/.undo-test-backup/
 
 # 公开仓：禁止 knowledge 回灌（私有仓策略不同；仅保留 .rivet/SELF）
 .rivet/knowledge/
+
+# 密钥与本地环境（安全：env 值即使写入 .env 也永不进 git；secrets.json 由 secrets-store 管理）
+.env
+.env.*
+!.env.example


### PR DESCRIPTION
## 变更

`.gitignore` 追加：

```
# 密钥与本地环境（安全：env 值即使写入 .env 也永不进 git；secrets.json 由 secrets-store 管理）
.env
.env.*
!.env.example
```

## 动机

- serve 模型 API key 当前经 env 注入（DEEPSEEK_API_KEY），进程层隔离安全。
- 但 `.gitignore` 原无 `.env` 条目——若未来有人把 key 写进 `.env` 文件（常见做法），会被 git 跟踪泄露。
- 补 `.env` 防护 = 双保险：env 进程隔离 + 文件级 ignore。

## 验证

- `touch .env && git check-ignore .env` → 返回 `.env`（被忽略）✓
- 假 .env 已删除；无实际 key 涉及。

## 协作

- 改动走 PR（Dual-Repo sync-merge 规范）；不碰 Protected Zone。