### PR TITLE
fix(worker): 单测改用具名导入 node:events——修复 typecheck 红灯

### DIFF
--- a/src/agent/worker-process/__tests__/worker-process.test.ts
+++ b/src/agent/worker-process/__tests__/worker-process.test.ts
@@ -1,6 +1,7 @@
 import { test, describe, after } from 'node:test'
 import assert from 'node:assert/strict'
 import { spawn } from 'node:child_process'
+import { getEventListeners } from 'node:events'
 import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -208,7 +209,6 @@ describe('OOP 运行器（真子进程假 agent）', () => {
   })
 
   test('settle 后摘除 abort 监听——同一会话级信号多次委派不累积监听（2026-09-10 泄漏修复）', async () => {
-    const { getEventListeners } = await import('node:events')
     const fixture = writeFixture(dir, 'crash') // 最快 settle：init 后 exit(1)
     const controller = new AbortController()
     const spawnFx = (_e: string[], script: string) => spawn(process.execPath, [script], { stdio: ['pipe', 'pipe', 'pipe'] })


### PR DESCRIPTION
## 变更摘要

修复 `src/agent/worker-process/__tests__/worker-process.test.ts` 的类型错误，让 `npm run typecheck` 恢复绿色。

## 动机

`main`（771da2fb）上 `npm run typecheck` 失败，CI `ci (24)` 也是 failure：

```
src/agent/worker-process/__tests__/worker-process.test.ts(211,13): error TS2339:
Property 'getEventListeners' does not exist on type 'typeof EventEmitter'.
```

该行写的是 `const { getEventListeners } = await import('node:events')`。`@types/node` 把 `events` / `node:events` 声明为 `export = EventEmitter`（CommonJS 导出赋值 + 类/命名空间合并），动态 `import()` 得到的类型里取不到具名的 `getEventListeners`，于是 tsc 报错。typecheck 是 pre-push hook 与 CI 的第一道门，红灯会同时挡住 push 和 CI。

## 主要改动

仅 `src/agent/worker-process/__tests__/worker-process.test.ts`：

- 顶部新增具名导入 `import { getEventListeners } from 'node:events'`（与该文件其余 `node:*` 导入风格一致）
- 删除测试内的 `const { getEventListeners } = await import('node:events')`

`getEventListeners` 的调用点未动，运行期行为不变。

## 测试

- `npm run typecheck`：修复前 exit=2（上述错误）；修复后 exit=0
- `npm exec -- tsx --test src/agent/worker-process/__tests__/worker-process.test.ts`：16 tests / 16 pass / 0 fail

补充说明：本地 `npm test` 全量仍有既有失败（env registry 审计、plugins install、ast-edit、TUI 渲染等，约 95 条 ✖，`npm test` exit=1）。经隔离验证与本次改动无关——`src/tools/__tests__/ast-edit.test.ts` 单独运行也失败（exit=1），且失败文件与本次改动的文件之间无导入耦合。推测因 CI 在 typecheck 一步就失败、测试从未跑到，这些失败长期未暴露。

## 检查清单

- [x] `npx tsc --noEmit` 无类型错误
- [x] 变更范围最小化，无关改动已排除
- [ ] 本地 `npm test` 通过 —— 全量套件存在上述既有失败；本次相关的 worker-process 测试 16/16 全绿
- [ ] 文档已同步更新 —— 本次为内部测试类型修复，无用户可见行为变化，无需更新

## 相关 Issue

（无）