### PR TITLE
fix(agent): prune 不再删除读不了的 checkpoint——瞬态错误不可逆毁掉回滚点

### DIFF
--- a/src/agent/__tests__/checkpoint.test.ts
+++ b/src/agent/__tests__/checkpoint.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import { execSync } from 'child_process'
-import { existsSync, mkdirSync, writeFileSync, rmSync, readFileSync } from 'fs'
+import { chmodSync, existsSync, mkdirSync, writeFileSync, rmSync, readFileSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { rivetHome } from '../../config/paths.js'
@@ -35,6 +35,40 @@ function cleanupRepo(repo: string): void {
 
 describe('checkpoint module', () => {
   describe('pruneOrphanCheckpoints', () => {
+    it('不可读（瞬态错误/损坏）的 checkpoint 保留不删——2026-09-11 F3 修复', () => {
+      const rivetDir = rivetHome()
+      mkdirSync(rivetDir, { recursive: true })
+      const tag = `prunekeep-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+      const garbage = join(rivetDir, `checkpoint-${tag}.json`)
+      // 模拟瞬态读取失败/半写：内容不是合法 JSON（修复前：解析失败→当孤儿→删除）
+      writeFileSync(garbage, '{ truncated not json')
+      try {
+        pruneOrphanCheckpoints()
+        assert.equal(existsSync(garbage), true,
+          '读不了的 checkpoint 必须保留——Windows EBUSY/权限抖动不应不可逆删除回滚点')
+      } finally {
+        if (existsSync(garbage)) rmSync(garbage, { force: true })
+      }
+    })
+
+    it('读取抛错（EACCES）的 checkpoint 同样保留（unix）', () => {
+      if (process.platform === 'win32') return
+      const rivetDir = rivetHome()
+      mkdirSync(rivetDir, { recursive: true })
+      const tag = `pruneperm-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+      const locked = join(rivetDir, `checkpoint-${tag}.json`)
+      const deadCwd = join(tmpdir(), `rivet-ck-gone-${Date.now()}`)
+      writeFileSync(locked, JSON.stringify({ version: 2, hash: 'x', timestamp: Date.now(), label: 'auto', cwd: deadCwd, preExistingDirtyFiles: [], preExistingUntrackedFiles: [], agentTouchedFiles: [] }))
+      chmodSync(locked, 0o000)
+      try {
+        pruneOrphanCheckpoints()
+        assert.equal(existsSync(locked), true, '读取抛错必须保留（修复前按孤儿删除）')
+      } finally {
+        chmodSync(locked, 0o644)
+        if (existsSync(locked)) rmSync(locked, { force: true })
+      }
+    })
+
     it('removes checkpoint files whose cwd no longer exists', () => {
       const rivetDir = rivetHome()
       mkdirSync(rivetDir, { recursive: true })

--- a/src/agent/checkpoint.ts
+++ b/src/agent/checkpoint.ts
@@ -198,10 +198,15 @@ export function pruneOrphanCheckpoints(max = MAX_CHECKPOINTS): number {
   // 1. Drop orphans whose recorded cwd is gone.
   const live: { file: string; mtime: number }[] = []
   for (const e of entries) {
-    let cwd = ''
+    let cwd: string | null = null
     try {
       cwd = (JSON.parse(readFileSync(e.file, 'utf-8')) as CheckpointData).cwd ?? ''
-    } catch { /* unreadable → treat as orphan */ }
+    } catch {
+      // 读取/解析失败 ≠ 孤儿：Windows 杀软扫描 EBUSY、权限抖动等瞬态错误
+      // 在这里删除会不可逆地毁掉用户的回滚点（checkpoint 是删除类操作唯一
+      // 的后悔药）。跳过保留，下次 prune 再试；确认损坏才由使用方处置。
+      continue
+    }
     if (cwd && existsSync(cwd)) {
       live.push(e)
     } else {


### PR DESCRIPTION
# fix(agent): prune 不再删除读不了的 checkpoint——瞬态错误不可逆毁掉回滚点

**分支**：`fix/checkpoint-prune-keep-unreadable` ｜ 改动：`checkpoint.ts` prune 一处 + 2 条回归测试

## 问题：'现在读不了' 被当成了 '孤儿'

`pruneOrphanCheckpoints`（每个进程首次 checkpoint 时跑一次）对读/解析失败的 checkpoint 文件按孤儿处理——**直接删除**。但"读不了"≠"孤儿"：

- Windows 上杀毒软件扫描文件时打开句柄（EBUSY 是 Windows 最常见的瞬态错误）
- 任何平台上权限都可能有短暂抖动
- 崩溃边界的半写文件，恰恰是用户在那次崩溃后**最想用的回滚点**

一个以回收磁盘为目的的清理过程，在不可逆地销毁"唯一职责就是在坏时刻活下来"的工件。

**对照组**（同仓库自己划过这条线）：cron-scheduler 对损坏的 schedule 文件用**隔离改名**（`.corrupt-<时间戳>`）而不是删除，且只有"cwd 可验证不存在"才算孤儿。

## 不修的后果

用户的 checkpoint 在错误时机被静默清掉：编辑器崩溃/OOM/杀软扫描之后想回滚，发现回滚点没了，而没有任何报错指向 prune。对把 checkpoint 当安全网的用户，这是"安全网在最可能被需要时消失"。

## 修复与验证

读/解析失败的文件**跳过保留**（下次 prune 再试）；只有成功解析出、且 cwd 确认不存在的才删除。
- 回归测试：截断 JSON 的 checkpoint 与 EACCES（chmod 000）的 checkpoint 都必须在 prune 后存活——修复前双双被删（阴性对照 2 红）
- checkpoint 全家（checkpoint + isolation）26/26 绿，`tsc --noEmit` 干净

## 为何潜伏

现有 prune 测试只造"cwd 不存在"的正例和"cwd 存在"的留例——"读失败"这个第三态没有用例；真实世界触发它需要杀软/权限/崩溃的三重巧合，且删除本身静默。
