### PR TITLE
fix(agent): CVM 注入预算裁剪先于送达记账——修复假送达腐蚀习惯化/效能反馈环

### DIFF
--- a/src/agent/__tests__/advisory-bus.test.ts
+++ b/src/agent/__tests__/advisory-bus.test.ts
@@ -926,3 +926,28 @@ describe('W3 穿透让位：验证债 MUTEX 对（2026-07-25 advisory-ecology-re
     assert.ok(!out.includes('virtue-encouragement'), '观察窗内「你有债」事实已被指认，表扬必须让位')
   })
 })
+
+describe('W6 注入预算 × 送达记账一致性（2026-09-10 audit：假送达修复）', () => {
+  it('被预算裁掉的条目不得进 delivered/ledgerRendered——两本账必须与实际渲染一致', () => {
+    const bus = new AdvisoryBus()
+    bus.setOverheadThrottled(true) // W6 节流 → cvmInjectionBudget = max(1, 3-2) = 1
+    bus.submitAll([
+      { key: 'turn-call-limit', priority: 0.9, category: 'discipline', content: 'A' },
+      { key: 'readonly-spiral', priority: 0.8, category: 'execution', content: 'B' },
+      { key: 'stale-plan', priority: 0.7, category: 'planning', content: 'C' },
+    ])
+    const out = bus.render(undefined, 1)
+    const delivered = bus.drainDelivered()
+    const ledger = bus.drainLedger()
+    const renderedKeys = [...out.matchAll(/<entry key="([^"]+)"/g)].map(m => m[1]!)
+
+    assert.equal(renderedKeys.length, 1, '预算=1 只放行 1 条')
+    assert.equal(delivered.length, renderedKeys.length,
+      'delivered 必须只含真正进 prompt 的条目——被裁条目进 delivered 会污染 readback/efficacy')
+    assert.equal(ledger.rendered, renderedKeys.length, 'ledgerRendered 同口径')
+    for (const key of ledger.droppedKeys) {
+      assert.ok(!delivered.some(d => d.key === key), `被裁 key ${key} 不得出现在 delivered`)
+    }
+  })
+
+})

--- a/src/agent/advisory-bus.ts
+++ b/src/agent/advisory-bus.ts
@@ -1160,7 +1160,31 @@ export class AdvisoryBus {
     taken.sort(compareEntries)
     sorted.push(...taken)
 
-    // 账本：本轮参与竞争但没拿到渲染位的条目（类别上限 / Top-N 截断）。
+    // ── Wave 2 统一注入预算 ──
+    // 上游 8 层降频机制各自判断后，此处单点约束最终进入 prompt 的总数。
+    // W6 throttle 信号 → 削减预算（替代隔周期 skip）；正常态预算 = 3。
+    // 必须先于下面的送达记账执行：被预算裁掉的条目从未进入 prompt，
+    // 若先记账再裁剪，它们会同时落在 delivered（假送达）与 dropped 两本账上，
+    // readback 会把它们误判为 ignored、推进习惯化静音与 efficacy 冷却。
+    const CVM_INJECTION_BASE_BUDGET = 3
+    const busCount = sorted.length
+    const srPending = this.srPendingDelivery.size
+    // ⚠ 按 key 数计数初期足够（SR 天然低频），后续可按 injectedTokens 加权校准
+    const cvmInjectionBudget = this.overheadThrottled
+      ? Math.max(1, CVM_INJECTION_BASE_BUDGET - 2)
+      : CVM_INJECTION_BASE_BUDGET
+
+    // constitutional / immediate 完全豁免——不占预算配额，nonexempt 独立计数
+    const exempt = sorted.filter(e => e.tier === 'constitutional' || e.immediate === true)
+    const nonexempt = sorted.filter(e => e.tier !== 'constitutional' && e.immediate !== true)
+    if (nonexempt.length > cvmInjectionBudget) {
+      const keep = [...exempt, ...nonexempt.slice(0, cvmInjectionBudget)]
+      const pruned = nonexempt.slice(cvmInjectionBudget)
+      this.recordDropped(pruned.map(e => e.key))
+      sorted = keep
+    }
+
+    // 账本：本轮参与竞争但没拿到渲染位的条目（类别上限 / Top-N 截断 / 注入预算）。
     // holdout 扣留 ≠ 丢弃（单独计 heldOut,且照常进 delivered 核销）。
     const renderedKeys = new Set(sorted.map(e => e.key))
     const heldKeys = new Set(heldOut.map(e => e.key))
@@ -1185,27 +1209,6 @@ export class AdvisoryBus {
       expect: e.expect,
       shadow: true,
     })))
