### PR TITLE
cache: add a real, all-in billed-hit-rate regression gate

### DIFF
--- a/src/cache/__fixtures__/regression-session.cache-log.jsonl
+++ b/src/cache/__fixtures__/regression-session.cache-log.jsonl
@@ -1,0 +1,10 @@
+{"t":1700000000000,"turn":1,"model":"deepseek-v4-pro","provider":"deepseek","input":10000,"cacheRead":9000,"cacheCreate":1000,"output":500,"hitRate":"90.0%"}
+{"t":1700000001000,"turn":2,"model":"deepseek-v4-pro","provider":"deepseek","input":10000,"cacheRead":9000,"cacheCreate":1000,"output":500,"hitRate":"90.0%"}
+{"t":1700000002000,"turn":3,"model":"deepseek-v4-pro","provider":"deepseek","input":10000,"cacheRead":9000,"cacheCreate":1000,"output":500,"hitRate":"90.0%"}
+{"t":1700000003000,"turn":4,"model":"deepseek-v4-pro","provider":"deepseek","input":10000,"cacheRead":9000,"cacheCreate":1000,"output":500,"hitRate":"90.0%"}
+{"t":1700000004000,"turn":5,"model":"deepseek-v4-pro","provider":"deepseek","input":10000,"cacheRead":9000,"cacheCreate":1000,"output":500,"hitRate":"90.0%"}
+{"t":1700000005000,"turn":6,"model":"deepseek-v4-pro","provider":"deepseek","input":10000,"cacheRead":9000,"cacheCreate":1000,"output":500,"hitRate":"90.0%"}
+{"event":"side_path","kind":"llm-speculation","t":1700000006500,"model":"deepseek-v4-pro","provider":"deepseek","input":8000,"cacheRead":800,"cacheCreate":0,"output":100,"hitRate":"10.0%"}
+{"event":"side_path","kind":"compact-summary","t":1700000007000,"model":"deepseek-v4-pro","provider":"deepseek","input":8000,"cacheRead":800,"cacheCreate":0,"output":300,"hitRate":"10.0%"}
+{"event":"side_path","kind":"llm-speculation","t":1700000007500,"model":"deepseek-v4-pro","provider":"deepseek","input":8000,"cacheRead":800,"cacheCreate":0,"output":100,"hitRate":"10.0%"}
+{"event":"reclaim_decision","t":1700000008000,"turn":6,"action":"compact","commit":false,"reason":"below_threshold","force":false,"windowBand":"mid","billing":0,"cache":0,"beforeTokens":10000,"afterTokens":10000,"reclaimedTokens":0,"reclaimRatio":0}

--- a/src/cache/__tests__/billed-hit-rate-regression.test.ts
+++ b/src/cache/__tests__/billed-hit-rate-regression.test.ts
@@ -1,0 +1,53 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { join, dirname } from 'node:path'
+import { parseUsageRows, aggregateUsageRows } from '../usage-aggregator.js'
+import { computeBilledHitRate } from '../billed-hit-rate.js'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const fixture = readFileSync(join(here, '..', '__fixtures__', 'regression-session.cache-log.jsonl'), 'utf8')
+
+/**
+ * Regression gate for the exact blind spot documented in this file's own
+ * header comment (see usage-aggregator.ts): side-path requests are real
+ * billing that the self-reported `hitRate` excludes by design. This fixture
+ * is a fixed, checked-in multi-turn session — 6 main rows at a 90% hit rate,
+ * 3 side-path rows (speculation + compaction) at a 10% hit rate — so the
+ * self-reported/billed gap it should produce is known and stable. If a
+ * future change to parsing or aggregation silently stops accounting for
+ * side-path consumption (or starts folding it into the main-row quotient,
+ * or drops it from `input`/`cacheRead` sums), one of the two assertions
+ * below goes red, instead of the drift being invisible until a bill shows up.
+ */
+describe('billed vs self-reported hit rate regression', () => {
+  it('self-reported hitRate (main rows only) matches this fixture\'s known baseline', () => {
+    const rows = parseUsageRows(fixture)
+    const { totals } = aggregateUsageRows(rows, { days: 36500 })
+    assert.equal(totals.hitRate, 90)
+    assert.equal(totals.requests, 6)
+    assert.equal(totals.sidePathRequests, 3)
+  })
+
+  it('billed hitRate (every row) is measurably lower than self-reported, not silently equal to it', () => {
+    const rows = parseUsageRows(fixture)
+    const billed = computeBilledHitRate(rows)
+    assert.equal(billed.hitRate, 67.1)
+    assert.equal(billed.requests, 6)
+    assert.equal(billed.sidePathRequests, 3)
+
+    const { totals } = aggregateUsageRows(rows, { days: 36500 })
+    const selfReported = totals.hitRate ?? 0
+    const gap = selfReported - (billed.hitRate ?? 0)
+    // The known gap for this fixture is ~22.9 points. Assert it stays large
+    // rather than pinning the exact float, so harmless rounding changes
+    // elsewhere don't make this test flaky for no reason.
+    assert.ok(gap > 15, `expected self-reported to exceed billed by >15pp on this fixture, got ${gap.toFixed(1)}pp`)
+  })
+
+  it('the non-usage reclaim_decision row in this fixture is ignored, not counted as a request', () => {
+    const rows = parseUsageRows(fixture)
+    assert.equal(rows.length, 9) // 6 main + 3 side_path; the reclaim_decision row carries no usage and is dropped
+  })
+})

