### PR TITLE
fix(api): stop sustained DeepSeek reasoning short-line loops

### DIFF
--- a/docs/deepseek-reasoning-repetition.md
+++ b/docs/deepseek-reasoning-repetition.md
@@ -1,0 +1,79 @@
+# DeepSeek reasoning short-line loops
+
+## Symptom and evidence
+
+The CLI can remain in thinking mode while its omitted-line counter reaches tens
+of thousands and its tail cycles through phrases such as `好。`, `好，我发送。`
+and `（发送）`.
+
+`formatThinking()` derives that counter from the accumulated reasoning text; it
+does not increment it on redraw. The API parser appends each
+`delta.reasoning_content` once. Repeated phrases have also been observed in
+persisted reasoning, independently of the terminal display. This is consistent
+with upstream reasoning degeneration, but screenshots and completed transcripts
+alone cannot distinguish model behavior, triggering context, or a replaying
+transport. A healthy short API request does not rule out a long-context failure.
+
+The runtime had a separate, reproducible containment gap:
+
+- The display deduplicator only checks identical chunks of at least 50
+  characters. Token-sized repeated phrases bypass it.
+- Every incoming reasoning event resets the idle timer and counts toward
+  progress-based extensions of the stream deadline.
+- The reasoning-spiral hook runs before a later turn, so it cannot stop a loop
+  inside the current response.
+
+## Runtime behavior
+
+For the existing `deepseek` provider, the SSE parser now checks thinking-only
+output before delivering it to the UI. It uses a bounded window of 128 non-empty
+lines. If at least 90% of that window consists of at most four repeated short
+phrases (no more than 32 UTF-16 code units per line), it raises
+`ReasoningRepetitionError` and cancels the unfinished response.
+
+The check is independent of SSE chunk boundaries, works on character-sized
+deltas and the final event without a trailing newline, and does not depend on a
+particular model ID. A model added through `/connect` under DeepSeek gets the same
+protection. It applies before answer text or tool-call progress; it does not
+truncate normal long reasoning, alter answer text, or deduplicate the reasoning
+that a successful tool turn must echo back to the provider.
+
+The failure is non-retryable and non-reconnectable. Partial reasoning from the
+failed response is not committed as a successful assistant turn or automatically
+injected into another attempt. The CLI suggests a fresh conversation or a model
+switch. The last displayed thinking remains partial output, not a completed
+answer. Aborted-attempt diagnostics continue to report received characters and
+elapsed time; final provider usage may be unavailable after cancellation.
+
+This is a conservative containment heuristic, not a repair of model weights or
+context. Deliberate reasoning with the same extreme short-line distribution can
+trigger it. Loops without newline boundaries, or with many long/varied phrases,
+are outside its scope; existing time and output limits still apply.
+
+## Diagnosing another occurrence
+
+1. Record the installed CLI version, provider/base URL, model ID, and whether a
+   gateway or proxy is involved. Do not share API keys.
+2. Compare an innocuous fresh request through the official endpoint with the
+   CLI. Then compare equivalent task/context and thinking settings. Changing
+   both task and model provides correlation, not a controlled A/B experiment.
+3. When raw evidence is needed, set `RIVET_DEBUG_RAW_SSE` to a private local file
+   path for one reproduction. The file includes model output and tool arguments;
+   inspect and redact it before sharing. Unset the variable after the run.
+4. Concatenate the captured `choices[0].delta.reasoning_content` fields in order
+   and compare counts with the CLI transcript. Repeated raw frames rule out a
+   rendering-only explanation; only CLI-side repetition points to client wiring.
+
+Do not repeatedly continue a conversation already dominated by degenerate
+reasoning. Start a fresh conversation with a concise task summary or use a stable
+model. Merely hiding duplicate lines does not stop server-side generation.
+
+## Verification
+
+`src/api/__tests__/reasoning-repetition.test.ts` covers synthetic short-line
+loops, character chunking, healthy long reasoning, occasional repetition, other
+providers, tool progress, residual SSE data, malformed JSON, consumer error
+propagation, same-event reasoning/content preservation, and no automatic retry.
+The fixtures contain no user transcript or credentials and require no API access.
+
+Reference: [DeepSeek thinking-mode protocol](https://api-docs.deepseek.com/guides/thinking_mode/).

--- a/src/api/__tests__/reasoning-repetition.test.ts
+++ b/src/api/__tests__/reasoning-repetition.test.ts
@@ -1,0 +1,136 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { OpenAIClient } from '../openai-client.js'
+import { classifyApiError, errorRecoveryGuidance } from '../error-classifier.js'
+import type { StreamCallbacks } from '../stream-client.js'
+
+// A custom ID verifies provider-level protection without a model-name allowlist.
+const model = 'deepseek-custom-flash'
+const config = {
+  apiKey: 'test', baseUrl: 'https://api.deepseek.com', model,
+  maxTokens: 4096, providerName: 'deepseek', thinking: 'enabled' as const,
+}
+const frame = (delta: Record<string, unknown>, finish_reason?: string) => `data: ${JSON.stringify({ choices: [{ delta, finish_reason }] })}\n\n`
+
+async function parse(deltas: Record<string, unknown>[], options: { residual?: boolean; provider?: string; prefix?: string; finishAt?: number; onThinking?: (s: string) => void } = {}) {
+  const thinking: string[] = []
+  const blocks: unknown[] = []
+  const aborted: unknown[] = []
+  let cancelled = false
+  const stream = new ReadableStream<Uint8Array>({
+    start(c) {
+      const wire = (options.prefix ?? '') + deltas.map((delta, i) => frame(delta, i === options.finishAt ? 'tool_calls' : undefined)).join('')
+      c.enqueue(new TextEncoder().encode(options.residual ? wire.trimEnd() : wire + 'data: [DONE]\n\n'))
+      // Residual parsing runs on EOF; other tests leave the transport open to
+      // verify that stopping a degenerate response releases its reader.
+      if (options.residual) c.close()
+    },
+    cancel() { cancelled = true },
+  })
+  const client = new OpenAIClient({ ...config, providerName: options.provider ?? 'deepseek' })
+  let error: unknown
+  try {
+    await client.parseStreamFromReader(stream.getReader(), {
+      onTextDelta() {}, onThinkingDelta(s) { thinking.push(s); options.onThinking?.(s) },
+      onContentBlock(b) { blocks.push(b) }, onStopReason() {},
+      onStreamAttemptAborted(info) { aborted.push(info) },
+    })
+  } catch (e) { error = e }
+  return { error, thinking: thinking.join(''), blocks, aborted, cancelled }
+}
+
+describe('DeepSeek streaming reasoning repetition', () => {
+  it('stops hundreds of short repeated reasoning lines before committing a completed turn', async () => {
+    const result = await parse(Array.from({ length: 300 }, () => ({ reasoning_content: '好。\n' })))
+    assert.ok(result.error instanceof Error)
+    assert.equal(result.error.name, 'ReasoningRepetitionError')
+    assert.ok(result.thinking.length < 900)
+    assert.equal(result.blocks.length, 0)
+    assert.equal(result.aborted.length, 1)
+    assert.equal(result.cancelled, true)
+    assert.equal(classifyApiError(result.error).retryable, false)
+    assert.equal(classifyApiError(result.error).shouldReconnect, false)
+    assert.match(errorRecoveryGuidance(result.error), /重复/)
+  })
+
+  it('recognizes a short-phrase cycle across individual character deltas', async () => {
+    const text = '好。\n好，我发送。\n（发送）\n'.repeat(80)
+    const result = await parse([...text].map(reasoning_content => ({ reasoning_content })))
+    assert.equal((result.error as Error)?.name, 'ReasoningRepetitionError')
+  })
+
+  it('also checks the final SSE event without a newline', async () => {
+    const result = await parse([{ reasoning_content: '好。\n'.repeat(300) }], { residual: true })
+    assert.equal((result.error as Error)?.name, 'ReasoningRepetitionError')
+  })
+
+  it('preserves healthy long reasoning and occasional repeated phrases byte-for-byte', async () => {
+    const text = Array.from({ length: 300 }, (_, i) => `步骤 ${i}：核对不同证据，继续分析。\n好。\n`).join('')
+    const result = await parse([{ reasoning_content: text }, { content: '完成' }])
+    assert.equal(result.error, undefined)
+    assert.equal(result.thinking, text)
+    assert.deepEqual(result.blocks[0], { type: 'thinking', thinking: text })
+  })
+
+  it('leaves short acknowledgements, other providers and answer text alone', async () => {
+    assert.equal((await parse([{ reasoning_content: '好。\n'.repeat(12) }])).error, undefined)
+    assert.equal((await parse([{ reasoning_content: '好。\n'.repeat(300) }], { provider: 'mimo' })).error, undefined)
+    assert.equal((await parse([{ content: '好。\n'.repeat(300) }])).error, undefined)
+  })
+
+  it('does not classify late reasoning after tool-call progress as a thinking-only loop', async () => {
+    const result = await parse([
+      { tool_calls: [{ index: 0, id: 'call_1', type: 'function', function: { name: 'read_file', arguments: '{"path":"a"}' } }] },
+      { reasoning_content: '好。\n'.repeat(300) },
+    ])
+    assert.equal(result.error, undefined)
+  })
+
+  it('does not re-arm the guard after finish_reason flushes a completed tool call', async () => {
+    const result = await parse([
+      { reasoning_content: '好。\n'.repeat(127) },
+      { tool_calls: [{ index: 0, id: 'call_1', type: 'function', function: { name: 'read_file', arguments: '{"path":"a"}' } }] },
+      { reasoning_content: '好。\n' },
+    ], { finishAt: 1 })
+    assert.equal(result.error, undefined)
+    assert.ok(result.blocks.some(b => (b as { type: string }).type === 'tool_use'))
+    assert.ok(result.blocks.some(b => (b as { type: string }).type === 'thinking'))
+  })
+
+  it('skips malformed JSON and structurally empty events', async () => {
+    const result = await parse([{ reasoning_content: 'normal' }], {
+      prefix: 'data: {bad json\n\ndata: null\n\ndata: {"choices":[{}]}\n\n',
+    })
+    assert.equal(result.error, undefined)
+    assert.equal(result.thinking, 'normal')
+  })
+
+  it('preserves reasoning arriving together with the first content delta', async () => {
+    const result = await parse([{ reasoning_content: '思考完成', content: '完成' }])
+    assert.equal(result.error, undefined)
+    assert.deepEqual(result.blocks[0], { type: 'thinking', thinking: '思考完成' })
+  })
+
+  it('propagates consumer errors instead of swallowing them', async () => {
+    const expected = new Error('consumer failed')
+    const result = await parse([{ reasoning_content: 'normal' }], { onThinking() { throw expected } })
+    assert.equal(result.error, expected)
+  })
+
+  it('does not retry or re-inject a degenerate reasoning prefix', async () => {
+    const original = globalThis.fetch
+    let attempts = 0
+    globalThis.fetch = async () => {
+      attempts++
+      return new Response(frame({ reasoning_content: '好。\n'.repeat(300) }) + 'data: [DONE]\n\n', {
+        headers: { 'content-type': 'text/event-stream' },
+      })
+    }
+    try {
+      const noop = () => {}
+      const cb: StreamCallbacks = { onTextDelta: noop, onThinkingDelta: noop, onContentBlock: noop, onStopReason: noop, onError: noop }
+      await assert.rejects(new OpenAIClient(config).stream({ model, messages: [{ role: 'user', content: 'hi' }], max_tokens: 4096 }, cb), { name: 'ReasoningRepetitionError' })
+      assert.equal(attempts, 1)
+    } finally { globalThis.fetch = original }
+  })
+})

--- a/src/api/error-classifier.ts
+++ b/src/api/error-classifier.ts
@@ -1,3 +1,5 @@
+import { ReasoningRepetitionError } from './reasoning-repetition.js'
+
 /**
  * API Error Classifier — maps raw exceptions to structured recovery strategies.
  *
@@ -19,6 +21,7 @@ export type ErrorCategory =
   | 'context_overflow'
   | 'image_strip'
   | 'stream_parse'
+  | 'reasoning_repetition'
   | 'unknown'
 
 export interface ClassifiedError {
@@ -377,6 +380,12 @@ function extractRetryAfter(error: unknown): number | undefined {
  * Priority: status code → error name → message pattern → fallback.
  */
 export function classifyApiError(error: unknown): ClassifiedError {
+  if (error instanceof ReasoningRepetitionError) {
+    return {
+      retryable: false, retryDelayMs: 0, shouldReconnect: false,
+      category: 'reasoning_repetition', userMessage: error.message, maxRetries: 0,
+    }
+  }
   // Non-SSE 200 (openai-client content-type gate): the endpoint answered but
   // not with a stream — wrong path / no streaming support. Retrying repeats
   // the same misconfiguration; surface the original actionable message.
@@ -455,6 +464,8 @@ export function errorRecoveryGuidance(error: unknown): string {
       return '图片负载超限：去掉部分图片后重发'
     case 'stream_parse':
       return '流解析失败：重发一次；反复出现用 /logs 打包日志提 issue'
+    case 'reasoning_repetition':
+      return '检测到推理短句持续重复，已停止请求；建议新建会话或 /model 切换模型后重试'
     default:
       return '重发一次；持续失败：/doctor 体检 + /logs 看日志'
   }

--- a/src/api/openai-client.ts
+++ b/src/api/openai-client.ts
@@ -8,6 +8,7 @@ import type { ProviderProfile } from './provider-profile.js'
 import { fetchWithTimeout } from './fetch-timeout.js'
 import { withStructuredRetry } from './retry-engine.js'
 import { parseRetryAfterMs } from './error-classifier.js'
+import { ReasoningRepetitionGuard } from './reasoning-repetition.js'
 import { sanitizeMessageContent } from '../utils/sanitize.js'
 import { wireAbortToReaderCancel, wrapBodyTimeoutError } from './abort-reader.js'
 import { debugLog } from '../utils/debug.js'
@@ -782,7 +783,7 @@ export class OpenAIClient implements StreamClient {
   /** Parse SSE stream from a reader — exposed for testing */
   async parseStreamFromReader(
     reader: ReadableStreamDefaultReader<Uint8Array>,
-    callbacks: Partial<Pick<StreamCallbacks, 'onTextDelta' | 'onContentBlock' | 'onStopReason' | 'onStreamAttemptAborted'>>,
+    callbacks: Partial<Pick<StreamCallbacks, 'onTextDelta' | 'onThinkingDelta' | 'onContentBlock' | 'onStopReason' | 'onStreamAttemptAborted'>>,
     signal?: AbortSignal,
     reasoningRef?: { content: string },
     /**
@@ -814,6 +815,32 @@ export class OpenAIClient implements StreamClient {
     let reasoningAccum = ''
     let textReceived = false
     let promotionFired = false
+    let toolProgressReceived = false
+    const repetitionGuard = this.config.providerName === 'deepseek'
+      ? new ReasoningRepetitionGuard() : undefined
+    const processPayload = (payload: string): void => {
+      let parsed: Parameters<OpenAIClient['processDelta']>[0]
+      try { parsed = JSON.parse(payload) } catch { return }
+      if (!parsed || typeof parsed !== 'object') return
+      const delta = parsed?.choices?.[0]?.delta
+      if (parsed.choices?.[0] && !delta) return
+      // Completed calls leave toolCallBuffer when flushed. Progress remains
+      // monotonic for this attempt, even if reasoning arrives after finish_reason.
+      if (delta?.tool_calls?.length) toolProgressReceived = true
+      // Match processDelta's channel ordering, including reasoning and content
+      // arriving in the same event. Only JSON decoding errors are recoverable;
+      // guard and consumer errors must reach stream cleanup and retry policy.
+      if (delta?.reasoning_content && !textReceived) {
+        reasoningAccum += delta.reasoning_content
+        receivedThinking = true
+        if (reasoningRef) reasoningRef.content = reasoningAccum
+        if (!delta.content && !toolProgressReceived && this.toolCallBuffer.size === 0) {
+          repetitionGuard?.push(delta.reasoning_content)
+        }
+      }
+      this.processDelta(parsed, callbacks)
+      if (delta?.content) textReceived = true
+    }
 
     // Create an internal timeout AbortSignal for hard timeout guarantee.
     // This ensures reader.read() is unblocked even if reader.cancel() alone
@@ -949,22 +976,7 @@ export class OpenAIClient implements StreamClient {
 
           if (process.env.RIVET_DEBUG_RAW_SSE) this.dumpRawSse(payload)
 
-          try {
-            const parsed = JSON.parse(payload)
-            this.processDelta(parsed, callbacks)
-            // Track whether text/content was received (for reasoning promotion fallback)
-            if (parsed.choices?.[0]?.delta?.content) textReceived = true
-            // Late reasoning (after content started) was reclassified as text in
-            // processDelta — exclude it from the thinking accumulation so the
-            // persisted thinking block matches the live UI channel.
-            if (parsed.choices?.[0]?.delta?.reasoning_content && !textReceived) {
-              reasoningAccum += parsed.choices[0].delta.reasoning_content
-              receivedThinking = true
-              if (reasoningRef) reasoningRef.content = reasoningAccum
-            }
-          } catch {
-            // Skip malformed SSE lines
-          }
+          processPayload(payload)
         }
         // 仅在收到真实内容事件时重置 idle timer（心跳不重置）
         if (sawDataEvent) {
@@ -979,16 +991,7 @@ export class OpenAIClient implements StreamClient {
         if (trimmed.startsWith('data:')) {
           const payload = trimmed.slice(5).trimStart()
           if (payload !== '[DONE]') {
-            try {
-              const parsed = JSON.parse(payload)
-              this.processDelta(parsed, callbacks)
-              if (parsed.choices?.[0]?.delta?.content) textReceived = true
-              if (parsed.choices?.[0]?.delta?.reasoning_content && !textReceived) {
-                reasoningAccum += parsed.choices[0].delta.reasoning_content
-                receivedThinking = true
-                if (reasoningRef) reasoningRef.content = reasoningAccum
-              }
-            } catch { /* skip malformed */ }
+            processPayload(payload)
           }
         }
       }
