### PR TITLE
fix(tools): 路径授权表按工作区分域——sidecar 多会话下 A 的批准不再泄漏给 B

### DIFF
--- a/src/tools/__tests__/path-grants.test.ts
+++ b/src/tools/__tests__/path-grants.test.ts
@@ -2,7 +2,7 @@ import { describe, it, beforeEach } from 'node:test'
 import assert from 'node:assert/strict'
 import { mkdtempSync, mkdirSync, rmSync, symlinkSync, existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
-import { join, resolve } from 'node:path'
+import { dirname, join, resolve } from 'node:path'
 
 import { rivetHome } from '../../config/paths.js'
 import {
@@ -418,5 +418,82 @@ describe('isPathUnder (win32 case semantics)', () => {
   it('separator boundary holds in both modes', () => {
     assert.equal(isPathUnder('/a/b', '/a/bc/x', true), false)
     assert.equal(isPathUnder('/a/b', '/a/bc/x', false), false)
+  })
+})
+
+describe('授权表会话作用域（2026-09-11 F1：sidecar 多会话跨工作区泄漏修复）', () => {
+  beforeEach(() => _resetGrantsForTest())
+
+  it('A 工作区批准的授权对 B 工作区的会话不可见', () => {
+    const workspaceA = tmp()
+    const workspaceB = tmp()
+    const outside = tmp()
+    // request-path-access 的真实姿势：A 会话批准工作区外目录可写
+    grantPath(outside, 'write', { persist: false, cwd: workspaceA })
+
+    assert.equal(isWriteGranted(outside, workspaceA), true, '批准方工作区照常可见')
+    assert.equal(isWriteGranted(outside, workspaceB), false, '未批准的工作区 B 不得继承 A 的授权')
+    assert.equal(isWriteGranted(outside), true, '无 cwd 的旧调用方保持全量视图（向后兼容）')
+  })
+
+  it('validatePathSafe 端到端：A 的批准不放行 B 的工作区外写入', () => {
+    const workspaceA = tmp()
+    const workspaceB = tmp()
+    const target = join(tmp(), 'report.txt')
+    grantPath(dirname(target), 'write', { persist: false, cwd: workspaceA })
+
+    assert.equal(validatePathSafe(workspaceA, target, 'write').ok, true)
+    assert.equal(validatePathSafe(workspaceB, target, 'write').ok, false,
+      'B 工作区写工作区外路径必须仍走审批——修复前会静默放行（泄漏）')
+  })
+
+  it('loadPersistedGrants 只为本工作区注水，不灌进其他工作区的视图', () => {
+    const workspaceA = tmp()
+    const workspaceB = tmp()
+    const outside = tmp()
+    grantPath(outside, 'write', { persist: true, cwd: workspaceA })
+    _resetGrantsForTest()
+
+    loadPersistedGrants(workspaceA)
+    assert.equal(isWriteGranted(outside, workspaceA), true, '本工作区的持久授权注水后可见')
+    assert.equal(isWriteGranted(outside, workspaceB), false,
+      '另一工作区（或其后续会话）不得看见 A 的持久授权')
+  })
+
+  it('config 级授权（无 cwd）保持进程级语义不变', () => {
+    const workspaceA = tmp()
+    const workspaceB = tmp()
+    const outside = tmp()
+    applyConfiguredPathGrants({ additionalWriteDirs: [outside] })
+
+    assert.equal(isWriteGranted(outside, workspaceA), true)
+    assert.equal(isWriteGranted(outside, workspaceB), true, '用户显式配置的目录授权对所有会话生效（行为不变）')
+  })
+
+  it('writeGrantedRoots(cwd) 只列出对该会话可见的可写根（沙箱喂食点）', () => {
+    const workspaceA = tmp()
+    const workspaceB = tmp()
+    const outsideA = tmp()
+    const outsideB = tmp()
+    grantPath(outsideA, 'write', { persist: false, cwd: workspaceA })
+    grantPath(outsideB, 'write', { persist: false, cwd: workspaceB })
+
+    const rootsA = writeGrantedRoots(workspaceA)
+    const rootsB = writeGrantedRoots(workspaceB)
+    assert.ok(rootsA.some(r => isPathUnder(r, outsideA)), 'A 看得见自己批准的根')
+    assert.ok(!rootsB.some(r => isPathUnder(r, outsideA)), 'B 的沙箱不得被 A 的授权撑宽')
+    assert.ok(rootsB.some(r => isPathUnder(r, outsideB)), 'B 看得见自己批准的根')
+  })
+
+  it('同一根目录可被不同工作区各自授权，互不串扰', () => {
+    const workspaceA = tmp()
+    const workspaceB = tmp()
+    const outside = tmp()
+    grantPath(outside, 'read', { persist: false, cwd: workspaceA })
+    grantPath(outside, 'write', { persist: false, cwd: workspaceB })
+
+    assert.equal(isReadGranted(outside, workspaceA), true)
+    assert.equal(isWriteGranted(outside, workspaceA), false, 'A 只批了读，B 的写授权不回流 A')
+    assert.equal(isWriteGranted(outside, workspaceB), true, 'B 的写授权只在 B 生效')
   })
 })

--- a/src/tools/path-grants.ts
+++ b/src/tools/path-grants.ts
@@ -35,12 +35,36 @@ export interface PathGrant {
   grantedAt: number
   /** True when this grant was written through to the per-workspace store. */
   persisted?: boolean
+  /**
+   * Session scope: canonicalized cwd of the session that approved this grant.
+   * Interactively approved grants (request_path_access) and per-workspace
+   * persisted grants are ALWAYS scoped. Scope-less grants (config
+   * permissions.additional*Dirs, dependency-cache read grants, rivet runtime
+   * dirs) are user- or tool-level by design and visible to every session in
+   * the process.
+   *
+   * The sidecar (`rivet serve`) hosts many sessions — possibly across
+   * different workspaces — in ONE process, so an unscoped interactive grant
+   * approved in workspace A would silently authorize writes from workspace B.
+   * The header contract below ("a grant for project A must not leak into
+   * project B") is enforced through this field.
+   */
+  scope?: string
 }
 
 const RIVET_DIR = rivetHome()
 
-/** In-memory grants for the current process/session. */
+/** In-memory grants for the current process. Interactive/persisted grants are
+ *  session-scoped via PathGrant.scope; scope-less entries are user-level. */
 let _grants: PathGrant[] = []
+
+/** True when grant `g` is visible to the session running in `cwd`. An omitted
+ *  cwd (legacy callers) sees everything. */
+function scopeVisible(g: PathGrant, cwd?: string): boolean {
+  if (!cwd) return true
+  if (g.scope === undefined) return true
+  return g.scope === canonicalize(cwd)
+}
 
 /**
  * Canonicalize a path: resolve symlinks where the path (or its nearest existing
@@ -118,11 +142,21 @@ function grantsFile(cwd: string): string {
  * Grant access to a directory subtree. `root` is canonicalized. A write grant
  * supersedes a prior read grant on the same root. When `opts.persist` is set,
  * the grant is also written to the per-workspace store (requires opts.cwd).
+ *
+ * When `opts.cwd` is provided the grant is SCOPED to that workspace/session:
+ * it authorizes only sessions running in the same cwd. Interactively approved
+ * grants must always pass cwd — an unscoped grant would leak across every
+ * session the sidecar hosts. Callers that intentionally grant process-wide
+ * (config permissions, dependency caches, rivet runtime dirs) omit cwd.
  */
 export function grantPath(root: string, mode: GrantMode, opts?: { persist?: boolean; cwd?: string }): PathGrant {
   const canonical = canonicalize(root)
+  const scope = opts?.cwd ? canonicalize(opts.cwd) : undefined
   const persist = opts?.persist === true
-  const existing = _grants.find(g => foldCase(g.root) === foldCase(canonical))
+  const existing = _grants.find(g =>
+    foldCase(g.root) === foldCase(canonical)
+    && g.scope === scope,
+  )
   let grant: PathGrant
   if (existing) {
     // Upgrade read → write; never downgrade.
@@ -130,28 +164,28 @@ export function grantPath(root: string, mode: GrantMode, opts?: { persist?: bool
     if (persist) existing.persisted = true
     grant = existing
   } else {
-    grant = { root: canonical, mode, grantedAt: Date.now(), ...(persist ? { persisted: true } : {}) }
+    grant = { root: canonical, mode, grantedAt: Date.now(), ...(persist ? { persisted: true } : {}), ...(scope ? { scope } : {}) }
     _grants.push(grant)
   }
   if (persist && opts?.cwd) persistGrants(opts.cwd)
   return grant
 }
 
-/** True if `absPath` is under any granted root (read or write satisfies read). */
-export function isReadGranted(absPath: string): boolean {
+/** True if `absPath` is under any granted root visible to `cwd` (read or write satisfies read). */
+export function isReadGranted(absPath: string, cwd?: string): boolean {
   const target = canonicalize(absPath)
-  return _grants.some(g => isUnder(g.root, target))
+  return _grants.some(g => scopeVisible(g, cwd) && isUnder(g.root, target))
 }
 
-/** True if `absPath` is under any WRITE-granted root. */
-export function isWriteGranted(absPath: string): boolean {
+/** True if `absPath` is under any WRITE-granted root visible to `cwd`. */
+export function isWriteGranted(absPath: string, cwd?: string): boolean {
   const target = canonicalize(absPath)
-  return _grants.some(g => g.mode === 'write' && isUnder(g.root, target))
+  return _grants.some(g => g.mode === 'write' && scopeVisible(g, cwd) && isUnder(g.root, target))
 }
 
-/** All write-granted roots (consumed by the sandbox's writable-roots builder). */
-export function writeGrantedRoots(): string[] {
-  return _grants.filter(g => g.mode === 'write').map(g => g.root)
+/** Write-granted roots visible to `cwd` (consumed by the sandbox's writable-roots builder). */
+export function writeGrantedRoots(cwd?: string): string[] {
+  return _grants.filter(g => g.mode === 'write' && scopeVisible(g, cwd)).map(g => g.root)
 }
 
 /** Snapshot of current grants. */
@@ -203,9 +237,12 @@ export function listPersistedGrants(cwd: string): PathGrant[] {
 export function revokeGrant(root: string, opts: { cwd: string }): boolean {
   const canonical = canonicalize(root)
   const matches = (candidate: string): boolean => foldCase(canonicalize(candidate)) === foldCase(canonical)
+  // Only this workspace's scoped grants (plus scope-less user-level grants) are
+  // revocable here — another workspace's in-memory grant must not be touched.
+  const revocable = (g: PathGrant): boolean => matches(g.root) && (g.scope === undefined || g.scope === canonicalize(opts.cwd))
 
-  const hadInMemory = _grants.some(g => matches(g.root))
-  if (hadInMemory) _grants = _grants.filter(g => !matches(g.root))
+  const hadInMemory = _grants.some(revocable)
+  if (hadInMemory) _grants = _grants.filter(g => !revocable(g))
 
   const onDisk = readPersistedFile(opts.cwd)
   const kept = onDisk.filter(g => !matches(g.root))
@@ -251,8 +288,13 @@ export function loadPersistedGrants(cwd: string): void {
     if (!g || typeof g.root !== 'string') continue
     if (!existsSync(g.root)) continue
     const mode: GrantMode = g.mode === 'write' ? 'write' : 'read'
-    grantPath(g.root, mode, { persist: false })
-    const stored = _grants.find(x => foldCase(x.root) === foldCase(canonicalize(g.root)))
+    // Scoped to this workspace: another workspace's persisted grants must not
+    // become visible to sessions running here (sidecar hosts many cwds).
+    grantPath(g.root, mode, { persist: false, cwd })
+    const stored = _grants.find(x =>
+      foldCase(x.root) === foldCase(canonicalize(g.root))
+      && x.scope === canonicalize(cwd),
+    )
     if (stored) stored.persisted = true
   }
 }

--- a/src/tools/path-validate.ts
+++ b/src/tools/path-validate.ts
@@ -84,7 +84,10 @@ export function validatePathSafe(cwd: string, inputPath: string, mode: 'read' | 
     // Out of workspace — allow only if the user has granted access to this
     // subtree at the requested mode (the grant store is widened solely through
     // the approval flow; nothing here grants on its own).
-    const granted = mode === 'write' ? isWriteGranted(real) : isReadGranted(real)
+    // Scoped to this workspace's cwd: the sidecar hosts sessions from many
+    // workspaces in one process, so only grants approved by (or persisted for)
+    // THIS workspace — plus user-level config/cache grants — may widen it.
+    const granted = mode === 'write' ? isWriteGranted(real, cwd) : isReadGranted(real, cwd)
     if (granted) return { ok: true, path: resolved }
     return {
       ok: false,

--- a/src/tools/request-path-access.ts
+++ b/src/tools/request-path-access.ts
@@ -52,7 +52,10 @@ export const REQUEST_PATH_ACCESS_TOOL: Tool = {
       root = dirname(target)
     }
 
-    const grant = grantPath(root, mode, { persist: remember, cwd: params.cwd })
+    // An interactive approval is ALWAYS scoped to this session's workspace —
+    // a missing cwd must fall back to the process cwd, never to an unscoped
+    // (process-wide) grant.
+    const grant = grantPath(root, mode, { persist: remember, cwd: params.cwd ?? process.cwd() })
     const lifetime = remember ? '已为本工作区持久化（重启后仍有效）' : '仅本会话'
     return {
       content: `已授予 ${grant.mode} 访问：${grant.root}\n范围：该目录及其下全部路径 — ${lifetime}。\n文件工具与 bash 现在可以在此${grant.mode === 'write' ? '读写' : '读取'}路径。`,

--- a/src/tools/sandbox-profile.ts
+++ b/src/tools/sandbox-profile.ts
@@ -144,8 +144,10 @@ export function defaultWritableRoots(ctx: { cwd: string; env?: NodeJS.ProcessEnv
 
   // User-approved out-of-workspace write grants (session or persisted). Recomputed
   // per command-wrap, so a grant approved mid-session takes effect on the next
-  // bash call with no restart.
-  for (const granted of writeGrantedRoots()) roots.add(granted)
+  // bash call with no restart. Scoped to this command's cwd: the sidecar hosts
+  // sessions from multiple workspaces, and a grant approved in workspace A must
+  // not widen B's sandbox.
+  for (const granted of writeGrantedRoots(ctx.cwd)) roots.add(granted)
 
   return [...roots]
 }


### PR DESCRIPTION
# fix(tools): 路径授权表按工作区分域——sidecar 多会话下 A 的批准不再泄漏给 B

**分支**：`fix/path-grants-session-scope` ｜ 改动：`path-grants.ts` + 三个消费方接线 + 6 条回归测试

## 问题（实测复现，非读码推断）：一个进程服务多个项目时，A 的授权静默变成 B 的通行证

`rivet serve` sidecar 在**一个进程里托管多个会话**（session-manager 的 sessions Map），且 `POST /sessions` 允许每个会话带**不同的 cwd**（桌面端多项目同开的自然用法）。而授权表 `path-grants.ts` 的 `_grants` 是**模块级全局数组**，所有文件工具（write_file/edit_file/apply_patch/ast_edit/delegate/diff…经 validatePathSafe）和 **bash 沙箱可写根**（writeGrantedRoots → sandbox-profile）查的都是同一张表。

本文件头注释自己写明的契约——"grants live in-process (**one session**) by default… a grant for project A must **not leak into project B**"——在这个进程模型下**完全失效**：

- 项目 A 会话经 `request_path_access` 批准的"~/Desktop 可写"，项目 B 的会话**立即免费继承**——B 写工作区外不弹审批、bash 沙箱也一并被撑宽
- 交互批准的授权（用户没勾"记住"的那些）寿命变成**进程级**——sidecar 不死授权不死
- `loadPersistedGrants(cwd)` 每次会话引导把各自工作区的持久授权灌进同一张全局表，跨工作区互相可见
- `revokeGrant` 从全局数组摘除，一个工作区的撤销会**误伤**另一个工作区正在使用的同名授权

## 实测复现（真实模块+真实目录，`F1_EXPECT_FIXED=1` 切换修复前后语义）

```
PASS | ① 基线：B 会话写工作区外被拒
PASS | ② A 会话写自己批准的路径放行（对照：门本身工作正常）
PASS | ③ B 会话（未批准方）也放行 = 跨会话泄漏      ← 修复后：B 被正确拒绝
PASS | ④ bash 沙箱可写根对全进程生效（含 B）          ← 修复后：B 的可写根为空
```

## 为什么一直没被发现

- CLI 单进程单会话，世界模型成立，泄漏路径根本不存在
- 授权相关测试全是单进程单会话——没有"同进程两个不同 cwd 会话"的用例
- 泄漏方向是"**少弹审批**"：没有报错、没有日志异常、对获得豁免的会话反而像体验优化——静默失败零信号

## 修复

`PathGrant` 增加 `scope` 字段（批准会话的 canonical cwd），交互授权与持久授权**必带作用域**；无作用域的条目（config permissions、依赖缓存只读授权、rivet 运行时目录）是用户级/工具级设计，保持进程级语义**不变**：

- `grantPath(root, mode, {cwd})` → 按 (root, scope) 去重与升级
- `isReadGranted/isWriteGranted(absPath, cwd)` / `writeGrantedRoots(cwd)` → 只见本工作区 + 无作用域条目
- `validatePathSafe`、`defaultWritableRoots(ctx)` 接线传入 cwd
- `loadPersistedGrants(cwd)` 注水即带本工作区作用域；`revokeGrant` 只摘本工作区作用域 + 无作用域条目（不再误伤他区）
- `request_path_access` 的 cwd 兜底 `?? process.cwd()`——交互批准**永不**落入无作用域态

## 回归测试（6 条）

- A 批准的授权 B 不可见 / validatePathSafe 端到端 B 仍被拒 / 持久授权注水不跨区 / config 授权进程级语义不变（防矫枉过正守卫）/ 沙箱喂食按会话过滤 / 同一根目录可被两区各自授权互不串扰
- 阴性对照：还原修复后 5 条泄漏测试全红、守卫条保持绿；修复后本套件 29/29、受影响全域（grants+validate+sandbox 家族+request-path-access）123/123 全绿

## 不修的后果

权限边界静默变宽：跨项目免审批越权写（含 bash）、审批"没问"与"放行"在用户眼里无法区分、授权泄漏对受害者不可见不可撤、出事后无法回答"这次写是谁批的"。对以"认知护栏"为核心卖点的项目，这是拆自己招牌的债。
