### PR TITLE
fix(agent): 会话转录写入失败丢批、flush 竞态击穿落盘屏障

### DIFF
--- a/src/agent/__tests__/session-persist-codec.test.ts
+++ b/src/agent/__tests__/session-persist-codec.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
-import { appendFileSync, existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
+import { appendFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { SessionPersist } from '../session-persist.js'
+import { SessionBatchWriter } from '../session-batch-writer.js'
 import { decodeTranscriptText, encodeBatch, isZstdFrameStream } from '../session-transcript-codec.js'
 
 describe('SessionPersist write-behind codec (P1)', () => {
@@ -158,5 +159,44 @@ describe('SessionPersist write-behind codec (P1)', () => {
     persist.initMetadata({ title: 'sync write' })
     const onDisk = JSON.parse(readFileSync(join(tempDir, 'codec-meta-sync.meta.json'), 'utf-8'))
     assert.equal(onDisk.title, 'sync write')
+  })
+
+  it('flush failure requeues the batch instead of dropping it (ENOSPC-class)', async () => {
+    // 目标路径是已存在目录 → readFileSync/appendFile 抛 EISDIR：真实 OS 错误，无 mock。
+    const dirAsFile = join(tempDir, 'as-a-dir')
+    mkdirSync(dirAsFile)
+    const writer = new SessionBatchWriter(dirAsFile, () => tempDir)
+    writer.enqueueLine('{"v":1,"content":"IMPORTANT_TOOL_RESULT"}\n')
+    await assert.rejects(
+      () => writer.flush(),
+      err => (err as NodeJS.ErrnoException).code === 'EISDIR',
+    )
+    // 修复前：pendingBuffer 已被清空，这批行永久丢（用户在 UI 里毫无感知）。
+    assert.match(writer.mergePending(''), /IMPORTANT_TOOL_RESULT/,
+      'failed batch must stay buffered for the next flush/shutdown drain to retry')
+  })
+
+  it('flush() during an in-flight drain still flushes lines queued in the meantime', async () => {
+    // flush:true 持久化屏障的回归：in-flight 窗口里入队的行不在被 await 的
+    // promise 覆盖范围内，也不能只留在内存里没有任何冲刷计划。
+    const file = join(tempDir, 'race.jsonl')
+    const writer = new SessionBatchWriter(file, () => tempDir)
+    writer.enqueueLine('{"n":1}\n')
+    writer.flushSync() // 建文件 + 置 codecReady
+
+    writer.enqueueLine('{"n":2}\n')
+    const first = writer.flush() // in-flight（真 I/O）
+
+    // 同一 tick：工具结果（flush:true 场景）在 in-flight 窗口里入队，随即被 flush 屏障调用
+    writer.enqueueLine('{"n":3,"flushBarrier":true}\n')
+    const second = writer.flush()
+    await Promise.all([first, second])
+
+    // 屏障返回后批3必须已经在盘上（修复前：悬挂内存且定时器已被清，强杀即丢）
+    const onDisk = decodeTranscriptText(readFileSync(file))
+    assert.match(onDisk, /"n":2/)
+    assert.match(onDisk, /"n":3,"flushBarrier":true/,
+      'line queued during an in-flight flush must be durable once the barrier resolves')
+    assert.equal(writer.mergePending(''), '', 'nothing left hanging in the buffer')
   })
 })

--- a/src/agent/session-batch-writer.ts
+++ b/src/agent/session-batch-writer.ts
@@ -56,7 +56,13 @@ export class SessionBatchWriter {
   /**
    * Flush barrier: cancel the timer, drain the pending batch into one
    * checksummed zstd frame append + datasync. Concurrent callers share the
-   * in-flight flush promise.
+   * in-flight drain promise; a drain that arrives while one is already in
+   * flight still drains whatever queued in the meantime (the awaited promise
+   * only covers the batch it started with).
+   *
+   * On write failure the batch is put back at the head of the buffer so the
+   * next flush / shutdown drain retries it — a failed append must not
+   * permanently drop queued lines (ENOSPC etc.).
    */
   async flush(): Promise<void> {
     if (this.flushTimer !== null) {
@@ -64,11 +70,21 @@ export class SessionBatchWriter {
       this.flushTimer = null
     }
     if (this.flushPromise !== null) return this.flushPromise
-    const text = this.pendingBuffer
-    this.pendingBuffer = ''
-    if (text.length === 0) return
-    this.flushPromise = this.writeBatch(text).finally(() => { this.flushPromise = null })
+    this.flushPromise = this.drainPending().finally(() => { this.flushPromise = null })
     return this.flushPromise
+  }
+
+  private async drainPending(): Promise<void> {
+    while (this.pendingBuffer.length > 0) {
+      const text = this.pendingBuffer
+      this.pendingBuffer = ''
+      try {
+        await this.writeBatch(text)
+      } catch (err) {
+        this.pendingBuffer = text + this.pendingBuffer
+        throw err
+      }
+    }
   }
 
   /** Synchronous flush variant for the sync compaction paths. */

--- a/src/agent/session-metadata.ts
+++ b/src/agent/session-metadata.ts
@@ -71,7 +71,15 @@ export class SessionMetadataStore {
   /** Persist in-memory metadata when dirty (batch-flush cadence). */
   flush(): void {
     if (!this.dirty) return
+    try {
+      writeFileAtomicSync(this.metadataPath, JSON.stringify(this.cached ?? {}, null, 2) + '\n')
+    } catch (err) {
+      // Keep dirty so the next batch flush retries — clearing it before the
+      // write meant one failed write silently dropped every metadata update
+      // since the last successful flush.
+      this.dirty = true
+      throw err
+    }
     this.dirty = false
-    writeFileAtomicSync(this.metadataPath, JSON.stringify(this.cached ?? {}, null, 2) + '\n')
   }
 }


### PR DESCRIPTION
# fix(agent): 会话转录写入失败丢批、flush 竞态击穿落盘屏障

**分支**：`fix/session-batch-writer-durability` ｜ 改动：`session-batch-writer.ts` + `session-metadata.ts` + 回归测试

## 问题 A：flush 失败后整批消息永久丢失

`flush()` 先清空 `pendingBuffer` 再写盘（session-batch-writer.ts）。`appendFile` 抛 ENOSPC（磁盘满）/EIO/权限类错误时，这批行既没落盘、也没留在内存——**永久丢失**。200ms 定时器路径只打一行 `console.error`，用户在界面上毫无感知，会话继续跑，重启后才发现对话缺了一截。`SessionMetadataStore.flush()` 同样的病：`dirty=false` 置于写盘之前，一次写失败静默丢掉自上次成功落盘以来的全部元数据更新（turn 数、token 记账等）。

而 session-persist.ts 的注释明说，这套 write-behind 机制要防的正是"工具结果必须落盘"——契约在最常见的故障（磁盘满）下失效。

## 问题 B：flush:true 持久化屏障被竞态击穿

in-flight flush 进行期间新入队的行：`flush()` 先 `clearTimeout` 再早返回 in-flight promise——新行不在被 await 的 promise 覆盖范围内、定时器又被清了，**从此没有任何冲刷计划**。`appendOaiWithChecksum(msg, {flush:true})` 的屏障语义失效：屏障返回≠数据落盘。这正是 2026-09-08 crash-recovery fix（session-persist-listener.ts「hard-kill 不能丢已完成的 tool result」）要堵的窗口，被这个竞态重新打开。

## 为什么一直没被发现

persist/codec 测试全走 happy path，没有对 `appendFile` 的失败注入；flush:true 的既有测试恰好测在 writer 空闲态；"in-flight 期间入队再 flush"这个交错无测试覆盖。

## 修复

- 写失败的批前置回缓冲区头部，下一次 flush / shutdown drain 自动重试——**同仓 server 侧写链（src/server/session-persistence.ts）失败重排队就是这么做的**，本 PR 把同一纪律补到 agent 侧；metadata 的 `dirty` 同样失败回滚。
- `flush()` 改 drain 语义：in-flight 结束后继续循环冲刷，并发调用方共享同一 drain promise。

## 回归测试

EISDIR 真实 OS 错误注入（零 mock）：失败后批必须仍在缓冲可重试；in-flight 窗口入队的行在屏障返回后必须已落盘。两条测试在修复前均红，修复后该套件 13/13 全绿。
