### PR TITLE
feat(server): 定时任务记住创建时的工作区——多项目 sidecar 下任务不再跑错目录

### DIFF
--- a/src/server/__tests__/cron-scheduler.test.ts
+++ b/src/server/__tests__/cron-scheduler.test.ts
@@ -603,3 +603,47 @@ function futureISO(secondsAhead: number): string {
 function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms))
 }
+
+
+describe('ScheduledTask.cwd 创建工作区快照（2026-09-11 F2：多项目 sidecar 修复）', () => {
+  it('runNow 触发时 TaskDueMeta 携带任务 cwd', () => {
+    const metas: Array<{ cwd?: string }> = []
+    const scheduler = new CronScheduler({
+      schedulePath: join(tmpDir, 'f2-meta.json'),
+      tickIntervalMs: 60_000,
+    })
+    scheduler.subscribeTaskDue(async (_prompt, _tools, _agentId, meta) => {
+      metas.push({ cwd: meta?.cwd })
+    })
+    const task = createScheduledTask('deps check', { type: 'interval', spec: '3600000' }, [], { cwd: '/workspace/A' })
+    scheduler.add(task)
+    assert.equal(scheduler.runNow(task.id), true)
+    assert.equal(metas.length, 1)
+    assert.equal(metas[0]!.cwd, '/workspace/A', 'due handler 必须拿到任务的工作区快照')
+  })
+
+  it('cwd 经持久化 roundtrip 存活（跨重启语义）', () => {
+    const path = join(tmpDir, 'f2-persist.json')
+    const s1 = new CronScheduler({ schedulePath: path, tickIntervalMs: 60_000 })
+    s1.add(createScheduledTask('daily check', { type: 'interval', spec: '86400000' }, [], { cwd: '/workspace/A' }))
+    s1.stop()
+
+    const s2 = new CronScheduler({ schedulePath: path, tickIntervalMs: 60_000 })
+    s2.start()
+    s2.stop()
+    const loaded = s2.list()
+    assert.equal(loaded.length, 1)
+    assert.equal(loaded[0]!.cwd, '/workspace/A', '持久化必须保留 cwd（重启后任务仍在原工作区跑）')
+  })
+
+  it('旧持久化数据（无 cwd）normalize 后保持 undefined——回退 defaultCwd', () => {
+    const path = join(tmpDir, 'f2-legacy.json')
+    const s1 = new CronScheduler({ schedulePath: path, tickIntervalMs: 60_000 })
+    s1.add(createScheduledTask('legacy', { type: 'interval', spec: '86400000' }))
+    s1.stop()
+    const s2 = new CronScheduler({ schedulePath: path, tickIntervalMs: 60_000 })
+    s2.start()
+    s2.stop()
+    assert.equal(s2.list()[0]!.cwd, undefined)
+  })
+})

--- a/src/server/__tests__/cron-wiring.test.ts
+++ b/src/server/__tests__/cron-wiring.test.ts
@@ -208,3 +208,29 @@ describe('CronWiring', () => {
 function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms))
 }
+
+describe('CronWiring cwd 透传（2026-09-11 F2）', () => {
+  let cleanup: () => void
+  afterEach(() => { cleanup?.() })
+
+  it('定时任务触发的 TaskRecord 携带创建工作区 cwd', async () => {
+    const { registry, scheduler, lock } = setup()
+    cleanup = () => {
+      scheduler.stop()
+      rmSync(TEST_LOCK_PATH, { force: true })
+      rmSync(TEST_SCHEDULE_PATH, { force: true })
+      rmSync(TEST_TASKS_DIR, { recursive: true, force: true })
+    }
+    const task = createScheduledTask('deps check in A', { type: 'interval', spec: '50' }, [], { cwd: '/workspace/A' })
+    scheduler.add(task)
+    const wiring = new CronWiring({ scheduler, registry, lock })
+    await wiring.start()
+    await sleep(250)
+    const cronTasks = await registry.listTasks({ source: 'cron' })
+    assert.ok(cronTasks.length >= 1)
+    assert.equal(cronTasks[0]!.cwd, '/workspace/A',
+      'cron 触发的任务必须记录创建工作区（执行 cwd 的来源）')
+    await wiring.stop()
+  })
+})
+

--- a/src/server/__tests__/session-runtime-pool.test.ts
+++ b/src/server/__tests__/session-runtime-pool.test.ts
@@ -213,3 +213,27 @@ test('runAndWait is tied to its exact run across rapid next run', async () => {
   )
   assert.equal(listenerCount(manager, session.id), 0)
 })
