### PR TITLE
fix(tui): 剪贴板 TIFF→PNG 转换守卫看注入的 platform——修复 ubuntu CI 持续假红

### DIFF
--- a/src/tui/engine/__tests__/clipboard-image.test.ts
+++ b/src/tui/engine/__tests__/clipboard-image.test.ts
@@ -223,3 +223,47 @@ test('RED #8: TIFF 剪贴板 → 单次读回后经 sips 转 PNG', async () => {
   assert.equal(result!.source, 'png')
   assert.ok(uuidSeq >= 2, 'TIFF 转换应再生成独立输出路径')
 })
+
+test('TIFF→sips 转换守卫看注入的 platform 而非 process.platform（ubuntu CI 复现回归）', async () => {
+  // RED #8 在维护者的 Mac 上永远绿：convertToPng 的守卫曾偷查真实
+  // process.platform（linux 上直接 return null，跳过 sips 转换返回原始 TIFF），
+  // 违背 ShellClipboardOpts.platform 的注入契约。本测试临时把真实平台改写为
+  // linux 复现 CI 条件——任何平台上都能抓住该回归。
+  const mod = await import('../clipboard-image.js')
+  const { tryShellClipboard } = mod
+
+  const pngBuf = Buffer.from(PNG_B64, 'base64')
+  const tiffBuf = Buffer.from('49492a000800000000000000', 'hex')
+  let sipsCalls = 0
+  const execFile = async (bin: string, args: string[]) => {
+    if (bin === 'osascript') return { stdout: 'TIFF' }
+    if (bin === 'sips') {
+      sipsCalls++
+      return { stdout: '' }
+    }
+    throw new Error(`unexpected exec: ${bin} ${args.join(' ')}`)
+  }
+  const readFile = async (p: string) => {
+    if (p.endsWith('.tiff')) return tiffBuf
+    if (p.endsWith('.png')) return pngBuf
+    throw new Error(`unexpected readFile: ${p}`)
+  }
+
+  const realPlatform = process.platform
+  Object.defineProperty(process, 'platform', { value: 'linux', configurable: true })
+  try {
+    const result = await tryShellClipboard({
+      execFile,
+      platform: 'darwin',
+      readFile,
+      tmpdir: '/tmp',
+      randomUUID: () => 'u',
+    } as any)
+    assert.ok(result, '注入 darwin 平台时 TIFF 流程应成功')
+    assert.equal(sipsCalls, 1, 'TIFF 应调用 sips 转换（守卫须看注入的 platform）')
+    assert.equal(result!.mime, 'image/png', '转换后应得到 PNG 而非原始 TIFF')
+    assert.equal(result!.source, 'png')
+  } finally {
+    Object.defineProperty(process, 'platform', { value: realPlatform, configurable: true })
+  }
+})

