### PR TITLE
fix(lsp): LSP 服务器崩死后恢复——有界重启 + 重开文档

### DIFF
--- a/src/lsp/__tests__/manager.test.ts
+++ b/src/lsp/__tests__/manager.test.ts
@@ -15,6 +15,8 @@ function createMockServer() {
   const stderr = new PassThrough()
 
   let killed = false
+  /** 收到的 didOpen 通知数（F4：重初始化必须向新服务器重发 didOpen）。 */
+  let didOpenCount = 0
 
   let serverBuf = ''
   stdin.on('data', (chunk: Buffer) => {
@@ -67,7 +69,11 @@ function createMockServer() {
           }))
         }
       }
-      // Notifications (initialized, textDocument/didOpen) — no response needed
+      for (const msg of messages) {
+        if ('method' in msg && (msg as { method: string }).method === 'textDocument/didOpen') {
+          didOpenCount++
+        }
+      }
     }
   })
 
@@ -80,7 +86,7 @@ function createMockServer() {
     get killed() { return killed },
   }
 
-  return { proc, stdin, stdout, stderr }
+  return { proc, stdin, stdout, stderr, get didOpenCount() { return didOpenCount } }
 }
 
 describe('LspManager', () => {
@@ -248,5 +254,23 @@ describe('LspManager', () => {
     await mgr.initialize()
     const result = await mgr.gotoDefinition('src/file.ts', 1, 1)
     assert.equal(result.length, 0)
+  })
+
+  it('重新 initialize 向新服务器重发 didOpen——openedDocs 必须清空（2026-09-11 F4）', async () => {
+    const s1 = createMockServer()
+    const s2 = createMockServer()
+    const servers = [s1, s2]
+    const mgr = createLspManager(() => servers.shift()!.proc as any, '/project')
+    managers.push(mgr)
+
+    await mgr.initialize()
+    await mgr.gotoDefinition('src/target.ts', 10, 5)
+    assert.equal(s1.didOpenCount, 1, '首任服务器收到 didOpen')
+
+    mgr.dispose() // 模拟服务器死亡清理
+    await mgr.initialize() // 重启路径：同一 manager 重新初始化
+    await mgr.gotoDefinition('src/target.ts', 10, 5)
+    assert.equal(s2.didOpenCount, 1,
+      '新服务器必须重新收到 didOpen——修复前 openedDocs 残留把 didOpen 短路掉')
   })
 })

--- a/src/lsp/__tests__/multi-manager.test.ts
+++ b/src/lsp/__tests__/multi-manager.test.ts
@@ -5,6 +5,7 @@ import { createMultiLspManager, defaultLspSpawn, type MultiLspOptions } from '..
 import type { LspServerDef } from '../server-registry.js'
 import type { ChildProcess } from 'node:child_process'
 import { PassThrough } from 'node:stream'
+import { encodeMessage, decodeMessages } from '../rpc.js'
 
 function mockChild(): ChildProcess {
   return { kill: () => true, on: () => {}, pid: 0 } as unknown as ChildProcess
@@ -143,3 +144,90 @@ describe('defaultLspSpawn', () => {
     )
   })
 })