+
+
+test('execute options.cwd 优先于池 defaultCwd（2026-09-11 F2：cron 任务在创建工作区跑）', async () => {
+  const env = setup()
+  const captured: Array<string | undefined> = []
+  const orig = env.manager.createSession.bind(env.manager)
+  env.manager.createSession = ((opts: { cwd?: string } & Record<string, unknown>) => {
+    captured.push(opts?.cwd)
+    return orig(opts)
+  }) as typeof env.manager.createSession
+
+  const handle = await env.pool.acquire('task-cwd')
+  const signal = new TrackedAbortSignal()
+  const withCwd = handle.execute('work', signal as unknown as AbortSignal, undefined, () => {}, { cwd: '/workspace/A' })
+  env.agents[0]!.finish(0)
+  await withCwd
+  const withoutCwd = handle.execute('work', signal as unknown as AbortSignal, undefined, () => {})
+  env.agents[1]!.finish(0)
+  await withoutCwd
+
+  assert.equal(captured[0], '/workspace/A', '任务自带 cwd 优先')
+  assert.equal(captured[1], '/tmp/work', '缺省回退池 defaultCwd（行为不变）')
+})
+

--- a/src/server/cron-scheduler.ts
+++ b/src/server/cron-scheduler.ts
@@ -70,6 +70,13 @@ export interface ScheduledTask {
   retry?: ScheduledTaskRetry
   /** 审查策略。缺省 = 'always-review'。 */
   reviewPolicy?: ReviewPolicy
+  /**
+   * 创建该任务时会话的工作区（快照）。任务触发后在快照 cwd 里执行——桌面端
+   * 一个 sidecar 托管多个项目，缺省时所有任务都会落到 sidecar 的启动目录，
+   * 项目 A 创建的「检查依赖更新」就会在错误的项目里跑 npm/git。
+   * 缺省（旧持久化数据）= 由执行方回退到 runtime 池的 defaultCwd。
+   */
+  cwd?: string
 }
 
 export type ScheduleTable = ScheduledTask[]
@@ -82,6 +89,8 @@ export interface TaskDueMeta {
   unattended?: boolean
   /** 手动触发（试跑/中止后重跑），非定时到点。 */
   manual?: boolean
+  /** 任务创建时会话的工作区快照（执行 cwd，见 ScheduledTask.cwd）。 */
+  cwd?: string
 }
 
 /**
@@ -552,6 +561,7 @@ export class CronScheduler {
         ? false
         : resolveRunUnattended({ reviewPolicy: task.reviewPolicy, triggerCount: preTriggerCount }),
       ...(opts?.manual ? { manual: true } : {}),
+      ...(task.cwd ? { cwd: task.cwd } : {}),
     }
     for (const handler of this.handlers) {
       try {
@@ -577,7 +587,7 @@ export function createScheduledTask(
   prompt: string,
   trigger: CronTrigger,
   allowedTools: string[] = [],
-  opts?: { recurringMaxAgeMs?: number; agentId?: string; retry?: ScheduledTaskRetry; reviewPolicy?: ReviewPolicy },
+  opts?: { recurringMaxAgeMs?: number; agentId?: string; retry?: ScheduledTaskRetry; reviewPolicy?: ReviewPolicy; cwd?: string },
 ): ScheduledTask {
   return {
     id: `cron_${randomUUID().slice(0, 8)}`,
@@ -590,6 +600,7 @@ export function createScheduledTask(
     triggerCount: 0,
     ...(normalizeRetry(opts?.retry) ? { retry: normalizeRetry(opts?.retry)! } : {}),
     ...(normalizeReviewPolicy(opts?.reviewPolicy) ? { reviewPolicy: normalizeReviewPolicy(opts?.reviewPolicy)! } : {}),
+    ...(opts?.cwd ? { cwd: opts.cwd } : {}),
   }
 }
 
@@ -659,6 +670,7 @@ function normalizeScheduledTask(value: unknown): ScheduledTask | null {
     triggerCount,
     ...(typeof task.recurringMaxAgeMs === 'number' && Number.isFinite(task.recurringMaxAgeMs) ? { recurringMaxAgeMs: task.recurringMaxAgeMs } : {}),
     ...(typeof task.agentId === 'string' ? { agentId: task.agentId } : {}),
+    ...(typeof task.cwd === 'string' && task.cwd ? { cwd: task.cwd } : {}),
     ...(typeof task.lastTriggeredAt === 'string' ? { lastTriggeredAt: task.lastTriggeredAt } : {}),
     ...(typeof task.enabled === 'boolean' ? { enabled: task.enabled } : {}),
     ...(normalizeRetry(task.retry) ? { retry: normalizeRetry(task.retry)! } : {}),

--- a/src/server/cron-wiring.ts
+++ b/src/server/cron-wiring.ts
@@ -75,6 +75,8 @@ export class CronWiring {
         retry: meta?.retry,
         // reviewPolicy 解析结果：无人值守运行的审批 fail-closed 中止。
         unattended: meta?.unattended,
+        // 任务在创建它的会话工作区里执行（见 ScheduledTask.cwd）。
+        cwd: meta?.cwd,
       })
     })
 

--- a/src/server/session-runtime-pool.ts
+++ b/src/server/session-runtime-pool.ts
@@ -34,7 +34,8 @@ export class SessionRuntimePool implements RuntimePool {
     const handle: RuntimeHandle = {
       execute: async (prompt, signal, allowedTools, onSessionStart, options): Promise<RuntimeResult> => {
         const session = this.manager.createSession({
-          cwd: this.defaultCwd,
+          // 任务自带 cwd（cron=创建时会话的工作区快照）优先；缺省回退池 defaultCwd。
+          cwd: options?.cwd ?? this.defaultCwd,
           title: `${this.titlePrefix}:${taskId.slice(0, 8)}`,
           // 无人值守（auto-proceed）：审批请求 fail-closed 中止本次运行。
           unattended: options?.unattended === true,

--- a/src/server/task-registry.ts
+++ b/src/server/task-registry.ts
@@ -44,6 +44,8 @@ export interface RuntimeHandle {
     options?: {
       /** 无人值守运行：会话内审批请求 fail-closed 中止（付费版 v1 · T2）。 */
       unattended?: boolean