--- a/src/cache/billed-hit-rate.ts
+++ b/src/cache/billed-hit-rate.ts
@@ -1,0 +1,49 @@
+/**
+ * Real, all-in billed cache hit rate — Σ cacheRead / Σ input across EVERY
+ * request the provider actually charged for, side-path rows included.
+ *
+ * `usage-aggregator.ts`'s own `hitRate` (see `UsageTotals.hitRate` and its
+ * doc comment) is computed over main rows only, by design — that's the
+ * right number for "is our own turn-taking cache-efficient", and this file
+ * does not change it. But it means a regression that quietly starts
+ * generating a lot of side-path traffic (speculation retries, oversized
+ * compaction summaries) at a poor hit rate is invisible to that metric:
+ * cost goes up, `hitRate` doesn't move. `computeBilledHitRate` is the
+ * complementary number — the one that actually reflects the bill — kept as
+ * a separate function rather than changed in place so nothing depends on
+ * `UsageTotals.hitRate`'s existing meaning being touched.
+ */
+import type { CacheUsageRow } from './usage-aggregator.js'
+
+export interface BilledHitRateResult {
+  /** Σ cacheRead / Σ input over every row, percent 0-100; null when there's no input at all. */
+  hitRate: number | null
+  input: number
+  cacheRead: number
+  /** main-row count */
+  requests: number
+  /** side_path-row count (speculation / compaction / other side-path kinds) */
+  sidePathRequests: number
+}
+
+export function computeBilledHitRate(rows: readonly CacheUsageRow[]): BilledHitRateResult {
+  let input = 0
+  let cacheRead = 0
+  let requests = 0
+  let sidePathRequests = 0
+
+  for (const row of rows) {
+    input += row.input
+    cacheRead += row.cacheRead
+    if (row.sidePath) sidePathRequests += 1
+    else requests += 1
+  }
+
+  return {
+    hitRate: input > 0 ? Math.round((cacheRead / input) * 1000) / 10 : null,
+    input,
+    cacheRead,
+    requests,
+    sidePathRequests,
+  }
+}


### PR DESCRIPTION
## Summary

`usage-aggregator.ts`'s own `hitRate` is main-rows-only by design — its own header comment says so explicitly:

> `event:'side_path'` rows are real billing (speculation / compaction) and count toward consumption, but are excluded from the hit-rate quotient

That's the right number for "is our own turn-taking cache-efficient", and this PR doesn't change it. But it means a regression that quietly starts generating a lot of side-path traffic (speculation retries, oversized compaction summaries), or a regression that drops side-path accounting entirely, is invisible to that metric — cost goes up, `hitRate` doesn't move, and nothing in CI notices. `cache-audit.ts`'s existing check (`npm run cache:audit`) doesn't help either — it's a static per-file path risk table (`findingFor()`), with no runtime data behind it at all.

This PR adds the missing piece, as a small, additive complement:

- `src/cache/billed-hit-rate.ts` — `computeBilledHitRate()`, Σ cacheRead / Σ input across **every** `CacheUsageRow` (main and side-path alike), reusing the existing `CacheUsageRow` type. `usage-aggregator.ts` itself is untouched.
- `src/cache/__fixtures__/regression-session.cache-log.jsonl` — a fixed, checked-in 10-line multi-turn session: 6 main rows at a 90% hit rate, 3 side-path rows (`llm-speculation` + `compact-summary`) at a 10% hit rate, plus one non-usage `reclaim_decision` row that should be ignored.
- `src/cache/__tests__/billed-hit-rate-regression.test.ts` — asserts the fixture's self-reported hit rate (90%), its billed hit rate (67.1%), and that the gap between them stays large (>15pp) — so a future change that silently stops accounting for side-path consumption, or folds it into the main quotient, goes red instead of nothing noticing.

## Test plan

- [x] `npx tsx --test src/cache/__tests__/billed-hit-rate-regression.test.ts` — 3/3 pass
- [x] `npx tsx --test src/cache/__tests__/usage-aggregator.test.ts src/cache/__tests__/cache-audit.test.ts src/cache/__tests__/billed-hit-rate-regression.test.ts` — 23/23 pass, confirming nothing existing broke
- [ ] A full monorepo `npm install`/`tsc --noEmit` was not run (native deps like better-sqlite3/tree-sitter wasm make that heavy to run unattended); the two new files only import from `usage-aggregator.ts` and `node:*`, so CI's own full build is the right place to catch anything this narrower check missed.