@@ -1038,6 +1041,9 @@ export class OpenAIClient implements StreamClient {
       }
     } catch (err) {
       // Observability: surface how much streamed output this attempt discards.
+      // Release the unfinished response even for direct parser callers without
+      // a fetch lifecycle controller (including repetition/consumer failures).
+      void reader.cancel().catch(() => {})
       callbacks.onStreamAttemptAborted?.({
         provider: this.config.providerName ?? 'openai',
         receivedChars: reasoningAccum.length + this._textAccum.length,

--- a/src/api/openai-client.ts
+++ b/src/api/openai-client.ts
@@ -779,8 +779,6 @@ export class OpenAIClient implements StreamClient {
   }
 
   /** Parse SSE stream from a reader — exposed for testing */
-
-  /** Parse SSE stream from a reader — exposed for testing */
   async parseStreamFromReader(
     reader: ReadableStreamDefaultReader<Uint8Array>,
     callbacks: Partial<Pick<StreamCallbacks, 'onTextDelta' | 'onThinkingDelta' | 'onContentBlock' | 'onStopReason' | 'onStreamAttemptAborted'>>,
@@ -986,14 +984,10 @@ export class OpenAIClient implements StreamClient {
       }
 
       // Process any residual data in the SSE buffer (final chunk without trailing newline)
-      if (buffer.trim()) {
-        const trimmed = buffer.trim()
-        if (trimmed.startsWith('data:')) {
-          const payload = trimmed.slice(5).trimStart()
-          if (payload !== '[DONE]') {
-            processPayload(payload)
-          }
-        }
+      const trimmed = buffer.trim()
+      if (trimmed.startsWith('data:')) {
+        const payload = trimmed.slice(5).trimStart()
+        if (payload !== '[DONE]') processPayload(payload)
       }
 
       this.flushToolCalls(callbacks, { final: true })

--- a/src/api/reasoning-repetition.ts
+++ b/src/api/reasoning-repetition.ts
@@ -1,0 +1,51 @@
+/** A terminal stream failure: replaying this partial reasoning can reinforce the loop. */
+export class ReasoningRepetitionError extends Error {
+  constructor() {
+    super('DeepSeek reasoning stream stopped: sustained short-phrase repetition detected. Start a fresh conversation or switch models before retrying.')
+    this.name = 'ReasoningRepetitionError'
+  }
+}
+
+const WINDOW_LINES = 128
+const MAX_LINE_CHARS = 32
+const MIN_REPEATED_LINES = Math.ceil(WINDOW_LINES * 0.9)
+
+/**
+ * Bounded, chunk-boundary-independent detector for thinking-only short-line loops.
+ * Require four or fewer short phrases to occupy >=90% of 128 non-empty lines.
+ * Length alone is never a reason to stop healthy reasoning. Long/novel lines
+ * count against repetition; whitespace-only lines do not inflate the window.
+ */
+export class ReasoningRepetitionGuard {
+  private line = ''
+  private longLine = false
+  private window: Array<string | null> = []
+
+  push(delta: string): void {
+    for (const char of delta) {
+      if (char !== '\n') {
+        if (!this.longLine) {
+          this.line += char
+          if (this.line.length > MAX_LINE_CHARS) this.longLine = true
+        }
+        continue
+      }
+      const line = this.line.trim()
+      if (this.longLine || line) {
+        this.window.push(this.longLine ? null : line)
+        if (this.window.length > WINDOW_LINES) this.window.shift()
+        if (this.window.length === WINDOW_LINES) {
+          const counts = new Map<string, number>()
+          for (const entry of this.window) {
+            if (entry !== null) counts.set(entry, (counts.get(entry) ?? 0) + 1)
+          }
+          const repeated = [...counts.values()].sort((a, b) => b - a).slice(0, 4)
+            .reduce((sum, count) => sum + count, 0)
+          if (repeated >= MIN_REPEATED_LINES) throw new ReasoningRepetitionError()
+        }
+      }
+      this.line = ''
+      this.longLine = false
+    }
+  }
+}


### PR DESCRIPTION
## 变更摘要

为 DeepSeek thinking-only 流增加持续短句重复检测。模型连续输出“好。”等短句时提前终止请求并显示恢复提示，避免持续生成到输出上限，也避免把退化片段自动带入重试。

## 动机

实际使用中，思考区域会出现数万行被折叠的重复短句。显示计数来自累计推理文本；本地已保存推理也存在重复，因此不符合单纯重绘问题的表现。不过没有异常当时的原始 SSE，仍不能区分模型自身、长上下文触发或传输重放；本 PR 修复的是可离线复现的客户端止损缺口。

原有显示去重只处理至少 50 字符的相同 chunk，逐字输出的短句可绕过；这些事件持续重置 idle timer，preTurn 推理提醒也无法中止当前流。

## 主要改动

- 在现有 `deepseek` provider 的 SSE 接收路径中，以有界窗口检测 128 个非空行：其中至少 90% 来自不超过四种短句，每行最多 32 个 UTF-16 单元。检测独立于 chunk 边界，适用于 `/connect` 添加的自定义模型 ID。
- 只检查尚未出现正文或工具进展的推理。工具进展使用本次请求内的持续标记，避免工具完成并清空 buffer 后误重新启用检测。
- 使用独立错误类型，取消未完成响应；禁止自动重试、fallback 和 agent reconnect。失败片段不会作为完整推理块提交。
- 缩小 JSON 解析的 catch 范围，确保检测/消费回调错误不被当作坏 JSON 吞掉；统一正常帧与末尾无换行帧的处理，并保留同帧 reasoning/content 中的推理。
- 增加 11 项合成回归测试和诊断文档。没有包含用户会话、密钥或私有业务文件，也不按模型 ID 硬编码实验模型。

正常长推理不按总长度截断，正文与成功工具轮回传的推理保持原样。该启发式不覆盖无换行、长句或大量变化的重复；刻意生成同样极端的短句分布也可能触发，详见文档。

## 测试

- 新回归测试：11/11 通过；先观察旧实现失败，再实现修复。另一个审查发现的“tool flush 后重启检测”反例也先失败再修复。
- 全部 `src/api` 测试、`turn-stream.test.ts`、`format-tool-diff-thinking.test.ts`：直接 Node test runner（不带 `--test-force-exit`）运行，588/588 通过。
- `npx tsc --noEmit`、`npm run build`、CLI `--version`、`git diff --check` 通过。`npm run lint` 退出 0，有仓库既有 warnings。
- 官方端点的简单非流式请求，以及修复客户端的真实 thinking + tool-call 流式请求均成功；这只是协议 smoke test，不是异常长会话的受控复现。
- **完整 `npm test` 未全绿**：同机未修改的 `cfeaceaa` 基线有 158 项失败。补丁的完整跑报告 159 项失败，其中新增的 max-lines ratchet 已在后续提交修复，并单独通过。其余差异涉及 Windows `EPERM` 清理及 Node/libuv 退出问题；`related-tests` 的 EPERM 和 vision onboarding 的 libuv 崩溃均在基线复现，provider onboarding 单独重跑通过。没有为了本 PR 修改这些无关测试或平台代码；长度整理后仅重跑针对性验证，未声称又跑了一次完整套件。
- 独立只读代码审查已通过。

## 检查清单

- [ ] 本地完整 `npm test` 通过（存在上述基线/平台失败）
- [x] `npx tsc --noEmit` 无类型错误
- [x] 变更范围最小化，无关改动已排除
- [x] 增加诊断、适用范围和复现说明文档

## 相关 Issue

无。
