### PR TITLE
fix(agent): undo/rewind 不再把「备份读取失败」当成「文件当时不存在」——撤销反向删除既有文件

### DIFF
--- a/src/agent/__tests__/file-history.test.ts
+++ b/src/agent/__tests__/file-history.test.ts
@@ -109,6 +109,44 @@ describe('FileHistory', () => {
     assert.equal(existsSync(created), false)
   })
 
+  it('rewind skips files whose backup read failed while the path existed (no unlink)', async () => {
+    // 跨平台的「存在但读不了」触发：trackEdit 时路径是目录（readFile EISDIR），
+    // 与 Windows AV/EDR 锁、EBUSY 同属「备份没拿到 ≠ 文件当时不存在」。
+    const file = join(TMP, 'was-busy.txt')
+    mkdirSync(file) // 路径存在，但读不了
+    await history.trackEdit(file, 'msg_1')
+    rmSync(file, { recursive: true })
+    writeFileSync(file, 'edited after lock released')
+
+    const changed = await history.rewind('msg_1')
+    assert.deepEqual(changed, [])
+    assert.equal(existsSync(file), true)
+    assert.equal(readFileSync(file, 'utf-8'), 'edited after lock released')
+  })
+
+  it('rewindToBoundary skips unreadable-backup files instead of deleting them', async () => {
+    const file = join(TMP, 'busy-boundary.txt')
+    mkdirSync(file)
+    await history.trackEdit(file, 'edit_1')
+    rmSync(file, { recursive: true })
+    writeFileSync(file, 'edited after boundary')
+
+    const changed = await history.rewindToBoundary(new Set(['edit_1']))
+    assert.deepEqual(changed, [])
+    assert.equal(readFileSync(file, 'utf-8'), 'edited after boundary')
+  })
+
+  it('getBoundaryFiles reports unreadable action instead of delete', async () => {
+    const file = join(TMP, 'busy-preview.txt')
+    mkdirSync(file)
+    await history.trackEdit(file, 'edit_1')
+    rmSync(file, { recursive: true })
+    writeFileSync(file, 'edited')
+
+    const files = history.getBoundaryFiles(new Set(['edit_1']))
+    assert.deepEqual(files, [{ path: file, action: 'unreadable' }])
+  })
+
   it('rewindToBoundary leaves pre-boundary-only files untouched', async () => {
     const kept = join(TMP, 'kept.txt')
     writeFileSync(kept, 'v1')

--- a/src/agent/file-history.ts
+++ b/src/agent/file-history.ts
@@ -33,6 +33,9 @@ export interface FileBackup {
   backupFileName: string | null
   version: number
   timestamp: number
+  /** 旧内容存在但备份读取失败（AV/EDR 锁、EBUSY…）。rewind 必须跳过该文件：
+   *  此时「没有备份」≠「文件当时不存在」，null-only 语义会把 undo 变成删除。 */
+  unreadable?: true
 }
 
 export interface FileSnapshot {
@@ -79,8 +82,11 @@ export class FileHistory {
       await mkdir(dirname(backupPath), { recursive: true })
       await writeFile(backupPath, content, 'utf-8')
       backup = { backupFileName, version, timestamp: Date.now() }
-    } catch {
-      backup = { backupFileName: null, version, timestamp: Date.now() }
+    } catch (err) {
+      // null 哨兵只保留一个含义：「trackEdit 时文件不存在」（rewind 据此 unlink）。
+      // 存在但读不了是另一个世界——标记 unreadable，让 rewind 跳过而不是删掉原文。
+      const unreadable = (err as NodeJS.ErrnoException)?.code !== 'ENOENT'
+      backup = { backupFileName: null, version, timestamp: Date.now(), ...(unreadable ? { unreadable: true } : {}) }
     }
 
     if (lastSnapshot && lastSnapshot.messageId === messageId) {
@@ -124,6 +130,7 @@ export class FileHistory {
       if (targetBackup === undefined) continue
 
       if (targetBackup.backupFileName === null) {
+        if (targetBackup.unreadable) continue // 备份没拿到 ≠ 文件当时不存在——不能拿 undo 当删除用
         try {
           await unlink(filePath)
           filesChanged.push(filePath)
@@ -154,13 +161,16 @@ export class FileHistory {
    * between the boundary and that first post-boundary edit). Restoring that
    * backup (or deleting it when the backup is null, i.e. the file did not yet
    * exist at the boundary) rewinds the file precisely to the boundary while
-   * preserving any edits made before it.
+   * preserving any edits made before it. Entries whose backup read failed at
+   * edit time are skipped: no backup ≠ file absent, and deleting it would turn
+   * a rewind into data loss.
    */
   async rewindToBoundary(postBoundaryIds: Set<string>): Promise<string[]> {
     const targets = this.firstBackupPerFile(postBoundaryIds)
     const filesChanged: string[] = []
     for (const [filePath, backup] of targets) {
       if (backup.backupFileName === null) {
+        if (backup.unreadable) continue
         try {
           await unlink(filePath)
           filesChanged.push(filePath)
@@ -179,10 +189,10 @@ export class FileHistory {
   }
 
   /** Files a boundary rewind would touch, for a pre-confirm preview. */
-  getBoundaryFiles(postBoundaryIds: Set<string>): { path: string; action: 'restore' | 'delete' }[] {
+  getBoundaryFiles(postBoundaryIds: Set<string>): { path: string; action: 'restore' | 'delete' | 'unreadable' }[] {
     return [...this.firstBackupPerFile(postBoundaryIds)].map(([path, b]) => ({
       path,
-      action: b.backupFileName === null ? 'delete' : 'restore',
+      action: b.backupFileName === null ? (b.unreadable ? 'unreadable' : 'delete') : 'restore',
     }))
   }
 
@@ -216,6 +226,7 @@ export class FileHistory {
     for (const filePath of this.trackedFiles) {
       const targetBackup = targetSnapshot.trackedFileBackups[filePath]
       if (targetBackup === undefined) continue
+      if (targetBackup.unreadable) continue // 无备份可比对，避免把「撤不了」误报成整文件删除
 
       let oldContent = ''
       if (targetBackup.backupFileName !== null) {

--- a/src/server/session-manager.ts
+++ b/src/server/session-manager.ts
@@ -4869,7 +4869,7 @@ export class RuntimeSessionManager {
   previewFilesPrecise(
     id: string,
     messageIndex: number,
-  ): { available: boolean; files: { path: string; action: 'restore' | 'delete' }[] } | undefined {
+  ): { available: boolean; files: { path: string; action: 'restore' | 'delete' | 'unreadable' }[] } | undefined {
     const s = this.sessions.get(id)
     if (!s) return undefined
     const fh = s.agent?.getFileHistory?.()

--- a/src/tui/format/rewind.ts
+++ b/src/tui/format/rewind.ts
@@ -23,7 +23,8 @@ export type RewindMode = 'convo' | 'code' | 'both' | 'summarize-from' | 'summari
 
 export interface RewindFile {
   path: string
-  action: 'restore' | 'delete'
+  /** unreadable = 该文件的备份在编辑时读取失败，回溯会跳过它（不删也不还原）。 */
+  action: 'restore' | 'delete' | 'unreadable'
 }
 
 export interface RewindEntry {
@@ -172,7 +173,9 @@ function buildActionBody(body: string[], data: RewindData, selected: number, w: 
       body.push(`  ${color(`将影响 ${files.length} 个文件：`, theme.muted)}`)
       const shown = files.slice(0, 8)
       shown.forEach(f => {
-        const badge = f.action === 'delete' ? color('删除', theme.error) : color('还原', theme.primary)
+        const badge = f.action === 'delete' ? color('删除', theme.error)
+          : f.action === 'unreadable' ? color('无法撤销（备份当时读取失败，将跳过）', theme.warning)
+          : color('还原', theme.primary)
         body.push(`    ${badge}  ${color(oneLine(f.path, w - 10), theme.secondary)}`)
       })
       if (files.length > shown.length) {


### PR DESCRIPTION
## 问题

`FileHistory.trackEdit` 在编辑前备份旧内容时，若 `readFile` 失败，会把 `backupFileName` 记为 `null`；而 `rewind` / `rewindToBoundary` 对 `null` 的唯一语义是「该文件当时还不存在 → `unlink`」。

问题在于 `null` 实际折叠了两种世界：

1. **文件当时不存在**（ENOENT，`write_file` 新建文件的场景）——unlink 是正确的设计语义；
2. **文件存在但备份读取失败**（Windows AV/EDR 实时扫描锁、EBUSY、EISDIR 等）——文件本有内容，unlink 把撤销变成了**静默删除**。

`rewindToBoundary` 的注释声称 null 即「the file did not yet exist at the boundary」——这个断言对第 2 类世界是假的。

## 为何潜伏

触发链需要「备份读取瞬时失败 + 之后编辑成功」的组合：锁是瞬态的，`trackEdit` 读失败后锁释放，`edit_file` 随后正常落盘。此时该文件的旧内容在 FileHistory 里唯一的记录是 `null`。用户之后执行 undo（恰恰是想要恢复的操作）→ 文件被删除，零警告零信号。

测试没抓住它，是因为 fixture 里「读失败」只出现在文件真的不存在的场景——作者盲区（瞬态读失败≈不存在）同时是 fixture 的盲区。与本仓 #86（prune 把读不了当孤儿删）同族：把「读不了」当成「不存在」。

## 修复

- `FileBackup` 增加 `unreadable?: true` 标记；`trackEdit` 的 catch 按 `code === 'ENOENT'` 分流——只有 ENOENT 保留 `null` 原语义，其余错误标记 `unreadable`。
- `rewind` / `rewindToBoundary` 跳过 `unreadable` 条目（不删、不拿错误内容覆盖）。
- `getBoundaryFiles` 新增 `action: 'unreadable'`，TUI 回溯预览与桌面端 `previewFilesPrecise` 如实显示「无法撤销（备份当时读取失败，将跳过）」，不再误报为「删除」。
- `getDiffStats` 跳过 `unreadable` 条目，避免把「撤不了」误报成整文件删除。

## 不修的后果

- undo / 对话回溯（含桌面端「仅恢复代码」「对话+代码」两个粒度）在偶发读锁场景下**反向删除既有文件**，且属静默失败——用户以为回到了过去，实际丢的是现在。
- 「可撤销」是编辑器族对用户的核心承诺；该路径在承诺兑现点上做破坏性操作，动摇 undo 的可信度。
- 与 #86 同根：凡「读不了→按不存在处置」的代码路径，都值得同样对待。

## 验证

- 复现脚本（真模块真目录，零 mock）：文件 chmod 000 模拟读锁 → trackEdit → 锁释放 → 编辑成功 → rewind。原码：文件被 unlink（红）；修复后：文件保留且内容不破坏（绿）。对照两组：真 ENOENT → null → unlink 设计语义保留；正常备份 → undo 恢复原文不回归。
- 新增 3 条跨平台回归测试（用 EISDIR 做「存在但读不了」的确定性触发，Windows 上 chmod 不可靠）：`rewind skips files whose backup read failed while the path existed`、`rewindToBoundary skips unreadable-backup files`、`getBoundaryFiles reports unreadable action`。阴性对照：stash 修复只留测试，3 条全红。
- `src/agent/__tests__/file-history.test.ts` 全套 14/14 绿；`tsc --noEmit` 干净（仅与本修无关的既有 worker-process 测试 node 类型报错）。