--- a/src/tui/engine/clipboard-image.ts
+++ b/src/tui/engine/clipboard-image.ts
@@ -144,7 +144,7 @@ export async function tryShellClipboard(opts?: ShellClipboardOpts): Promise<Clip
   const uuid = opts?.randomUUID ?? randomUUID
 
   try {
-    if (pf === 'darwin') return await tryMacOSClipboard(ef, rf, td, uuid)
+    if (pf === 'darwin') return await tryMacOSClipboard(pf, ef, rf, td, uuid)
     if (pf === 'linux') return await tryLinuxClipboard(ef)
     if (pf === 'win32') return await tryWindowsClipboard(ef, rf, td, uuid)
   } catch {
@@ -156,6 +156,7 @@ export async function tryShellClipboard(opts?: ShellClipboardOpts): Promise<Clip
 // ── macOS: osascript（单次嵌套 coercion）──
 
 async function tryMacOSClipboard(
+  pf: NodeJS.Platform,
   ef: (bin: string, args: string[]) => Promise<{ stdout: string }>,
   rf: (path: string) => Promise<Buffer>,
   td: string,
@@ -226,7 +227,7 @@ async function tryMacOSClipboard(
     // 大多数视觉模型 API 不支持 TIFF，用 sips 转 PNG。
     const mime = detectImageMime(buf, 'clipboard.png')
     if (mime === 'image/tiff' || mime === 'image/bmp') {
-      const pngBuf = await convertToPng(buf, target, ef, td, uuid, rf)
+      const pngBuf = await convertToPng(pf, buf, target, ef, td, uuid, rf)
       if (pngBuf) return bufToClipboardImage(pngBuf, 'clipboard.png')
     }
     return bufToClipboardImage(buf, 'clipboard.png')
@@ -291,6 +292,7 @@ else { exit 1 }
 
 /** Convert TIFF/BMP buffer to PNG using macOS sips. Returns null on failure. */
 async function convertToPng(
+  pf: NodeJS.Platform,
   buf: Buffer,
   srcPath: string,
   ef: (bin: string, args: string[]) => Promise<{ stdout: string }>,
@@ -298,7 +300,10 @@ async function convertToPng(
   uuid: () => string,
   rf?: (path: string) => Promise<Buffer>,
 ): Promise<Buffer | null> {
-  if (process.platform !== 'darwin') return null
+  // 守卫必须看注入的 platform（ShellClipboardOpts.platform 的契约）：查真实
+  // process.platform 会让非 darwin 的测试/嵌入环境跳过转换，把 TIFF 原样返回
+  // （ubuntu CI 上 RED #8 假红的根因）。运行时 pf === process.platform，语义不变。
+  if (pf !== 'darwin') return null
   const pngPath = `${td}/rivet-clip-${uuid()}.png`
   try {
     await ef('sips', ['-s', 'format', 'png', srcPath, '--out', pngPath])


### PR DESCRIPTION
## 问题

main 的 CI 自 2026-09-09 起 Test 步骤持续红：

```
✖ RED #8: TIFF 剪贴板 → 单次读回后经 sips 转 PNG
```

该测试在维护者的 macOS 上永远绿，只在 linux CI 上失败——因为它测的是注入 mock 的管道，而实现里有一处偷查真实平台。

## 根因

`tryShellClipboard` 的契约（文件头注释）是 execFile/platform/readFile 全部可注入；测试也确实注入了 `platform: 'darwin'`，osascript/sips 全是 mock。但 TIFF→PNG 的 `convertToPng` 守卫写的是：

```ts
if (process.platform !== 'darwin') return null   // ← 真实平台，不是注入值
```

ubuntu CI 上 `process.platform === 'linux'` → sips 转换被跳过 → 原始 TIFF 被当作结果返回（`mime: 'image/tiff'`）→ 断言 `image/png` 失败。运行时无影响（生产 `pf === process.platform`，且非 darwin 根本走不进 macOS 分支），纯属测试接缝泄漏——但它让 CI 失去了区分「这个 PR 有问题」和「main 本来就红」的能力。

## 修复

注入 platform 贯穿 `tryShellClipboard → tryMacOSClipboard → convertToPng`，守卫改看注入值。新增回归测试：临时把真实 `process.platform` 改写为 linux 复现 CI 条件——修复前在**任何**平台必红（已在 macOS 上实测红），修复后绿；此后该回归在维护者的 Mac 上也抓得住了。

## 不修的后果

- ubuntu CI 持续假红，CI 门禁失去信号价值（与 #89 修复的 typecheck 红叠加，main 已连续红一周）；
- 同款「守卫偷查真实平台」的写法留在测试接缝附近，下一个被注入测试覆盖到的平台分支还会再犯。

## 验证

- 新回归测试：修复前 1 红（macOS 上复现 CI 条件），修复后 clipboard 套件 **9/9 绿**
- 运行时语义零变化：非 darwin 平台从不进入 macOS 剪贴板分支；darwin 上守卫值不变
- 注：本 PR 的 CI 在 typecheck 步骤仍会红——那是 #78 引入、由 **#89 独立修复**的 TS2339（与本修相互独立）。#89 合入后本 PR 的 CI 即全绿；两个都合入后 main CI 应恢复完整绿。
