### PR TITLE
fix(agent): 运行时 hook 超时后的迟到收尾兜底——孤儿 rejection 不再击穿进程

### DIFF
--- a/src/agent/__tests__/runtime-hooks.test.ts
+++ b/src/agent/__tests__/runtime-hooks.test.ts
@@ -143,6 +143,30 @@ describe('RuntimeHookPipeline', () => {
     assert.equal(pipeline.getStats()[0]!.timeouts, 1)
   })
 
+  it('超时后迟到的 rejection 不成孤儿——迟到失败进 onError 保留现场（2026-09-10 修复）', async () => {
+    const errors: RuntimeHookError[] = []
+    const lateReject: PreTurnRuntimeHook = {
+      phase: 'preTurn',
+      name: 'late-reject',
+      // 超时窗（50ms）过后 80ms 才 reject——修复前是 unhandledRejection：
+      // main.ts 有 eperm-filter 兜底只打 stderr，未装的嵌入方在 Node ≥15 直接崩。
+      run: () => new Promise<void>((_, reject) => setTimeout(() => reject(new Error('essence LLM 网络错误')), 130)),
+    }
+    const pipeline = new RuntimeHookPipeline([lateReject], {
+      onError: error => errors.push(error),
+      hookTimeoutMs: 50,
+    })
+    await pipeline.runPreTurn(makeContext())
+    // 等迟到 rejection 落地
+    await new Promise(resolve => setTimeout(resolve, 250))
+
+    assert.equal(pipeline.getStats()[0]!.timeouts, 1, 'run 统计只记一次 timed_out，不重复计 runs')
+    const late = errors.find(e => e.message.includes('late failure after timeout'))
+    assert.ok(late, '迟到失败应进 onError 保留现场')
+    assert.equal(late!.hookName, 'late-reject')
+    assert.match(late!.message, /essence LLM 网络错误/)
+  })
+
   it('超时 hook 只报一条 onError，不重复标 slow（slow 只认 completed 结局）', async () => {
     // 生产默认 hookTimeoutMs=10_000 > hookSlowMs=2_000（runtime-hooks.ts L154-155）。
     // 现有超时测试 hookTimeoutMs:50 未设 slowMs（默认 2000），elapsed≈50 < 2000，

--- a/src/agent/runtime-hooks.ts
+++ b/src/agent/runtime-hooks.ts
@@ -339,9 +339,10 @@ export class RuntimeHookPipeline {
       let timedOut = false
       let outcome: RuntimeHookRunOutcome = 'completed'
       let message: string | undefined
+      let pending: Promise<void> | undefined
 
       try {
-        const pending = Promise.resolve().then(() => invoke(hook))
+        pending = Promise.resolve().then(() => invoke(hook))
         if (timeoutMs > 0) {
           await Promise.race([
             pending,
@@ -375,6 +376,22 @@ export class RuntimeHookPipeline {
           budgetMs: timeoutMs,
           slow: outcome === 'completed' && durationMs >= slowMs,
           message,
+        })
+      }
+
+      if (timedOut && pending) {
+        // 迟到收尾：race 超时后 pending 仍会 settle。迟到的 rejection 是
+        // unhandledRejection（main.ts 有 eperm-filter 兜底只打 stderr；未装
+        // 该 filter 的嵌入方/headless 在 Node ≥15 直接崩进程）；迟到的成功
+        // 则副作用照常落地却零记账。迟到失败在此送 onError 保留现场——
+        // run 统计已在上面 finally 以 timed_out 记账，不重复计 runs。
+        pending.catch(lateError => {
+          this.options.onError?.({
+            phase,
+            hookName: hook.name,
+            message: `late failure after timeout: ${toMessage(lateError)}`,
+            error: lateError,
+          })
         })
       }
     }


### PR DESCRIPTION
# fix(agent): 运行时 hook 超时后的迟到收尾兜底——孤儿 rejection 不再击穿进程

**分支**：`fix/runtime-hook-orphan-late-settlement` ｜ 改动：`runtime-hooks.ts` 一处兜底 + 回归测试

## 问题：超时获胜后，hook 自己的 promise 成了没有任何人接手的孤儿

`RuntimeHookPipeline` 用 `Promise.race` 在 hook 与超时之间竞争（src/agent/runtime-hooks.ts:343-357）。超时赢之后，hook 的 pending promise 仍在跑，且没有任何 `.catch` 兜底：

- **迟到 reject → unhandledRejection**。main.ts 装了 eperm-filter 兜底所以 CLI 只是打 stderr 噪音；但 headless 模式（`-p`/`--stream-json` 管道消费方）和任何未装该 filter 的嵌入方，在 Node ≥15 的默认行为是**整个进程崩溃**。最现实的触发载体：postSession 阶段的 essence-gate / session-consolidation 侧路 LLM 调用——长会话结束时的记忆整理 hook 遇到一次网络抖动，就把跑了几十分钟、刚要收尾的会话进程带崩。
- **迟到 resolve → 副作用照常落地但零记账**：advisory 提交、stigmergy 沉淀、LTM 写入在管线已继续推进之后落地，run 记录却已终态 `timed_out`——迟到的失败连现场都不保留（stderr 一行、无 hook 名关联）。

## 为什么一直没被发现

既有超时测试全部使用**永不 settle** 的 hook（wedged promise）——结构上不可能产生迟到 rejection；而 node:test 会把真实的 unhandledRejection 判为测试失败，现有测试形态恰好绕开了这条路径。

## 修复

超时后给 pending 挂迟到收尾：迟到失败送 `onError`（消息前缀 `late failure after timeout:`，保留 hook 名与原始错误）；run 统计已在 finally 以 `timed_out` 记账，不重复计 runs。

## 不修的后果

headless/嵌入场景下一次后台 hook 的网络抖动 = 整个 agent 进程崩溃（长时间任务全丢）；CLI 场景下则是持续的 stderr 噪音 + 失败现场零保留，hook 健康遥测（runtime-hook-health）永远看不到迟到失败的真实率。

## 回归测试

hook 在 50ms 预算后 80ms 才 reject → onError 收到带原始错误消息的迟到失败、stats 恰一次 timeout。修复前红（孤儿 rejection、无 onError），修复后 runtime-hooks 套件 19/19 全绿。