+      /** 任务执行的工作区（cron 任务=创建时会话工作区快照）。缺省=池 defaultCwd。 */
+      cwd?: string
     },
   ): Promise<RuntimeResult>
   /** 释放 runtime 回池 */
@@ -160,6 +162,7 @@ export class TaskRegistry {
         ...(input.retryOf ? { retryOf: input.retryOf } : {}),
         ...(input.retry ? { retry: input.retry } : {}),
         ...(input.unattended ? { unattended: true } : {}),
+        ...(input.cwd ? { cwd: input.cwd } : {}),
       }
 
       await this.store.save(r)
@@ -457,7 +460,7 @@ export class TaskRegistry {
         ac.signal,
         record.allowedTools,
         (sessionId) => { void this.attachSessionId(record.id, sessionId) },
-        { unattended: record.unattended === true },
+        { unattended: record.unattended === true, cwd: record.cwd },
       )
 
       await this.transition(record.id, 'completed', { result })

--- a/src/server/task-store.ts
+++ b/src/server/task-store.ts
@@ -65,6 +65,8 @@ export interface TaskRecord {
   scheduledTaskId?: string
   /** 执行该任务的可见 session id（runtime 池创建后回填，用于跳转会话线程）。 */
   sessionId?: string
+  /** 任务执行的工作区（cron 任务=创建时快照；缺省=runtime 池 defaultCwd）。 */
+  cwd?: string
   /** 第几次尝试（首次=1）。 */
   attempt?: number
   /** 若本记录是重试，指向原始任务 id。 */
@@ -97,6 +99,8 @@ export interface CreateTaskInput {
   retry?: ScheduledTaskRetry
   /** 无人值守运行（审批 fail-closed 中止）。 */
   unattended?: boolean
+  /** 任务执行的工作区（cron 任务=创建时快照；缺省=runtime 池 defaultCwd）。 */
+  cwd?: string
 }
 
 // ─── TaskStore 接口 ───────────────────────────────────────────

--- a/src/tools/schedule/__tests__/tool.test.ts
+++ b/src/tools/schedule/__tests__/tool.test.ts
@@ -136,3 +136,14 @@ test('工具定义使用 input_schema 命名（7f22186b0 修复守卫）', () =>
     assert.equal(tool.isEnabled(), true)
   }
 })
+
+
+test('create 把调用会话的 cwd 快照进任务（F2：任务在创建工作区执行）', async () => {
+  await run(SCHEDULE_CREATE_TOOL, { prompt: 'morning check', trigger: { type: 'interval', spec: '3600000' } })
+  const listed = await run(SCHEDULE_LIST_TOOL, {})
+  const tasks = scheduler.list()
+  assert.equal(tasks.length, 1)
+  assert.equal(tasks[0]!.cwd, dir, '任务 cwd = 工具调用上下文的工作区')
+  assert.ok(listed.content.length > 0)
+})
+