+
+
+describe('LSP 服务器崩溃后有界重启（2026-09-11 F4）', () => {
+  function makeRestartableMock() {
+    const stdin = new PassThrough()
+    const stdout = new PassThrough()
+    const stderr = new PassThrough()
+    let serverBuf = ''
+    const exitHandlers: Array<(...args: unknown[]) => void> = []
+    stdin.on('data', (chunk: Buffer) => {
+      serverBuf += chunk.toString()
+      const { messages, rest } = decodeMessages(serverBuf)
+      serverBuf = rest
+      for (const msg of messages) {
+        if ('method' in msg && 'id' in msg) {
+          const id = (msg as { id: number }).id
+          const method = (msg as { method: string }).method
+          if (method === 'initialize') {
+            stdout.write(encodeMessage({
+              jsonrpc: '2.0' as const,
+              id,
+              result: { capabilities: { definitionProvider: true, referencesProvider: true } },
+            }))
+          } else if (method === 'textDocument/definition') {
+            stdout.write(encodeMessage({
+              jsonrpc: '2.0' as const,
+              id,
+              result: [{
+                uri: 'file:///tmp/test.ts',
+                range: { start: { line: 0, character: 0 }, end: { line: 0, character: 4 } },
+              }],
+            }))
+          }
+        }
+      }
+    })
+    const proc = {
+      stdin,
+      stdout,
+      stderr,
+      kill: () => true,
+      on: (ev: string, cb: (...args: unknown[]) => void) => {
+        if (ev === 'exit') exitHandlers.push(cb)
+      },
+    } as unknown as ChildProcess
+    return { proc, emitExit: () => { for (const cb of [...exitHandlers]) cb(1, null) } }
+  }
+
+  it('崩死后下次调用重启出新进程；重启次数有界，crash-loop 不打爆 spawn', async () => {
+    const mocks: Array<ReturnType<typeof makeRestartableMock>> = []
+    const opts: MultiLspOptions = {
+      which: () => true,
+      spawnFor: () => {
+        const m = makeRestartableMock()
+        mocks.push(m)
+        return m.proc
+      },
+    }
+    const mgr = createMultiLspManager('/tmp', opts)
+    // 本文件的既有用例依赖上游 runner 的循环语义；此处显式保活，确保
+    // 重启链路（多次 spawn/init/exit）在任意环境下都能走完。
+    const keepAlive = setInterval(() => {}, 50)
+    try {
+      const loc1 = await mgr.gotoDefinition('test.ts', 1, 0)
+      assert.equal(mocks.length, 1)
+      assert.ok(loc1.length > 0, '首个实例正常服务')
+      mocks[0]!.emitExit() // 服务器崩死
+
+      const loc2 = await mgr.gotoDefinition('test.ts', 1, 0)
+      assert.equal(mocks.length, 2, `崩溃后必须重启出新进程（修复前 ensure 永远返回 null），spawns=${mocks.length}`)
+      assert.ok(loc2.length > 0, '重启后的实例正常服务')
+      mocks[1]!.emitExit()
+
+      await mgr.gotoDefinition('test.ts', 1, 0)
+      assert.equal(mocks.length, 3, '第二次重启')
+      mocks[2]!.emitExit()
+
+      const loc4 = await mgr.gotoDefinition('test.ts', 1, 0)
+      assert.equal(mocks.length, 3, '重启有界：额度耗尽不再 spawn')
+      assert.deepEqual(loc4, [], '额度耗尽后降级为空（不挂起）')
+    } finally {
+      mgr.dispose()
+      clearInterval(keepAlive)
+    }
+  })
+})
+

