### PR TITLE
fix(server): disk-evidence self-heal for apply_edit delegation stalls (#61)

### DIFF
--- a/src/server/__tests__/delegation-disk-probe.test.ts
+++ b/src/server/__tests__/delegation-disk-probe.test.ts
@@ -1,0 +1,175 @@
+// E4a — apply_edit 磁盘证据自愈（issue #61）：客户端已落盘但结果 POST 丢失时，
+// 内核应经磁盘探针立即结算委托，而不是等满 300s 人审窗口。
+import { describe, it, before, after, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { RuntimeSessionManager, type ManagedAgent } from '../session-manager.js'
+import type { AgentCallbacks } from '../../agent/loop-types.js'
+import type { OaiMessage } from '../../api/oai-types.js'
+
+class FakeAgent implements ManagedAgent {
+  callbacks?: AgentCallbacks
+  messages: OaiMessage[] = []
+  private resolveRun?: () => void
+  run(_prompt: string, cb: AgentCallbacks): Promise<void> {
+    this.callbacks = cb
+    return new Promise<void>((res) => { this.resolveRun = res })
+  }
+  abort(): void { this.resolveRun?.() }
+  listArtifacts() { return [] }
+  async readArtifact() { return null }
+  getMessages() { return this.messages }
+  replaceMessages(msgs: OaiMessage[]) { this.messages = msgs }
+  rewindToMessages(msgs: OaiMessage[]) { this.messages = msgs }
+}
+
+/** 竞速等待：settle 前返回 'pending'，否则返回结果/null。 */
+function racePending<T>(p: Promise<T>, ms: number): Promise<T | 'pending'> {
+  return Promise.race([
+    p.then((v) => v),
+    new Promise<'pending'>((res) => setTimeout(() => res('pending'), ms)),
+  ])
+}
+
+/** 断言已结算并收窄类型（assert.notEqual 无法让 TS 收窄联合）。 */
+async function expectSettled<T>(p: Promise<T | 'pending'>, label: string): Promise<T> {
+  const v = await p
+  assert.notEqual(v, 'pending', label)
+  return v as T
+}
+
+describe('E4a delegation disk probe', () => {
+  let cwd: string
+  let manager: RuntimeSessionManager
+  let agents: FakeAgent[]
+
+  before(() => {
+    // 测试用短轮询间隔，避免真实等待
+    process.env.RIVET_DELEGATE_PROBE_MS = '30'
+    cwd = mkdtempSync(join(tmpdir(), 'delegate-probe-'))
+    writeFileSync(join(cwd, 'a.txt'), 'old\n')
+    agents = []
+    manager = new RuntimeSessionManager({
+      createAgent: () => {
+        const a = new FakeAgent()
+        agents.push(a)
+        return a
+      },
+      defaultCwd: cwd,
+      approvalTimeoutMs: 0,
+      watchdogContinueDelayMs: 0,
+    })
+  })
+
+  after(() => {
+    delete process.env.RIVET_DELEGATE_PROBE_MS
+    manager.shutdownAll()
+    rmSync(cwd, { recursive: true, force: true })
+  })
+
+  it('客户端已落盘（内容精确匹配）→ 无需应答即自愈结算', async () => {
+    const rec = manager.createSession({ cwd, title: 'p1', prompt: 'go' })
+    const cb = agents.at(-1)!.callbacks!
+    manager.registerDelegateCapabilities(rec.id, 'c1', ['apply_edit'])
+    // 模拟客户端比应答先落盘：文件已经是 newContent
+    writeFileSync(join(cwd, 'a.txt'), 'new\n')
+    const result = cb.onToolDelegate!('apply_edit', {
+      path: 'a.txt', oldContent: 'old\n', newContent: 'new\n',
+    })
+    const settled = await expectSettled(racePending(result, 2_000), '磁盘证据存在时应自愈，不应等满窗口')
+    assert.ok(settled, '自愈结果不应为 null')
+    assert.equal(settled.status, 'ok')
+    assert.match(settled.content ?? '', /自愈|落盘/)
+  })
+
+  it('客户端未落盘 → 保持 pending，不提前 ack', async () => {
+    const rec = manager.createSession({ cwd, title: 'p2', prompt: 'go' })
+    const cb = agents.at(-1)!.callbacks!
+    manager.registerDelegateCapabilities(rec.id, 'c2', ['apply_edit'])
+    writeFileSync(join(cwd, 'a.txt'), 'old\n') // 仍是旧内容
+    const result = cb.onToolDelegate!('apply_edit', {
+      path: 'a.txt', oldContent: 'old\n', newContent: 'new\n',
+    })
+    const probeDelay = Number.parseInt(process.env.RIVET_DELEGATE_PROBE_MS ?? '30', 10)
+    const still = await racePending(result, probeDelay * 6)
+    assert.equal(still, 'pending', '内容不匹配时不得提前结算')
+    // 随后客户端真正落盘 → 探针自愈
+    writeFileSync(join(cwd, 'a.txt'), 'new\n')
+    const settled = await expectSettled(racePending(result, 2_000), '落盘后应自愈')
+    assert.ok(settled, '自愈结果不应为 null')
+    assert.equal(settled.status, 'ok')
+  })
+
+  it('部分写入/尺寸不符 → 不误判为已落盘', async () => {
+    const rec = manager.createSession({ cwd, title: 'p3', prompt: 'go' })
+    const cb = agents.at(-1)!.callbacks!
+    manager.registerDelegateCapabilities(rec.id, 'c3', ['apply_edit'])
+    writeFileSync(join(cwd, 'a.txt'), 'old\n')
+    const result = cb.onToolDelegate!('apply_edit', {
+      path: 'a.txt', oldContent: 'old\n', newContent: 'new\n',
+    })
+    // 半截写入（尺寸不同）
+    writeFileSync(join(cwd, 'a.txt'), 'n')
+    const probeDelay = Number.parseInt(process.env.RIVET_DELEGATE_PROBE_MS ?? '30', 10)
+    const still = await racePending(result, probeDelay * 6)
+    assert.equal(still, 'pending', '半截写入不得触发自愈')
+    // 客户端显式应答照常生效
+    const events = manager.getEvents(rec.id, 0)
+    const rid = String(events?.events.find((e) => e.type === 'tool_delegate')?.data.requestId)
+    assert.ok(manager.answerDelegation(rec.id, rid, { content: 'user accepted', status: 'ok' }))
+    const settled = await result
+    assert.equal(settled?.content, 'user accepted')
+  })
+
+  it('显式应答后探针停止（重复结算不生效）', async () => {
+    const rec = manager.createSession({ cwd, title: 'p4', prompt: 'go' })
+    const cb = agents.at(-1)!.callbacks!
+    manager.registerDelegateCapabilities(rec.id, 'c4', ['apply_edit'])
+    writeFileSync(join(cwd, 'a.txt'), 'old\n')
+    const result = cb.onToolDelegate!('apply_edit', {
+      path: 'a.txt', oldContent: 'old\n', newContent: 'new\n',
+    })
+    const events = manager.getEvents(rec.id, 0)
+    const rid = String(events?.events.find((e) => e.type === 'tool_delegate')?.data.requestId)
+    assert.ok(manager.answerDelegation(rec.id, rid, { content: 'ok', status: 'ok' }))
+    const settled = await result
+    assert.equal(settled?.content, 'ok')
+    // 应答后再写盘：pending 已移除，探针必须已停（不会有第二次结算/异常）
+    writeFileSync(join(cwd, 'a.txt'), 'new\n')
+    await new Promise((r) => setTimeout(r, Number.parseInt(process.env.RIVET_DELEGATE_PROBE_MS ?? '30', 10) * 4))
+    assert.equal(manager.answerDelegation(rec.id, rid, { content: 'x', status: 'ok' }), false)
+  })
+
+  it('能力清除（SSE 断开）→ 立即失败回退并停探针', async () => {
+    const rec = manager.createSession({ cwd, title: 'p5', prompt: 'go' })
+    const cb = agents.at(-1)!.callbacks!
+    manager.registerDelegateCapabilities(rec.id, 'c5', ['apply_edit'])
+    writeFileSync(join(cwd, 'a.txt'), 'old\n')
+    const result = cb.onToolDelegate!('apply_edit', {
+      path: 'a.txt', oldContent: 'old\n', newContent: 'new\n',
+    })
+    assert.ok(manager.clearDelegateCapabilities(rec.id, 'c5'))
+    const settled = await racePending(result, 2_000)
+    assert.equal(settled, null, '客户端失联 → fail-back null（本地写）')
+  })
+
+  it('RIVET_DELEGATE_DISK_PROBE=0 可关闭探针（回退旧行为）', async () => {
+    process.env.RIVET_DELEGATE_DISK_PROBE = '0'
+    try {
+      const rec = manager.createSession({ cwd, title: 'p6', prompt: 'go' })
+      const cb = agents.at(-1)!.callbacks!
+      manager.registerDelegateCapabilities(rec.id, 'c6', ['apply_edit'])
+      writeFileSync(join(cwd, 'a.txt'), 'new\n') // 文件已匹配，但探针被关
+      const result = cb.onToolDelegate!('apply_edit', {
+        path: 'a.txt', oldContent: 'old\n', newContent: 'new\n',
+      })
+      const probeDelay = Number.parseInt(process.env.RIVET_DELEGATE_PROBE_MS ?? '30', 10)
+      const still = await racePending(result, probeDelay * 6)
+      assert.equal(still, 'pending', '探针关闭时不得自愈')
+    } finally {
+      delete process.env.RIVET_DELEGATE_DISK_PROBE
+    }
+  })
+})

--- a/src/server/delegation-protocol.ts
+++ b/src/server/delegation-protocol.ts
@@ -27,6 +27,21 @@ export const DELEGATE_TIMEOUT_MS: Record<DelegateKind, number> = {
 /** Capability TTL — client must heartbeat before this elapses. */
 export const DELEGATE_CAPABILITY_TTL_MS = 60_000
 
+/** E4a — disk-evidence self-heal for apply_edit (issue #61). */
+export const DELEGATE_DISK_PROBE_DEFAULT_MS = 1_500
+
+/** Poll interval while an apply_edit delegation is unanswered (tests shorten it). */
+export function delegateDiskProbeIntervalMs(): number {
+  const v = Number.parseInt(process.env.RIVET_DELEGATE_PROBE_MS ?? '', 10)
+  return Number.isFinite(v) && v > 0 ? v : DELEGATE_DISK_PROBE_DEFAULT_MS
+}
+
+/** Default on; set RIVET_DELEGATE_DISK_PROBE=0 or false to disable the probe. */
+export function isDelegateDiskProbeEnabled(): boolean {
+  const v = process.env.RIVET_DELEGATE_DISK_PROBE
+  return v !== '0' && v !== 'false'
+}
+
 export interface ApplyEditPayload {
   path: string
   oldContent: string

--- a/src/server/session-manager.ts
+++ b/src/server/session-manager.ts
@@ -65,7 +65,7 @@ import type { StarDomainId } from '../agent/star-domain.js'
 import { skillRegistry, loadProjectSkills, listInstallableSkills, importSkillsIntoRivet, countInstalledSkills, readSkillContent, writeSkill, uninstallSkill, type InstallableSkill } from '../skills/skill-loader.js'
 import type { MissionStore } from './mission-store.js'
 import { join, resolve, dirname } from 'node:path'
-import { readFile } from 'node:fs/promises'
+import { readFile, stat } from 'node:fs/promises'
 import { existsSync, copyFileSync, statSync, mkdirSync, readFileSync } from 'node:fs'
 import { createWorktree, createWorktreeAtBranch, removeWorktree, listWorktrees, hasUnlandedWork, commitAll, revParseHead, getCurrentGitRef, squashMergeBranch, pushBranch, type WorktreeEntry } from '../agent/worktree.js'
 import { createPr } from './gh-cli.js'
@@ -79,6 +79,8 @@ import { outOfWorkspaceFilePaths } from '../agent/tool-pipeline.js'
 import {
   DELEGATE_CAPABILITY_TTL_MS,
   DELEGATE_TIMEOUT_MS,
+  delegateDiskProbeIntervalMs,
+  isDelegateDiskProbeEnabled,
   isDelegateKind,
   type DelegateKind,
   type DelegateResult as ClientDelegateResult,
@@ -783,6 +785,17 @@ interface PendingDelegation {
   kind: DelegateKind
   resolve: (value: ClientDelegateResult | null) => void
   timer?: ReturnType<typeof setTimeout>
+  /**
+   * E4a — disk-evidence probe for apply_edit (issue #61): the desktop client
+   * may have applied the edit while its result POST was lost. While the
+   * delegation is unanswered we poll the target file; an exact newContent
+   * match settles the request instead of waiting out the full review window.
+   */
+  probe?: {
+    absPath: string
+    newContent: string
+    interval?: ReturnType<typeof setInterval>
+  }
 }
 
 interface DelegateCapabilitySlot {
@@ -4482,12 +4495,73 @@ export class RuntimeSessionManager {
     if (clientId && slot.clientId !== clientId) return false
     s.delegateCapabilities = undefined
     // Fail-back in-flight landings — client is gone.
-    for (const [rid, pend] of [...s.pendingDelegations]) {
-      s.pendingDelegations.delete(rid)
-      if (pend.timer) clearTimeout(pend.timer)
-      pend.resolve(null)
+    for (const [rid] of [...s.pendingDelegations]) {
+      this.settlePendingDelegation(s, rid, null)
     }
     return true
+  }
+
+  /**
+   * Settle a pending delegation exactly once, releasing its timeout timer and
+   * (E4a) disk probe. Every terminal path goes through here so no settlement
+   * can leak a live timer/interval.
+   */
+  private settlePendingDelegation(
+    session: InternalSession,
+    requestId: string,
+    value: ClientDelegateResult | null,
+  ): void {
+    const pend = session.pendingDelegations.get(requestId)
+    if (!pend) return
+    session.pendingDelegations.delete(requestId)
+    if (pend.timer) clearTimeout(pend.timer)
+    if (pend.probe?.interval) clearInterval(pend.probe.interval)
+    pend.resolve(value)
+  }
+
+  /**
+   * E4a — disk-evidence self-heal for apply_edit (issue #61): the desktop
+   * client may have applied the edit while its result POST was lost, leaving
+   * the write tool stalled for the full review window (5 min). While the
+   * delegation is unanswered, poll the target file — an exact newContent
+   * match settles the request with a synthetic success so the agent proceeds
+   * without a manual stop. Human-review flows (VS Code CodeLens) are
+   * unaffected: nothing is written until the human acts, so polling stays
+   * silent and the 300s window is unchanged. Partial/renamed writes never
+   * match (byte-exact comparison), so no premature ack is possible.
+   */
+  private startDelegationDiskProbe(
+    session: InternalSession,
+    requestId: string,
+    absPath: string,
+    newContent: string,
+  ): ReturnType<typeof setInterval> | undefined {
+    if (!isDelegateDiskProbeEnabled()) return undefined
+    const intervalMs = delegateDiskProbeIntervalMs()
+    const interval = setInterval(() => {
+      const pend = session.pendingDelegations.get(requestId)
+      if (!pend?.probe) {
+        clearInterval(interval)
+        return
+      }
+      void (async () => {
+        try {
+          const st = await stat(absPath)
+          if (!st.isFile()) return
+          if (st.size !== Buffer.byteLength(newContent, 'utf8')) return
+          const current = await readFile(absPath, 'utf8')
+          if (current !== newContent) return
+          this.settlePendingDelegation(session, requestId, {
+            content: '客户端已落盘（磁盘证据确认——结果回传丢失已自愈，请直接继续，切勿重写）',
+            status: 'ok',
+          })
+        } catch {
+          // File not ready / transient read error — keep polling.
+        }
+      })()
+    }, intervalMs)
+    if (typeof interval.unref === 'function') interval.unref()
+    return interval
   }
 
   /** Whether the session currently has a live capability for `kind`. */
@@ -4511,9 +4585,7 @@ export class RuntimeSessionManager {
     if (!s) return false
     const pend = s.pendingDelegations.get(requestId)
     if (!pend) return false
-    s.pendingDelegations.delete(requestId)
-    if (pend.timer) clearTimeout(pend.timer)
-    pend.resolve({
+    this.settlePendingDelegation(s, requestId, {
       content: typeof result.content === 'string' ? result.content : '',
       isError: result.isError === true,
       uiContent: typeof result.uiContent === 'string' ? result.uiContent : undefined,
@@ -4551,12 +4623,22 @@ export class RuntimeSessionManager {
         kind,
         resolve,
         timer: setTimeout(() => {
-          if (!session.pendingDelegations.delete(requestId)) return
           // Timeout → null (fail-back). NOT an error — agent never sees it.
-          resolve(null)
+          this.settlePendingDelegation(session, requestId, null)
         }, timeoutMs),
       }
       if (typeof pend.timer?.unref === 'function') pend.timer.unref()
+      // E4a — disk-evidence self-heal for apply_edit (issue #61): the client
+      // may have applied the edit while its result POST was lost. Poll the
+      // target file until it matches newContent or the request settles.
+      if (kind === 'apply_edit') {
+        const p = payload as { path?: unknown; newContent?: unknown }
+        if (typeof p.path === 'string' && typeof p.newContent === 'string') {
+          const absPath = join(session.record.cwd, p.path)
+          pend.probe = { absPath, newContent: p.newContent }
+          pend.probe.interval = this.startDelegationDiskProbe(session, requestId, absPath, p.newContent)
+        }
+      }
       session.pendingDelegations.set(requestId, pend)
       this.append(session, 'tool_delegate', {
         requestId,


### PR DESCRIPTION
# fix(server): apply_edit 委托磁盘证据自愈 — 修复 #61 写工具挂起

## 问题（#61 + 评论区实测分析）

写工具（write_file/edit_file）经 `landingWriteFile → tryClientApplyEdit → onClientDelegate('apply_edit', …)` 把落盘委托给客户端（桌面端），内核等待 `POST /sessions/:id/delegate/:requestId/result`。

实测（3.13.0 内核沙箱 + 注册 apply_edit 能力但永不应答的 ghost 客户端）：

- write_file 触发后工具调用 ≥90s 零进展（仅 15s 心跳），无本地兜底；
- 委托超时为 `DELEGATE_TIMEOUT_MS.apply_edit = 300s`（为 VS Code CodeLens 人审窗口设计）；
- 与 #61 现象逐条吻合（只影响写工具 / 挂起数分钟 / stop 后磁盘证据确认已写入 / 3.10–3.14 回归，3.15 = 回退 3.9 基线）。

推断：桌面客户端已落盘、但结果 POST 丢失（Windows/WebView2 应答回传问题，GUI 侧闭源）。

## 本 PR（公开内核侧可做的自愈）

委托等待期间，对 apply_edit 目标文件做**磁盘证据轮询**（默认 1.5s/次）：

- 文件内容与 `newContent` **逐字节精确匹配** → 判定客户端已落盘、应答丢失 → 立即以合成成功结算委托，agent 继续，无需等满 300s 或手动 stop；
- 未匹配（未写/半截写/改名写）→ 保持等待，绝不提前 ack；
- 显式应答 / 客户端失联清除 / 超时路径均先停探针再结算（统一走 `settlePendingDelegation`，杜绝双结算与计时器泄漏）；
- VS Code CodeLens 人审不受影响：用户未点同意前文件不变，300s 窗口语义原样；
- 开关：`RIVET_DELEGATE_DISK_PROBE=0` 关闭；间隔 `RIVET_DELEGATE_PROBE_MS` 可调（测试用）。

## 改动

- `src/server/delegation-protocol.ts`：探针默认间隔 + 两个 env 读取函数
- `src/server/session-manager.ts`：`PendingDelegation.probe`；`startDelegationDiskProbe`；统一结算 `settlePendingDelegation`（超时/应答/能力清除三路重接）；requestToolDelegate 为 apply_edit 挂探针
- `src/server/__tests__/delegation-disk-probe.test.ts`：6 例（落盘自愈 / 未落盘不提前 ack / 半截写不误判 / 应答后探针停 / 能力清除 fail-back / 开关关闭）

## 验证

- `delegation-disk-probe.test.ts`：6/6 pass
- `delegation-protocol.test.ts`（回归）：8/8 pass
- 全仓 `tsc --noEmit`：见 CI / 本地跑

关联：#61（含评论区实测分析）；不涉及 GUI 侧修复——若桌面端应答回传问题仍在，本 PR 将"丢失应答"从 5 分钟死等降为秒级自愈。