--- a/src/tools/schedule/tool.ts
+++ b/src/tools/schedule/tool.ts
@@ -75,7 +75,8 @@ export const SCHEDULE_CREATE_TOOL: Tool = {
       required: ['prompt', 'trigger'],
     },
   },
-  async execute({ input }) {
+  async execute(params) {
+    const { input, cwd: sessionCwd } = params
     const scheduler = getActiveScheduler()
     if (!scheduler) return noScheduler()
     const parsed = createSchema.safeParse(input)
@@ -98,6 +99,9 @@ export const SCHEDULE_CREATE_TOOL: Tool = {
       ...(reviewPolicy ? { reviewPolicy } : {}),
       createdAt: new Date().toISOString(),
       triggerCount: 0,
+      // 快照创建时会话的工作区：任务到点在快照 cwd 里执行（桌面多项目下
+      // sidecar 的 process.cwd() 不是任何一个会话的工作区）。
+      ...(sessionCwd ? { cwd: sessionCwd } : { cwd: process.cwd() }),
     })
     return {
       content: `定时任务已创建（id: ${id}，触发器: ${trigger.type}${trigger.spec ? ` "${trigger.spec}"` : ''}）。它会按触发器自动执行并跨重启存活，可在「自动化」面板管理。`,


### PR DESCRIPTION
# feat(server): 定时任务记住创建时的工作区——多项目 sidecar 下任务不再跑错目录

**分支**：`feat/scheduled-task-cwd` ｜ 改动：`cron-scheduler / cron-wiring / task-store / task-registry / session-runtime-pool / schedule tool` + 5 条回归测试

## 问题：定时任务没有"工作区"这个概念

`rivet serve` 的定时任务（cron/interval/oneshot/startup/app-open）从创建到执行**全程不带 cwd**：

- **创建端**：schedule_create 的输入与 `ScheduledTask` schema 都没有 cwd 字段——用户在项目 A 的会话里说"每天早上检查依赖更新"，任务记录里只有 prompt 和触发器，"在哪个项目里检查"这个最关键的信息**无处存放**
- **执行端**：任务到点 → CronWiring → TaskRegistry → SessionRuntimePool，池子用**固定的 `defaultCwd`**（serve.ts 把它接成 `process.cwd()`——sidecar 的启动目录）给每个触发的会话建 cwd

后果按前端分层：

- **桌面多项目**（POST /sessions 明确支持每会话不同 cwd）：项目 A 建的任务在**错误的目录**里跑 `npm outdated`/`git pull`——要么跑错项目，要么跑在任意的应用启动目录
- **持久化文件** `.rivet/scheduled_tasks.json` 把所有项目的任务混在一个桶里，无从区分
- **VS Code**（每工作区一个 sidecar）和 **CLI**（调度器明示不可用）：恰好不触发——这也是它没被发现的原因

## 修复：创建时快照 cwd，全链透传

- `ScheduledTask` / `createScheduledTask` 增加 `cwd`（创建时会话工作区快照）；`normalizeScheduledTask` 保留它跨持久化 roundtrip（**旧数据无 cwd 保持 undefined，行为不变**）
- `fireTask` 经 `TaskDueMeta.cwd` 透传（与 retry policy 同一条既有通道）
- CronWiring → `TaskRegistry.createTask` → `TaskRecord.cwd` 落库
- `SessionRuntimePool.execute` 优先用任务自带 cwd，缺省回退池 `defaultCwd`
- schedule_create 从工具调用上下文快照 cwd（`process.cwd()` 兜底——交互创建**永不**落入无工作区态）

## 回归测试（5 条，四层各一）

1. 工具层：create 把调用上下文 cwd 快照进任务
2. 调度层：runNow 触发时 TaskDueMeta 携带任务 cwd
3. 持久层：cwd 经持久化 roundtrip 存活（跨重启语义）；旧数据无 cwd → undefined（回退守卫）
4. 接线层：定时任务触发的 TaskRecord 携带创建工作区 cwd
5. 执行层：execute options.cwd 优先于池 defaultCwd；缺省回退行为不变

**阴性对照**：还原修复后 5 条全红；修复后 cron/pool/schedule 全套 75/75 绿，`tsc --noEmit` 干净。
