### PR TITLE
fix(ci): worker-process 测试的 node:events 改静态命名导入——解除 typecheck 全红

### DIFF
--- a/src/agent/worker-process/__tests__/worker-process.test.ts
+++ b/src/agent/worker-process/__tests__/worker-process.test.ts
@@ -4,6 +4,10 @@ import { spawn } from 'node:child_process'
 import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+// 静态命名导入（Node 官方文档姿势）。动态 import 解构会在 @types/node 22.19.x
+// 下报 TS2339：该版本把 node:events 声明为 `export = EventEmitter`，getEventListeners
+// 只挂在类 static 上、不在模块类型面里，CI typecheck 因此全红。
+import { getEventListeners } from 'node:events'
 import { createFrameDecoder, encodeFrame } from '../protocol.js'
 import {
   runWorkerSessionOop, resolveChildEntry, WorkerOopUnavailable,
@@ -208,7 +212,6 @@ describe('OOP 运行器（真子进程假 agent）', () => {
   })
 
   test('settle 后摘除 abort 监听——同一会话级信号多次委派不累积监听（2026-09-10 泄漏修复）', async () => {
-    const { getEventListeners } = await import('node:events')
     const fixture = writeFixture(dir, 'crash') // 最快 settle：init 后 exit(1)
     const controller = new AbortController()
     const spawnFx = (_e: string[], script: string) => spawn(process.execPath, [script], { stdio: ['pipe', 'pipe', 'pipe'] })


### PR DESCRIPTION
## 问题

自 #78 合入起，CI 的 typecheck 步骤 exit 2，main 与所有从 main 切出的分支（#81-88）全部被染红：

```
src/agent/worker-process/__tests__/worker-process.test.ts(211,13): error TS2339:
Property 'getEventListeners' does not exist on type '{ default: typeof EventEmitter; ... }'
```

出错的断言代码来自 #78 自带的回归测试，与后续 PR 的改动无关——它们只是从 main 继承了这个红。

## 根因

仓库锁定 @types/node **22.19.19**。该版本把 `node:events` 声明为 **`export = EventEmitter`**（events.d.ts 末尾），`getEventListeners`、`once`、`addAbortListener` 等只以 **类 static** 形式存在（events.d.ts:325），模块类型面上没有独立函数导出。于是：

- ❌ `const { getEventListeners } = await import('node:events')` —— 动态 import 返回精确的模块类型，解构即 TS2339
- ✅ `import { getEventListeners } from 'node:events'` —— 静态命名导入（Node 官方文档姿势），类型干净
- ✅ 运行时两种形态等价：模块级导出与 `EventEmitter.getEventListeners` 类静态都真实存在（node 24 实测 `typeof === 'function'`）

## 修复

测试文件改为顶层静态命名导入，删掉测试函数体内的动态 import。一行写法变更，断言语义零变化。

## 不修的后果

- typecheck 对全仓持续 exit 2，CI 红成为常态——真回归出现时不再有人看得见红；
- 每个新 PR 从 main 切出即带红叉，维护者与贡献者都无法用 CI 区分「这个 PR 有问题」和「main 本来就红」。

## 验证

- `npm run typecheck`：修复前 exit 2（CI 实录 + 本地复现），修复后 **exit 0**
- `worker-process.test.ts` 全套 **16/16 绿**（含使用 `getEventListeners` 断言的 abort 监听泄漏回归测试）
- 全仓 grep 确认动态 import 解构 node:events 仅此一处

另注：main 的 CI 在本错误之前还叠着一个**更早的失败**（2026-09-09 起的 `RED #8: TIFF 剪贴板 → sips 转 PNG` 测试，早于 #78/#79 合并）——修掉本 PR 后 CI 若仍红，则是那个测试的问题，建议单独排查。
