### PR TITLE
fix(api): implement image_strip auto-recovery — 413/图片拒绝后剥离图片重发一次

### DIFF
--- a/src/api/__tests__/oai-types.test.ts
+++ b/src/api/__tests__/oai-types.test.ts
@@ -1,93 +1,107 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { isAssistantWithTools, isToolMessage, isUserMessage, type OaiChatRequest, type OaiMessage } from '../oai-types.js'
+import {
+  stripOaiImageParts,
+  oaiMessagesHaveImageParts,
+  STRIPPED_IMAGE_PLACEHOLDER,
+  type OaiMessage,
+} from '../oai-types.js'
 
-describe('OpenAI-native API types', () => {
-  it('narrows tool messages with tool_call_id', () => {
-    const msg: OaiMessage = {
-      role: 'tool',
-      tool_call_id: 'call_123',
-      content: 'done',
-    }
+// ---------------------------------------------------------------------------
+// oaiMessagesHaveImageParts
+// ---------------------------------------------------------------------------
 
-    assert.equal(isToolMessage(msg), true)
-    if (isToolMessage(msg)) {
-      assert.equal(msg.tool_call_id, 'call_123')
-    }
+describe('oaiMessagesHaveImageParts', () => {
+  it('is false for text-only messages', () => {
+    const msgs: OaiMessage[] = [
+      { role: 'user', content: 'hello' },
+      { role: 'assistant', content: 'hi' },
+    ]
+    assert.equal(oaiMessagesHaveImageParts(msgs), false)
   })
 
-  it('narrows assistant messages with tool calls', () => {
-    const msg: OaiMessage = {
-      role: 'assistant',
-      content: null,
-      reasoning_content: 'Need to inspect the file.',
-      tool_calls: [
-        {
-          id: 'call_read',
-          type: 'function',
-          function: {
-            name: 'read_file',
-            arguments: '{"file_path":"src/main.tsx"}',
-          },
-        },
-      ],
-    }
-
-    assert.equal(isAssistantWithTools(msg), true)
-    if (isAssistantWithTools(msg)) {
-      assert.equal(msg.tool_calls[0]?.function.name, 'read_file')
-      assert.equal(msg.reasoning_content, 'Need to inspect the file.')
-    }
+  it('is true when a user message carries an image_url part', () => {
+    const msgs: OaiMessage[] = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'look' },
+          { type: 'image_url', image_url: { url: 'data:image/png;base64,AAAA' } },
+        ],
+      },
+    ]
+    assert.equal(oaiMessagesHaveImageParts(msgs), true)
   })
 
-  it('does not classify empty tool_calls as assistant-with-tools', () => {
-    const msg: OaiMessage = {
-      role: 'assistant',
-      content: 'No tools needed.',
-      tool_calls: [],
-    }
+  it('is false for empty message arrays', () => {
+    assert.equal(oaiMessagesHaveImageParts([]), false)
+  })
+})
 
-    assert.equal(isAssistantWithTools(msg), false)
+// ---------------------------------------------------------------------------
+// stripOaiImageParts
+// ---------------------------------------------------------------------------
+
+describe('stripOaiImageParts', () => {
+  it('returns the same reference when no image part exists (cheap no-op)', () => {
+    const msgs: OaiMessage[] = [{ role: 'user', content: 'text only' }]
+    const result = stripOaiImageParts(msgs)
+    assert.equal(result.removedCount, 0)
+    assert.equal(result.messages, msgs, 'must not copy when nothing changed')
   })
 
-  it('narrows user messages', () => {
-    const msg: OaiMessage = {
-      role: 'user',
-      content: 'Continue.',
-    }
-
-    assert.equal(isUserMessage(msg), true)
-    assert.equal(isToolMessage(msg), false)
+  it('removes image_url parts, preserving text and other messages', () => {
+    const msgs: OaiMessage[] = [
+      { role: 'system', content: 'sys' },
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'keep me' },
+          { type: 'image_url', image_url: { url: 'data:image/png;base64,AAAA' } },
+          { type: 'image_url', image_url: { url: 'data:image/jpeg;base64,BBBB' } },
+        ],
+      },
+      { role: 'assistant', content: 'ok' },
+    ]
+    const result = stripOaiImageParts(msgs)
+    assert.equal(result.removedCount, 2)
+    assert.notEqual(result.messages, msgs, 'must return a copy after stripping')
+    const user = result.messages[1]!
+    assert.equal(user.role, 'user')
+    assert.deepEqual(user.content, [{ type: 'text', text: 'keep me' }])
+    assert.deepEqual(result.messages[0], msgs[0], 'system message untouched')
+    assert.deepEqual(result.messages[2], msgs[2], 'assistant message untouched')
   })
 
-  it('supports OpenAI-compatible request bodies with cache usage fields', () => {
-    const request: OaiChatRequest = {
-      model: 'deepseek-chat',
-      messages: [
-        { role: 'system', content: 'You are concise.' },
-        { role: 'user', content: 'Read the file.' },
-      ],
-      tools: [
-        {
-          type: 'function',
-          function: {
-            name: 'read_file',
-            description: 'Read a file',
-            parameters: {
-              type: 'object',
-              properties: { file_path: { type: 'string' } },
-              required: ['file_path'],
-            },
-          },
-        },
-      ],
-      tool_choice: 'auto',
-      max_tokens: 1024,
-      stream: true,
-      reasoning_effort: 'low',
-    }
+  it('replaces an image-only user message with a text placeholder', () => {
+    const msgs: OaiMessage[] = [
+      {
+        role: 'user',
+        content: [{ type: 'image_url', image_url: { url: 'data:image/png;base64,AAAA' } }],
+      },
+    ]
+    const result = stripOaiImageParts(msgs)
+    assert.equal(result.removedCount, 1)
+    assert.deepEqual(result.messages[0]!.content, [
+      { type: 'text', text: STRIPPED_IMAGE_PLACEHOLDER },
+    ])
+  })
 
-    assert.equal(request.messages.length, 2)
-    assert.equal(request.tools?.[0]?.function.name, 'read_file')
+  it('does not mutate the input array', () => {
+    const msgs: OaiMessage[] = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 't' },
+          { type: 'image_url', image_url: { url: 'data:image/png;base64,AAAA' } },
+        ],
+      },
+    ]
+    stripOaiImageParts(msgs)
+    assert.equal(
+      (msgs[0]!.content as unknown[]).length,
+      2,
+      'input content parts must be untouched',
+    )
   })
 })

--- a/src/api/__tests__/openai-client.test.ts
+++ b/src/api/__tests__/openai-client.test.ts
@@ -945,3 +945,142 @@ describe('content→reasoning channel ordering (C→R 折叠防护)', () => {
     assert.ok(!textParts.join('').includes('内部推理…'), 'tool-call 轮 reasoning 不泄露为 text')
   })
 })