-
-    // ── Wave 2 统一注入预算 ──
-    // 上游 8 层降频机制各自判断后，此处单点约束最终进入 prompt 的总数。
-    // W6 throttle 信号 → 削减预算（替代隔周期 skip）；正常态预算 = 3。
-    const CVM_INJECTION_BASE_BUDGET = 3
-    const busCount = sorted.length
-    const srPending = this.srPendingDelivery.size
-    // ⚠ 按 key 数计数初期足够（SR 天然低频），后续可按 injectedTokens 加权校准
-    const cvmInjectionBudget = this.overheadThrottled
-      ? Math.max(1, CVM_INJECTION_BASE_BUDGET - 2)
-      : CVM_INJECTION_BASE_BUDGET
-
-    // constitutional / immediate 完全豁免——不占预算配额，nonexempt 独立计数
-    const exempt = sorted.filter(e => e.tier === 'constitutional' || e.immediate === true)
-    const nonexempt = sorted.filter(e => e.tier !== 'constitutional' && e.immediate !== true)
-    if (nonexempt.length > cvmInjectionBudget) {
-      const keep = [...exempt, ...nonexempt.slice(0, cvmInjectionBudget)]
-      const pruned = nonexempt.slice(cvmInjectionBudget)
-      this.recordDropped(pruned.map(e => e.key))
-      sorted = keep
-    }
 
     if (sorted.length === 0) {
       this.entries = []


### PR DESCRIPTION
# fix(agent): CVM 注入预算裁剪先于送达记账——修复假送达腐蚀习惯化/效能反馈环

**分支**：`fix/advisory-bus-budget-accounting` ｜ 改动：`advisory-bus.ts` render() 一处重排 + 回归测试

## 问题：被预算裁掉的条目同时记「已送达」和「已丢弃」，但从未进入 prompt

`render()` 的执行顺序缺陷（src/agent/advisory-bus.ts）：

1. 先记账：`ledgerRendered +=`、`delivered.push(...)`、`recordDeliveredRender`（冷却时钟推进）
2. 后裁剪：Wave 2 CVM 注入预算才把超出配额的条目踢出渲染列表并 `recordDropped`

被裁条目进了 delivered 账本，却从未被模型看到。下游四条腐蚀链全部实装：

- **习惯化静音**：AdvisoryReadback 把幽灵送达当成真，到期判 ignored → `ignoredStreak≥3` → 连续 4 周期静音该类建议；
- **全会话禁言**：efficacy 负反馈环 delivered≥3 零采纳冷却翻倍、≥6 直接全会话禁言——一个从未渲染过的 key 被永久禁言；
- **冷却虚胖**：被裁 key 照常推进冷却时钟，下次真正该提醒时被压住；
- **幽灵信号**：control-plane 为假条目发 `advisory:delivered:*` 信号，污染下游注意力路由。

**触发面集中在最坏的时刻**：W6 开销压力态把预算降到 1（pressure-monitor 节流路径），此时每轮 co-render 的建议里除第一条外全部被假记账——而压力态恰是建议最密集、反馈环最需要准确的时候。

## 为什么一直没被发现

advisory-bus 既有测试只断言渲染字符串里 key 出现与否，从不核对 `drainDelivered()`/账本与实际输出的一致性；readback 测试手喂 delivered 数组、不经过 bus。同类问题在 SR 通道已经修过（turn-step-producer 注释「cap 拦截不进 delivered」），bus 通道漏了同样的规则。

## 修复

预算裁剪块整体上移到送达记账之前——一处重排，零逻辑增删。

## 为什么值得修（不修的后果）

CVM 是本项目的核心卖点（72 hook + A/B 实证报告），而 habituation/efficacy 这套反馈环是它"越用越准"的机制。记账一旦掺假：该响的提醒被系统性静音（假 ignored）、不该禁言的 key 被永久禁言（假 delivered 零采纳），**CVM 在压力场景下静默退化为摆设，而遥测看起来一切正常**。顺带，A/B 实证数据本身也会被污染的反馈环拉偏。

## 回归测试

节流态（预算=1）+ 3 条建议 → `drainDelivered()` 数量必须等于渲染 XML 里实际条目数、被裁 key 不得出现在 delivered。修复前红，修复后 advisory-bus 套件 59/59、全部消费方套件（readback/holdout/lift-consumer/cvm-vector-integration/turn-step-producer-hardstall）73/73 全绿。
