### PR TITLE
fix(worker): OOP worker 结算后摘除 abort 监听——不再把运行闭包钉死在会话信号上

### DIFF
--- a/src/agent/worker-process/__tests__/worker-process.test.ts
+++ b/src/agent/worker-process/__tests__/worker-process.test.ts
@@ -173,6 +173,25 @@ describe('OOP 运行器（真子进程假 agent）', () => {
     assert.equal(run.result.failureReason, 'stalled', '击杀梯收尾后合成 stalled 而非 worker_crash')
   })
 
+  test('settle 后摘除 abort 监听——同一会话级信号多次委派不累积监听（2026-09-10 泄漏修复）', async () => {
+    const { getEventListeners } = await import('node:events')
+    const fixture = writeFixture(dir, 'crash') // 最快 settle：init 后 exit(1)
+    const controller = new AbortController()
+    const spawnFx = (_e: string[], script: string) => spawn(process.execPath, [script], { stdio: ['pipe', 'pipe', 'pipe'] })
+    const opts = (): WorkerOopOptions => ({ ...baseOpts(fixture), spawnOverride: spawnFx })
+
+    // abortSignal 是会话级合成信号（AbortSignal.any([session, order])）时，order 级
+    // 不触发 abort 则 once 永不消耗——修复前监听钉在会话信号上每次委派 +1，
+    // 长会话单调泄漏并最终触发 MaxListenersExceededWarning。
+    const run1 = await runWorkerSessionOop(makeConfig({ abortSignal: controller.signal }), opts())
+    assert.equal(run1.result.status, 'failed')
+    assert.equal(getEventListeners(controller.signal, 'abort').length, 0, '第一次委派 settle 后监听已摘除')
+
+    const run2 = await runWorkerSessionOop(makeConfig({ abortSignal: controller.signal }), opts())
+    assert.equal(run2.result.status, 'failed')
+    assert.equal(getEventListeners(controller.signal, 'abort').length, 0, '第二次委派后同样不残留')
+  })
+
   test('abort 下行 → 子进程返回 blocked/caller_aborted', async () => {
     const fixture = writeFixture(dir, 'ok')
     const cfg = makeConfig()

--- a/src/agent/worker-process/parent.ts
+++ b/src/agent/worker-process/parent.ts
@@ -203,10 +203,13 @@ export async function runWorkerSessionOop(
   let watchdogTimer: ReturnType<typeof setTimeout> | undefined
   let killTimer: ReturnType<typeof setTimeout> | undefined
   let killStage: 'none' | 'term' | 'kill' = 'none'
+  // settle 时摘除 abort 监听（见下方 abort 接线处的说明）
+  let detachAbort: (() => void) | undefined
 
   const cleanup = (): void => {
     if (watchdogTimer) clearTimeout(watchdogTimer)
     if (killTimer) clearTimeout(killTimer)
+    detachAbort?.()
   }
 
   const killLadder = (reason: string): void => {
@@ -329,7 +332,15 @@ export async function runWorkerSessionOop(
         try { stdin.write(encodeFrame({ t: 'abort', reason: String(config.abortSignal?.reason ?? 'caller_aborted') })) } catch { /* stdin 已关——close 事件兜底 */ }
       }
       if (config.abortSignal.aborted) onAbort()
-      else config.abortSignal.addEventListener('abort', onAbort, { once: true })
+      else {
+        config.abortSignal.addEventListener('abort', onAbort, { once: true })
+        // settle 后摘除：abortSignal 常是会话级合成信号（AbortSignal.any([会话, order])，
+        // coordinator.ts mergedSignal），order 级先触发 abort 时 once 不消耗、监听继续挂在
+        // 会话信号上——把整个运行闭包（ChildProcess 句柄、解码器、含会话史的 initPayload）
+        // 钉在会话生命周期。长会话多次委派单调泄漏，第 11 个监听触发
+        // MaxListenersExceededWarning。wrapAbort / worker-session 路径已有同款摘除纪律。
+        detachAbort = () => config.abortSignal?.removeEventListener('abort', onAbort)
+      }
     }
 
     // steer 桥：coordinator 的 onSteerDrain 在父侧排空队列 → 转发子进程。


### PR DESCRIPTION
# fix(worker): OOP worker 结算后摘除 abort 监听——不再把运行闭包钉死在会话信号上

**分支**：`fix/worker-oop-abort-listener` ｜ 改动：`worker-process/parent.ts` 一行摘除 + 回归测试

## 问题：每次委派在会话级信号上挂一条永不摘除的监听链

OOP 运行器挂 `config.abortSignal.addEventListener('abort', onAbort, { once: true })`（parent.ts:327-333）但从不移除——`cleanup()` 只清 watchdog/kill 定时器，全文件 0 处 `removeEventListener`。

`abortSignal` 是 coordinator 的合成信号 `AbortSignal.any([会话级, order级])`：order 级先触发 abort 时 `once` 不会消耗，监听继续挂在**会话级**信号上，把整个运行闭包（ChildProcess 句柄、帧解码器、stderr 环、含完整 priorMessages 会话史的 initPayload）钉死在会话生命周期。

## 不修的后果

长会话反复委派（`/team`、`delegate_batch` 重度用户的常态）内存单调上涨；第 11 个监听触发 Node `MaxListenersExceededWarning`，之后每次委派都在加重泄漏——会话越长越卡，只有重启能解。全仓其他路径（coordinator 的 wrapAbort、worker-session）都有同款摘除纪律，唯独 OOP 层漏了。

## 为什么一直没被发现

没有测试对同一长寿命信号跑两次以上 OOP 派发后断言监听数量。

## 修复与验证

`cleanup()` 经 `detachAbort` 钩子摘除监听（挂载点登记、settle 点调用）。回归测试：同一 never-aborted 会话信号连跑两次委派 → `getEventListeners(signal,'abort')` 恒为 0。修复前红（每次委派 +1），修复后 worker-process 套件 15/15 全绿。