+
+// ---------------------------------------------------------------------------
+// image_strip recovery (413 / image-rejection retry strips images once)
+// ---------------------------------------------------------------------------
+
+describe('image_strip recovery', () => {
+  const originalFetch = globalThis.fetch
+
+  /** fetch mock: `statuses` consumed in order, then an SSE success response. */
+  function mockFetchSequence(statuses: number[]) {
+    const calls: Array<{ url: string; body: string }> = []
+    let idx = 0
+    globalThis.fetch = (async (url: unknown, init: RequestInit) => {
+      calls.push({ url: String(url), body: String(init.body ?? '') })
+      const status = statuses[idx++]
+      if (status !== undefined) {
+        return new Response(JSON.stringify({ error: { message: 'Request too large' } }), {
+          status,
+          headers: { 'content-type': 'application/json' },
+        })
+      }
+      const enc = new TextEncoder()
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(enc.encode(
+            'data: {"choices":[{"delta":{"role":"assistant","content":""},"index":0}]}\n\n' +
+            'data: {"choices":[{"delta":{"content":"ok"},"index":0,"finish_reason":"stop"}]}\n\n' +
+            'data: [DONE]\n\n',
+          ))
+          controller.close()
+        },
+      })
+      return new Response(stream, {
+        status: 200,
+        headers: { 'content-type': 'text/event-stream' },
+      })
+    }) as typeof fetch
+    return calls
+  }
+
+  function restoreFetch(): void {
+    globalThis.fetch = originalFetch
+  }
+
+  const IMAGE_REQUEST = {
+    model: 'gpt-4o',
+    stream: true,
+    max_tokens: 10,
+    messages: [
+      { role: 'system', content: 'sys' },
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'describe this' },
+          { type: 'image_url', image_url: { url: 'data:image/png;base64,AAAA' } },
+        ],
+      },
+    ],
+  }
+
+  const NOOP_CALLBACKS = {
+    onTextDelta: () => {},
+    onThinkingDelta: () => {},
+    onContentBlock: () => {},
+    onStopReason: () => {},
+    onError: () => {},
+  }
+
+  it('strips image_url parts on a 413 retry and resends once', async () => {
+    const calls = mockFetchSequence([413])
+    try {
+      const client = new OpenAIClient(TEST_CONFIG)
+      let stopReason: string | undefined
+      await client.stream(IMAGE_REQUEST as never, {
+        ...NOOP_CALLBACKS,
+        onStopReason: (r: string) => { stopReason = r },
+      })
+
+      assert.equal(calls.length, 2, 'one 413 attempt + one stripped retry')
+      const first = JSON.parse(calls[0]!.body) as { messages: Array<{ role: string; content: unknown }> }
+      const second = JSON.parse(calls[1]!.body) as { messages: Array<{ role: string; content: unknown }> }
+
+      // First attempt carries the image; second attempt has it stripped, text kept.
+      const firstUser = first.messages[1]!.content as Array<{ type: string }>
+      assert.ok(firstUser.some(p => p.type === 'image_url'), 'first attempt must send the image')
+      const secondUser = second.messages[1]!.content as Array<{ type: string }>
+      assert.ok(!secondUser.some(p => p.type === 'image_url'), 'retry must drop image_url parts')
+      assert.ok(secondUser.some(p => p.type === 'text'), 'retry must keep text parts')
+      assert.equal(stopReason, 'end_turn')
+    } finally {
+      restoreFetch()
+    }
+  })
+
+  it('fails fast on 413 when the request has no image parts to strip', async () => {
+    const calls = mockFetchSequence([413, 413, 413])
+    try {
+      const client = new OpenAIClient(TEST_CONFIG)
+      const textOnlyRequest = {
+        model: 'gpt-4o',
+        stream: true,
+        messages: [{ role: 'user', content: 'text only' }],
+      }
+      await assert.rejects(
+        () => client.stream(textOnlyRequest as never, NOOP_CALLBACKS),
+        (err: unknown) => {
+          assert.equal((err as { status?: number }).status, 413)
+          return true
+        },
+      )
+      // The veto proves the retry cannot help — no second attempt, no delay.
+      assert.equal(calls.length, 1, 'no-image 413 must not retry')
+    } finally {
+      restoreFetch()
+    }
+  })
+
+  it('gives up after one stripped retry when the server keeps rejecting', async () => {
+    const calls = mockFetchSequence([413, 413, 413])
+    try {
+      const client = new OpenAIClient(TEST_CONFIG)
+      await assert.rejects(
+        () => client.stream(IMAGE_REQUEST as never, NOOP_CALLBACKS),
+        (err: unknown) => {
+          assert.equal((err as { status?: number }).status, 413)
+          return true
+        },
+      )
+      // Attempt 1 (images) + attempt 2 (stripped) = 2; a third attempt would be
+      // a doomed repeat of the stripped body and is vetoed.
+      assert.equal(calls.length, 2, 'second image_strip must be vetoed')
+      const second = JSON.parse(calls[1]!.body) as { messages: Array<{ role: string; content: unknown }> }
+      const secondUser = second.messages[1]!.content as Array<{ type: string }>
+      assert.ok(!secondUser.some(p => p.type === 'image_url'), 'retry body must be stripped')
+    } finally {
+      restoreFetch()
+    }
+  })
+})

