### PR TITLE
docs(issue-template): Surface 判据引导，减少 TUI/桌面端误标 (#58)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -10,12 +10,22 @@ body:
     id: surface
     attributes:
       label: 使用端 · Surface
+      description: 不确定选哪个？看下面两条判据再选，避免误标导致问题被分流到错误的代码路径。
       options:
         - TUI (终端 rivet)
         - 桌面端 Desktop (Tauri)
         - 无界面模式 headless (-p / --json)
     validations:
       required: true
+  - type: markdown
+    attributes:
+      value: |
+        **如何区分 TUI 与桌面端（常见误标点）：**
+        - 用鼠标滚轮能滚动聊天区 / 能"贴底跟随、上翻不被拽"→ **桌面端**。raw 模式 TUI 的内容进入终端
+          scrollback 后由终端模拟器接管滚动，天枢收不到滚轮事件，也没有桌面端那套滚动跟随状态机。
+        - 终端里 Ctrl+C / 键盘翻页 scrollback → **TUI**。
+        - 若是 UI 卡顿/抖动类问题，请注明发生时的输出模式与终端模拟器（Windows Terminal / ConHost 等）。
+        - 参考：滚动/视图相关问题归集于 #54 / #56 / #58；写工具/委托问题见 #61。
   - type: input
     id: version
     attributes:


### PR DESCRIPTION
# docs(issue-template): Surface 判据引导——减少 TUI/桌面端误标 (#58)

## 背景
#58 把桌面端滚动行为（滚轮滚聊天区、贴底跟随、"滚动跟随状态机"语义）标成了 `TUI (终端 rivet)`。

判据（来自代码走查）：
- raw 模式 TUI 把内容提交到终端 scrollback 后，滚动由终端模拟器接管，应用**收不到滚轮事件**，也没有桌面端那套滚动跟随状态机；
- 能"用滚轮滚聊天区/跳回顶部"的只有桌面端 WebView2 视口。

Surface 误标会把问题分流到错误的代码路径（TUI 的 live-engine vs 桌面端渲染层），拖慢定位。

## 改动
bug_report.yml：Surface 下拉框加判据 description + 新增一段 markdown 引导（滚轮=桌面 / 终端 scrollback=TUI / 注明终端模拟器），并归集同类滚动/视图问题（#54/#56/#58）。

## 验证
纯模板 yml 改动（typecheck 不涉及；CI 里 .github 模板无需构建验证——如项目要求 schema 校验请指出）。