--- a/src/lsp/manager.ts
+++ b/src/lsp/manager.ts
@@ -122,6 +122,11 @@ export function createLspManager(
 
   return {
     async initialize() {
+      // 全新服务器进程对历史一无所知：崩溃后重新 initialize 必须清掉
+      // openedDocs/diagnosticCache，否则 openedDocs 短路 didOpen——新服务器
+      // 永远收不到那些文档的打开通知，诊断与定义静默失真。
+      openedDocs.clear()
+      diagnosticCache.clear()
       try {
         proc = spawnFn()
 

--- a/src/lsp/multi-manager.ts
+++ b/src/lsp/multi-manager.ts
@@ -44,6 +44,8 @@ export interface MultiLspOptions {
 export const DEFAULT_LSP_INITIALIZE_TIMEOUT_MS = 45_000
 /** Shortest wait used by post-edit diagnostics so a cold LSP never stalls an edit. */
 export const LSP_DIAGNOSTIC_READY_WAIT_MS = 2_000
+/** 服务器崩死后允许的重启次数（有界，防 crash-loop 无限 spawn）。 */
+const MAX_LSP_RESTARTS = 2
 
 type LspSpawnFn = (cmd: string, args: string[], opts: Record<string, unknown>) => ChildProcess
 
@@ -81,6 +83,9 @@ export function createMultiLspManager(cwd: string, opts: MultiLspOptions = {}): 
     ready: Promise<boolean>
   }
   const managers = new Map<string, LspEntry>()
+  /** 每个 def 的累计重启次数。放在 managers 外：重启会删 entry 重建，
+   *  计数挂 entry 上会被一并清零——上限永远达不到（crash-loop 防护失效）。 */
+  const restartCounts = new Map<string, number>()
   let availableCache: LspServerDef[] | null = null
 
   const getAvailable = (): LspServerDef[] => {
@@ -139,6 +144,19 @@ export function createMultiLspManager(cwd: string, opts: MultiLspOptions = {}): 
         timer.unref?.()
       }),
     ])
+    if (ok && !entry.mgr.isReady()) {
+      // initialize 曾成功、但服务器进程此后死掉：entry.ready 永远停在 true，
+      // 没有本分支时之后每次 ensure() 都返回 null——LSP 对会话剩余时间静默
+      // 失效（崩溃一次 = 定义跳转/诊断全部降级且永不恢复）。丢弃条目让下次
+      // ensure 重新 spawn；有界重试防 crash-loop 打爆 spawn。
+      const restarts = (restartCounts.get(def.id) ?? 0) + 1
+      restartCounts.set(def.id, restarts)
+      if (restarts <= MAX_LSP_RESTARTS) {
+        try { entry.mgr.dispose() } catch { /* already dead */ }
+        managers.delete(def.id)
+        return ensure(def, waitMs)
+      }
+    }
     return ok && entry.mgr.isReady() ? entry.mgr : null
   }
 


### PR DESCRIPTION
# fix(lsp): LSP 服务器崩死后恢复——有界重启 + 重开文档

**分支**：`fix/lsp-server-crash-recovery` ｜ 改动：`multi-manager.ts` + `manager.ts` + 2 条回归测试

## 问题：任何一次 LSP 服务器进程死亡，都是整个会话的永久性致盲

两个缺陷耦合：

**① multi-manager 的 ensure() 缓存了永真的 ready**：每个服务器条目的 `ready` promise 在**首次** initialize 成功时 settle 为 true，此后不再评估。子进程退出后（崩溃、OOM 被杀、npx 包装层抖动），后续每次 `ensure()` 都返回 null——`gotoDefinition`、`findReferences`、编辑后诊断对**会话剩余时间**全部静默降级为空，没有任何东西重试服务器。

**② manager 的 initialize() 不清 openedDocs**：即使发生了重启，残留的 `openedDocs` 集合把 `textDocument/didOpen` 短路掉——新服务器进程永远不知道以前打开过的文档，定义查询返回空、诊断过期但显示绿色（false green）。

## 不修的后果

长会话里 tsserver/gopls 之类崩一次（内存大户 tsserver 在大仓库上不罕见），agent 的符号导航和编辑后诊断就静默失效到会话结束——模型开始在"没有类型反馈"的状态下盲改代码，且没有任何信号提示为什么质量下降了。

## 修复

- `ensure()` 检测"ready=true 但进程已死"（isReady false）：dispose 旧条目、重新 spawn，每服务器 id 上限 `MAX_LSP_RESTARTS=2` 次——**计数放在 entry Map 外**：重启本身会替换 entry，挂在 entry 上的计数每次归零、上限永远达不到（crash-loop 回归测试当场抓住了这个第一版实现错误）
- `initialize()` 清空 `openedDocs`/`diagnosticCache`，新进程从头被告知文档

## 为何潜伏

现有套件覆盖"从不初始化"和"初始化卡死"两种形态，但没有测试在 initialize **成功之后**杀掉服务器——崩溃恢复路径零覆盖。

## 验证

- 回归测试：manager 重初始化向新服务器重发 didOpen（假服务器计数）；multi-manager 崩溃→下次调用 spawn 新进程（修复前永远 null）、有界 2 次、之后降级为空不挂起。阴性对照 2 红。
- manager+client 15/15 绿；`tsc --noEmit` 干净。multi-manager 既有套件在本机 node23+tsx 环境有基线性失败（unref 定时器语义，与上游 CI 的 runner 环境不同），新测试隔离运行全绿——已在 PR 描述中注明。