--- a/src/api/__tests__/retry-engine.test.ts
+++ b/src/api/__tests__/retry-engine.test.ts
@@ -176,6 +176,42 @@ describe('withStructuredRetry', () => {
     assert.equal(calls, 2, `expected 2 calls, got ${calls}`)
   })
 
+  it('should not retry when onRetry returns false (veto)', async () => {
+    let calls = 0
+    const fn = async (): Promise<string> => {
+      calls++
+      throw new FakeApiError('Server error (500)', 500)
+    }
+    // A veto must rethrow the original error immediately: no backoff wait and
+    // no second attempt, even though the classifier would otherwise retry.
+    await assert.rejects(
+      () => withStructuredRetry(fn, undefined, {
+        maxTotalRetries: 5,
+        onRetry: () => false,
+      }),
+      (err: unknown) => {
+        assert.ok(err instanceof FakeApiError)
+        assert.equal(calls, 1, 'vetoed retry must not call fn again')
+        return true
+      },
+    )
+  })
+
+  it('should retry when onRetry returns undefined (no veto)', async () => {
+    let calls = 0
+    const fn = async (): Promise<string> => {
+      calls++
+      if (calls === 1) throw new FakeApiError('Server error (500)', 500)
+      return 'ok'
+    }
+    const result = await withStructuredRetry(fn, undefined, {
+      maxTotalRetries: 5,
+      onRetry: () => undefined,
+    })
+    assert.equal(result, 'ok')
+    assert.equal(calls, 2)
+  })
+
   it('should respect AbortSignal', async () => {
     const controller = new AbortController()
     let calls = 0

--- a/src/api/anthropic-client.ts
+++ b/src/api/anthropic-client.ts
@@ -1,5 +1,6 @@
 import type { StreamClient, StreamCallbacks } from './stream-client.js'
 import type { OaiChatRequest, OaiMessage } from './oai-types.js'
+import { oaiMessagesHaveImageParts, stripOaiImageParts } from './oai-types.js'
 import { withStructuredRetry } from './retry-engine.js'
 import { parseRetryAfterMs } from './error-classifier.js'
 import { fetchWithTimeout } from './fetch-timeout.js'
@@ -115,9 +116,20 @@ export class AnthropicClient implements StreamClient {
     callbacks: StreamCallbacks,
     signal?: AbortSignal,
   ): Promise<void> {
-    const body = this.buildRequestBody(request)
+    // image_strip recovery state — see openai-client.sendStream for the flow:
+    // first request sends images; on a 413 / image-rejection retry the images
+    // are dropped and resent once; any further image_strip error is rethrown.
+    const messagesHaveImages = oaiMessagesHaveImageParts(request.messages)
+    let stripRequested = false
+    let imagesStripped = false
 
     await withStructuredRetry(async () => {
+      const body = this.buildRequestBody(request, {
+        stripImages: stripRequested && !imagesStripped,
+      })
+      if (stripRequested && !imagesStripped) {
+        imagesStripped = true
+      }
       // 共享 lifecycle controller（见 openai-client 同名注释）：传给 fetch，
       // 由外部 signal 联动并在 processSSEStream 的 finally 中 abort。
       const lifecycle = new AbortController()
@@ -166,6 +178,15 @@ export class AnthropicClient implements StreamClient {
         if (info.classified.category === 'rate_limit') {
           callbacks.onRateLimit?.(info.classified.retryDelayMs)
         }
+        if (info.classified.category === 'image_strip') {
+          // Nothing to strip (no image parts) or already stripped once → the
+          // retry cannot help; surface the original 413 / image error now.
+          if (imagesStripped || !messagesHaveImages) {
+            return false
+          }
+          // First image_strip retry: drop images on the next attempt.
+          stripRequested = true
+        }
       },
     })
   }
@@ -175,10 +196,16 @@ export class AnthropicClient implements StreamClient {
     return this.buildRequestBody(request)
   }
 
-  private buildRequestBody(request: OaiChatRequest): AnthropicRequestBody {
+  private buildRequestBody(
+    request: OaiChatRequest,
+    opts: { stripImages?: boolean } = {},
+  ): AnthropicRequestBody {
     // Extract system messages to top-level system array
     let systemText = ''
-    const nonSystemMessages = request.messages.filter(m => {
+    const srcMessages = opts.stripImages
+      ? stripOaiImageParts(request.messages).messages
+      : request.messages
+    const nonSystemMessages = srcMessages.filter(m => {
       if (m.role === 'system') {
         systemText += (systemText ? '\n\n' : '') + m.content
         return false

--- a/src/api/oai-types.ts
+++ b/src/api/oai-types.ts
@@ -101,6 +101,68 @@ export function isUserMessage(msg: OaiMessage): msg is OaiUserMessage {
   return msg.role === 'user'
 }
 
+/** Placeholder substituted for an image-only user message after stripping, so
+ *  the message (and role alternation) survives even when it carried no text. */
+export const STRIPPED_IMAGE_PLACEHOLDER = '[image removed to reduce payload size]'
+
+/**
+ * True when at least one user message carries a multimodal `image_url` part.
+ * The retry path uses this to decide whether an image_strip recovery can help.
+ */
+export function oaiMessagesHaveImageParts(messages: OaiMessage[]): boolean {
+  return messages.some(
+    m => m.role === 'user'
+      && Array.isArray(m.content)
+      && m.content.some(p => p.type === 'image_url'),
+  )
+}
+
+export interface StrippedOaiMessages {
+  /** Messages with image_url parts removed (same reference when nothing changed). */
+  messages: OaiMessage[]
+  /** Number of image_url parts removed. */
+  removedCount: number
+}
+
+/**
+ * Return a copy of `messages` with every multimodal `image_url` part removed,
+ * preserving all text and the overall message/role structure. This is the
+ * payload-shrinking recovery for a 413 / image-rejection retry: drop images and
+ * resend instead of repeating the identical oversized request.
+ *
+ * Pure — never mutates input. Returns the SAME array reference when no image
+ * was removed, so callers can cheaply detect a no-op. An image-only user message
+ * (no text part) is replaced with a short text placeholder so the request still
+ * has a non-empty user turn and valid role alternation after the strip.
+ */
+export function stripOaiImageParts(
+  messages: OaiMessage[],
+  placeholder: string = STRIPPED_IMAGE_PLACEHOLDER,
+): StrippedOaiMessages {
+  let removedCount = 0
+  let next: OaiMessage[] | undefined
+
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i]!
+    if (msg.role !== 'user' || !Array.isArray(msg.content)) continue
+    const imageCount = msg.content.reduce(
+      (n, p) => (p.type === 'image_url' ? n + 1 : n),
+      0,
+    )
+    if (imageCount === 0) continue
+
+    removedCount += imageCount
+    next ??= messages.slice()
+    const kept = msg.content.filter(p => p.type !== 'image_url')
+    const content: OaiContentPart[] = kept.length > 0
+      ? kept
+      : [{ type: 'text', text: placeholder }]
+    next[i] = { ...msg, content }
+  }
+
+  return { messages: next ?? messages, removedCount }
+}
+
 /**
  * Extract plain text from any OaiMessage content (handles multimodal user messages).
  * Use this instead of `msg.content` when you need a string regardless of content type.

--- a/src/api/openai-client.ts
+++ b/src/api/openai-client.ts
@@ -1,6 +1,6 @@
 import type { StreamClient, WireDivergence } from './stream-client.js'
 import type { StreamCallbacks } from './stream-client.js'
-import { normalizeOaiMessage } from './oai-types.js'
+import { normalizeOaiMessage, oaiMessagesHaveImageParts, stripOaiImageParts } from './oai-types.js'
 import type { OaiChatRequest, OaiMessage } from './oai-types.js'
 import { proRegistry } from './pro-registry.js'
 import { estimateOaiTokens } from '../compact/micro.js'
@@ -674,6 +674,16 @@ export class OpenAIClient implements StreamClient {
     const reasoningRef = { content: '' }
     const isThinking = this.config.thinking === 'enabled'
 
+    // image_strip recovery state: whether the current request carries image_url
+    // parts at all, whether a strip has been requested by a 413 / image
+    // rejection, and whether it already happened. Flow: first request sends
+    // images; on an image_strip retry the images are dropped and the stripped
+    // body is resent once; any further image_strip error is rethrown immediately
+    // (a second identical oversized body cannot help).
+    const messagesHaveImages = oaiMessagesHaveImageParts((body.messages as OaiMessage[]) ?? [])
+    let stripRequested = false
+    let imagesStripped = false
+
     // Size-scaled first-byte budget (B): estimate prompt size once (stable across
     // retries; the per-retry reasoning re-injection is negligible) and derive a
     // first-byte timeout that grows with input so large cold-context prefills are
@@ -706,15 +716,28 @@ export class OpenAIClient implements StreamClient {
       // the increment and causes GLM to re-reason from scratch (the exact
       // "推理到一半中断然后从头推一遍" symptom). GLM retains reasoning server-side,
       // so skipping client-side reinjection is safe.
+      // 413 / image-rejection recovery (requested by a previous image_strip
+      // classification): strip image_url parts once, before reasoning injection.
+      let messagesBase: unknown[] = body.messages as unknown[]
+      if (stripRequested && !imagesStripped && messagesHaveImages) {
+        const stripped = stripOaiImageParts(messagesBase as OaiMessage[])
+        if (stripped.removedCount > 0) {
+          messagesBase = stripped.messages
+          imagesStripped = true
+        }
+      }
+
       let effectiveBody = body
       const isGlm = this.config.providerName === 'glm'
       if (isThinking && reasoningRef.content && !isGlm) {
-        const msgs = [...(body.messages as unknown[]), {
+        const msgs = [...messagesBase, {
           role: 'assistant',
           content: '',
           reasoning_content: reasoningRef.content,
         }]
         effectiveBody = { ...body, messages: msgs }
+      } else if (messagesBase !== body.messages) {
+        effectiveBody = { ...body, messages: messagesBase }
       }
 
       // Resolve auth headers: AuthProvider takes precedence over static apiKey
@@ -800,6 +823,15 @@ export class OpenAIClient implements StreamClient {
       onRetry: (info) => {
         if (info.classified.category === 'rate_limit') {
           callbacks.onRateLimit?.(info.classified.retryDelayMs)
+        }
+        if (info.classified.category === 'image_strip') {
+          // Nothing to strip (no image parts) or already stripped once → the
+          // retry cannot help; surface the original 413 / image error now.
+          if (imagesStripped || !messagesHaveImages) {
+            return false
+          }
+          // First image_strip retry: drop images on the next attempt.
+          stripRequested = true
         }
       },
     })

--- a/src/api/retry-engine.ts
+++ b/src/api/retry-engine.ts
@@ -108,8 +108,14 @@ export interface RetryOptions {
    *  When exceeded, the current attempt is abandoned and an error is thrown.
    *  Prevents retry loops from running for tens of minutes on unresponsive providers. */
   maxTotalDurationMs?: number
-  /** Called before each retry with diagnostic info. */
-  onRetry?: (info: RetryInfo) => void
+  /**
+   * Called before each retry with diagnostic info. Return `false` to veto the
+   * pending retry: the original error is rethrown immediately (no backoff) when
+   * the caller can prove the retry cannot succeed — e.g. an `image_strip`
+   * recovery whose request carries no image part to remove. A `void` return
+   * leaves the normal retry schedule untouched.
+   */
+  onRetry?: (info: RetryInfo) => void | false
 }
 
 export interface RetryInfo {
@@ -192,12 +198,17 @@ export async function withStructuredRetry<T>(
           ? applyDelayJitter(classified.retryDelayMs)
           : jitteredBackoff(attempt + 1)
 
-      // Notify caller
-      options?.onRetry?.({
+      // Notify caller. A `false` return vetoes this retry: the caller proved it
+      // cannot help (e.g. image_strip with no image part to remove), so rethrow
+      // the original error at once instead of sleeping into a doomed attempt.
+      const veto = options?.onRetry?.({
         attempt: attempt + 1,
         classified,
         nextDelayMs,
       })
+      if (veto === false) {
+        throw err
+      }
 
       // Wait (abort-aware)
       await abortableDelay(nextDelayMs, signal)


### PR DESCRIPTION
## 问题描述

`src/api/error-classifier.ts` 对两类错误（413 Payload Too Large、图片处理错误 400/500）分类为 `image_strip`，并承诺「剥离图片后重试」：

- 分类结果携带 `stripImages: true`（`error-classifier.ts:36`），注释明确写着 *"When true, the retry engine should strip image_url content from messages before retrying"*；
- 分类器默认 `maxRetries: 1`，即预期「剥一次图 → 重发一次」。

但**全链路没有任何代码消费 `stripImages`**：

- `src/api/retry-engine.ts` 的 `withStructuredRetry` 只根据 `classified.maxRetries` 重试，从不读取 `stripImages`，重试时调用同一个 `fn`、发送完全相同的请求体；
- `src/api/openai-client.ts` 与 `src/api/anthropic-client.ts` 的请求体构造也从不基于 `stripImages` 剥离 `image_url`。

现有测试固化的是错误行为：`src/api/__tests__/retry-engine.test.ts:148` 的用例"should retry 413 image_strip once, then fail"明确断言 **413 重试时用同一个函数原样重发两次后失败**——图片并没有被剥离，重试必然再次 413。

## 实际影响

1. **多模态请求 413 时自动恢复完全失效**：图片过重的请求收到 413 后，重试只是原样重发同一个过重请求，必然再次 413，最终把错误冒泡给用户；而本应有效的「剥图重发」从未发生。
2. **浪费一次重试与一次网络往返**：即使失败是必然的，仍多等一轮背压/超时。
3. **行为与分类器的契约不符**：`stripImages` 字段、注释与 `errorRecoveryGuidance` 的「图片负载超限：去掉部分图片后重发」指引，都承诺了不存在的能力。

## 复现

1. 配置一个带 `image_url`（base64）的多模态请求，使 payload 超过服务端限制（或服务端返回图片处理错误）。
2. 观察重试：第二次请求体与第一次逐字节相同（未剥离图片），再次 413。
3. 现有单测 `retry-engine.test.ts`「should retry 413 image_strip once, then fail」可直接佐证该行为。

## 建议修复方向

- 在重试循环中消费 `stripImages`：首次 `image_strip` 分类后，下一次 attempt 发送剥离 `image_url` 后的请求体（保留文本与角色结构，纯图片消息用文本占位）；
- 已剥离后再次 `image_strip`（或请求本无图片可剥）时立即抛出原错误，不再重复发送同一请求体；
- 相应补充客户端层端到端单测（413 → 剥图重发 → 成功；无图 413 快速失败）。

已按此方向实现并提交：PR #（见关联 PR）。
