### PR TITLE
feat(api): 可配置重试策略 + 可选客户端限速（provider.providers.<name>.retry）

### DIFF
--- a/src/api/__tests__/retry-engine.test.ts
+++ b/src/api/__tests__/retry-engine.test.ts
@@ -318,3 +318,91 @@ describe('withStructuredRetry', () => {
     }
   })
 })
+
+// ---------------------------------------------------------------------------
+// Retry policy overrides (provider.providers.<name>.retry)
+// ---------------------------------------------------------------------------
+
+describe('retry policy overrides', () => {
+  // Zero backoff everywhere in this suite: budget semantics are what we assert,
+  // not delay pacing (that has its own cases below).
+  const FAST_BACKOFF = { baseDelayMs: 0, maxDelayMs: 0, jitterRatio: 0 }
+
+  it('raises a category budget above the classifier built-in cap', async () => {
+    // rate_limit is capped at 5 by the classifier; an override of 8 must win.
+    // The engine's own global ceiling (maxTotalRetries) still applies on top.
+    let calls = 0
+    const fn = async (): Promise<string> => {
+      calls++
+      throw new FakeApiError('Rate limited (429)', 429)
+    }
+    await assert.rejects(
+      () => withStructuredRetry(fn, undefined, {
+        maxTotalRetries: 8,
+        overrides: { rate_limit: { maxRetries: 8 } },
+        backoff: FAST_BACKOFF,
+      }),
+    )
+    // 1 initial + 8 retries = 9
+    assert.equal(calls, 9, `expected 9 calls, got ${calls}`)
+  })
+
+  it('clamps a category override by the global maxTotalRetries ceiling', async () => {
+    let calls = 0
+    const fn = async (): Promise<string> => {
+      calls++
+      throw new FakeApiError('Rate limited (429)', 429)
+    }
+    await assert.rejects(
+      () => withStructuredRetry(fn, undefined, {
+        maxTotalRetries: 3,
+        overrides: { rate_limit: { maxRetries: 8 } },
+        backoff: FAST_BACKOFF,
+      }),
+    )
+    // global ceiling 3 wins: 1 initial + 3 retries = 4
+    assert.equal(calls, 4, `expected 4 calls, got ${calls}`)
+  })
+
+  it('replaces the classifier delay with the category override delay', async () => {
+    const { infos, onRetry } = createCollector()
+    const fn = flakyFactory('done', 1, 429)
+    await withStructuredRetry(fn, undefined, {
+      maxTotalRetries: 5,
+      overrides: { rate_limit: { retryDelayMs: 1 } },
+      backoff: { jitterRatio: 0 },
+      onRetry,
+    })
+    assert.equal(infos.length, 1)
+    // 429 classifier delay is 2000; the override replaces it.
+    assert.equal(infos[0]!.nextDelayMs, 1)
+    assert.equal(infos[0]!.classified.category, 'rate_limit')
+  })
+
+  it('honours a custom backoff shape when no classifier delay applies', async () => {
+    // image_strip carries retryDelayMs 0 → falls back to jitteredBackoff, which
+    // must now honour the configured shape instead of the hardcoded defaults.
+    const { infos, onRetry } = createCollector()
+    const fn = flakyFactory('done', 1, 413)
+    await withStructuredRetry(fn, undefined, {
+      maxTotalRetries: 5,
+      backoff: { baseDelayMs: 1, maxDelayMs: 1000, jitterRatio: 0 },
+      onRetry,
+    })
+    assert.equal(infos.length, 1)
+    assert.equal(infos[0]!.nextDelayMs, 1, 'attempt 1 delay = baseDelayMs with zero jitter')
+  })
+
+  it('leaves behavior unchanged when no overrides are configured', async () => {
+    let calls = 0
+    const fn = async (): Promise<string> => {
+      calls++
+      throw new FakeApiError('Rate limited (429)', 429)
+    }
+    await assert.rejects(
+      () => withStructuredRetry(fn, undefined, { backoff: FAST_BACKOFF }),
+    )
+    // classifier cap for rate_limit is 5: 1 initial + 5 retries = 6
+    assert.equal(calls, 6, `expected 6 calls, got ${calls}`)
+  })
+})

--- a/src/api/__tests__/retry-policy.test.ts
+++ b/src/api/__tests__/retry-policy.test.ts
@@ -1,0 +1,111 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  DEFAULT_RETRY_BACKOFF,
+  resolveBackoff,
+  isRateLimitEnabled,
+} from '../retry-policy.js'
+import {
+  acquireProviderSlot,
+  resetRateLimiterRegistry,
+} from '../rate-limiter.js'
+
+// ---------------------------------------------------------------------------
+// resolveBackoff — partial config fills with historical defaults
+// ---------------------------------------------------------------------------
+
+describe('resolveBackoff', () => {
+  it('fills every field with the built-in defaults when no config is given', () => {
+    const resolved = resolveBackoff(undefined)
+    assert.equal(resolved.baseDelayMs, DEFAULT_RETRY_BACKOFF.baseDelayMs)
+    assert.equal(resolved.maxDelayMs, DEFAULT_RETRY_BACKOFF.maxDelayMs)
+    assert.equal(resolved.jitterRatio, DEFAULT_RETRY_BACKOFF.jitterRatio)
+  })
+
+  it('keeps user values and fills only the missing fields', () => {
+    const resolved = resolveBackoff({ baseDelayMs: 250, jitterRatio: 0 })
+    assert.equal(resolved.baseDelayMs, 250)
+    assert.equal(resolved.maxDelayMs, DEFAULT_RETRY_BACKOFF.maxDelayMs)
+    assert.equal(resolved.jitterRatio, 0, 'explicit 0 must not be treated as absent')
+  })
+
+  it('treats 0 as a legal value, not a missing one (no `||` bug)', () => {
+    const resolved = resolveBackoff({ baseDelayMs: 0, maxDelayMs: 0 })
+    assert.equal(resolved.baseDelayMs, 0)
+    assert.equal(resolved.maxDelayMs, 0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// isRateLimitEnabled
+// ---------------------------------------------------------------------------
+
+describe('isRateLimitEnabled', () => {
+  it('is false when config is absent', () => {
+    assert.equal(isRateLimitEnabled(undefined), false)
+  })
+
+  it('is false when requestsPerSecond is absent or not positive', () => {
+    assert.equal(isRateLimitEnabled({}), false)
+    assert.equal(isRateLimitEnabled({ requestsPerSecond: 0 }), false)
+    assert.equal(isRateLimitEnabled({ requestsPerSecond: -1 }), false)
+  })
+
+  it('is true when requestsPerSecond is positive', () => {
+    assert.equal(isRateLimitEnabled({ requestsPerSecond: 10 }), true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// acquireProviderSlot — pacing, FIFO order, off-by-default
+// ---------------------------------------------------------------------------
+
+describe('acquireProviderSlot', () => {
+  it('is a no-op when the limiter is disabled', async () => {
+    resetRateLimiterRegistry()
+    const t0 = Date.now()
+    await Promise.all([1, 2, 3, 4].map(() => acquireProviderSlot('prov', undefined)))
+    assert.ok(Date.now() - t0 < 100, 'disabled limiter must not pace')
+  })
+
+  it('paces acquisitions to the configured rate (loose timing bounds)', async () => {
+    resetRateLimiterRegistry()
+    // 20 req/s, burst 1 → one token every 50ms after the first.
+    const t0 = Date.now()
+    await Promise.all([1, 2, 3, 4].map(() => acquireProviderSlot('prov', { requestsPerSecond: 20, burst: 1 })))
+    const elapsed = Date.now() - t0
+    assert.ok(elapsed >= 120, `expected >= ~150ms for 4 slots at 20/s, got ${elapsed}ms`)
+    assert.ok(elapsed < 1500, `expected bounded pacing, got ${elapsed}ms`)
+  })
+
+  it('releases one waiter per token period (FIFO order preserved)', async () => {
+    resetRateLimiterRegistry()
+    const order: number[] = []
+    const acquire = async (i: number): Promise<void> => {
+      await acquireProviderSlot('fifo', { requestsPerSecond: 20, burst: 1 })
+      order.push(i)
+    }
+    await Promise.all([1, 2, 3].map(i => acquire(i)))
+    assert.deepEqual(order, [1, 2, 3], 'acquisitions must resolve in call order')
+  })
+
+  it('shares one bucket across callers with the same key', async () => {
+    resetRateLimiterRegistry()
+    // Two independent callers, same provider key → the bucket is shared, so the
+    // second caller waits for the first one's token rather than starting fresh.
+    const t0 = Date.now()
+    const a = acquireProviderSlot('shared', { requestsPerSecond: 20, burst: 1 })
+    const b = acquireProviderSlot('shared', { requestsPerSecond: 20, burst: 1 })
+    await Promise.all([a, b])
+    assert.ok(Date.now() - t0 >= 40, 'second caller must wait for the shared bucket')
+  })
+
+  it('resets cleanly between tests', async () => {
+    resetRateLimiterRegistry()
+    await acquireProviderSlot('prov', { requestsPerSecond: 100 })
+    resetRateLimiterRegistry()
+    const t0 = Date.now()
+    await acquireProviderSlot('prov', { requestsPerSecond: 100 })
+    assert.ok(Date.now() - t0 < 100, 'a fresh bucket must not inherit debt from a previous run')
+  })
+})

--- a/src/api/anthropic-client.ts
+++ b/src/api/anthropic-client.ts
@@ -2,6 +2,8 @@ import type { StreamClient, StreamCallbacks } from './stream-client.js'
 import type { OaiChatRequest, OaiMessage } from './oai-types.js'
 import { withStructuredRetry } from './retry-engine.js'
 import { parseRetryAfterMs } from './error-classifier.js'
+import type { RetryPolicyConfig } from './retry-policy.js'
+import { acquireProviderSlot } from './rate-limiter.js'
 import { fetchWithTimeout } from './fetch-timeout.js'
 import { wireAbortToReaderCancel, wrapBodyTimeoutError } from './abort-reader.js'
 import { parseJsonObjectWithEscapeRepair } from './json-escape-repair.js'
@@ -17,6 +19,13 @@ export interface AnthropicClientConfig {
   requestTimeoutMs?: number
   /** 重试次数覆盖；undefined = 内置默认（5），0 = 禁用。 */
   maxRetries?: number
+  /**
+   * 重试策略（退避曲线 / 分类覆盖 / 总时长上限 / 客户端限速）。
+   * undefined = 完全保持内置硬编码行为。来源：`provider.providers.<name>.retry`。
+   */
+  retry?: RetryPolicyConfig
+  /** Provider name — rate-limiter bucket key（缺省回退到 baseUrl）。 */
+  providerName?: string
   /** 采样温度默认值（clamp 到 Anthropic 合法的 0–1）；thinking 启用时不注入
    *  （Anthropic 要求 thinking 请求 temperature=1）。 */
   temperature?: number
@@ -102,6 +111,11 @@ export class AnthropicClient implements StreamClient {
     this.proxyDispatcher = config.proxy ? new ProxyAgent(config.proxy) : undefined
   }
 
+  /** Rate-limiter bucket key — see OpenAIClient.rateLimitKey. */
+  private get rateLimitKey(): string {
+    return this.config.providerName ?? this.config.baseUrl
+  }
+
   setReasoningEffort(_effort: string): void {
     // Anthropic doesn't use reasoning_effort — thinking budget is set at construction
   }
@@ -125,6 +139,9 @@ export class AnthropicClient implements StreamClient {
         if (signal.aborted) lifecycle.abort()
         else signal.addEventListener('abort', () => lifecycle.abort(), { once: true })
       }
+      // Client-side rate limit (opt-in) — see openai-client for rationale.
+      await acquireProviderSlot(this.rateLimitKey, this.config.retry?.rateLimit, lifecycle.signal)
+
       const response = await fetchWithTimeout(`${this.config.baseUrl.replace(/\/+$/, '')}/v1/messages`, {
         method: 'POST',
         headers: {
@@ -159,9 +176,14 @@ export class AnthropicClient implements StreamClient {
 
       await this.processSSEStream(response, callbacks, signal, lifecycle)
     }, signal, {
-      maxTotalDurationMs: 10 * 60_000,
+      // Precedence: explicit retry.maxTotalDurationMs → built-in 10min cap.
+      maxTotalDurationMs: this.config.retry?.maxTotalDurationMs ?? 10 * 60_000,
       // provider 级 maxRetries 显式配置时覆盖内置默认（0 = 禁用重试）。
-      maxTotalRetries: this.config.maxRetries,
+      // Precedence: retry.maxTotalRetries → legacy maxRetries → engine default.
+      maxTotalRetries: this.config.retry?.maxTotalRetries ?? this.config.maxRetries,
+      // Backoff shape + per-category budget overrides (undefined = built-in).
+      backoff: this.config.retry?.backoff,
+      overrides: this.config.retry?.overrides,
       onRetry: (info) => {
         if (info.classified.category === 'rate_limit') {
           callbacks.onRateLimit?.(info.classified.retryDelayMs)

--- a/src/api/factory.ts
+++ b/src/api/factory.ts
@@ -124,6 +124,9 @@ export function createProviderClient(
       thinkingBudget,
       requestTimeoutMs: provider.requestTimeoutMs,
       maxRetries: provider.maxRetries,
+      // Retry policy (backoff shape / per-category overrides / rate limit).
+      retry: provider.retry,
+      providerName: provider.name,
       temperature: provider.temperature,
       proxy: provider.proxy,
       userAgent: wire?.userAgent,

--- a/src/api/openai-client.ts
+++ b/src/api/openai-client.ts
@@ -7,6 +7,8 @@ import { estimateOaiTokens } from '../compact/micro.js'
 import type { ProviderProfile } from './provider-profile.js'
 import { fetchWithTimeout } from './fetch-timeout.js'
 import { withStructuredRetry } from './retry-engine.js'
+import type { RetryPolicyConfig } from './retry-policy.js'
+import { acquireProviderSlot } from './rate-limiter.js'
 import { parseRetryAfterMs } from './error-classifier.js'
 import { ReasoningRepetitionGuard } from './reasoning-repetition.js'
 import { sanitizeMessageContent } from '../utils/sanitize.js'
@@ -191,6 +193,11 @@ export interface OpenAIClientConfig {
   /** Max retry attempts for retryable API errors. undefined = 保留内置默认
    *  （thinking 1 次 / slow-thinking 2 次 / 非 thinking 5 次）；0 = 禁用重试。 */
   maxRetries?: number
+  /**
+   * 重试策略（退避曲线 / 分类覆盖 / 总时长上限 / 客户端限速）。
+   * undefined = 完全保持内置硬编码行为。来源：`provider.providers.<name>.retry`。
+   */
+  retry?: RetryPolicyConfig
   /** Provider-level sampling temperature default (0–2)。仅当请求未显式指定
    *  temperature 且 thinking 未启用时注入——推理模式下多数服务端拒绝调温。 */
   temperature?: number
@@ -391,6 +398,16 @@ export class OpenAIClient implements StreamClient {
       : ''
     this._sanitizedCount = 0
     this.proxyDispatcher = config.proxy ? new ProxyAgent(config.proxy) : undefined
+  }
+
+  /**
+   * Rate-limiter bucket key. Prefer the provider name so entries that point at
+   * the same provider share one bucket across client instances (the factory
+   * builds a client per request); fall back to baseUrl for unnamed custom
+   * endpoints.
+   */
+  private get rateLimitKey(): string {
+    return this.config.providerName ?? this.config.baseUrl
   }
 
   /** 慢思考端点判定（名称/URL/显式配置三级，见 isSlowThinkingProvider）。 */
@@ -735,6 +752,12 @@ export class OpenAIClient implements StreamClient {
         if (signal.aborted) lifecycle.abort()
         else signal.addEventListener('abort', () => lifecycle.abort(), { once: true })
       }
+      // Client-side rate limit (opt-in): pace outgoing requests per provider so a
+      // wave of subagents cannot stampede the same quota and all collect 429s.
+      // No-op unless `retry.rateLimit.requestsPerSecond` is configured. Waits on
+      // the lifecycle signal so user cancellation also aborts the queue.
+      await acquireProviderSlot(this.rateLimitKey, this.config.retry?.rateLimit, lifecycle.signal)
+
       const response = await fetchWithTimeout(`${this.config.baseUrl}/chat/completions`, {
         method: 'POST',
         headers: {
@@ -787,16 +810,22 @@ export class OpenAIClient implements StreamClient {
 
       await this.parseStreamFromReader(reader, callbacks, signal, reasoningRef, lifecycle, firstByteMs)
     }, signal, {
-      maxTotalDurationMs: this.config.providerName === 'glm' ? 20 * 60_000 : 10 * 60_000,
+      // Precedence: explicit retry.maxTotalDurationMs → built-in per-provider cap.
+      maxTotalDurationMs: this.config.retry?.maxTotalDurationMs
+        ?? (this.config.providerName === 'glm' ? 20 * 60_000 : 10 * 60_000),
       // Thinking retries are normally throttled to 1 because re-reasoning is costly.
       // 例外：slow-thinking providers 在被中止的那次尝试里已把整个 prompt 灌进服务端
       // 前缀缓存，重试命中近 100% 缓存（实测 deepseek 99.4% hit、~12s 完成），代价极低。
       // 给它们 2 次重试，让「单次服务端 thinking 卡死」甚至「连续两次卡死」都能自愈而
       // 不冒泡成错误。maxTotalDurationMs 仍是总时长兜底，防 runaway。
       // An explicit provider maxRetries overrides the built-in thinking budget (0 disables retries).
-      maxTotalRetries: this.config.maxRetries ?? (isThinking
-        ? (this.isSlowThinking ? 2 : 1)
-        : undefined),
+      // Precedence: retry.maxTotalRetries → legacy maxRetries → built-in thinking budget.
+      maxTotalRetries: this.config.retry?.maxTotalRetries
+        ?? this.config.maxRetries
+        ?? (isThinking ? (this.isSlowThinking ? 2 : 1) : undefined),
+      // Backoff shape + per-category budget overrides (undefined = built-in).
+      backoff: this.config.retry?.backoff,
+      overrides: this.config.retry?.overrides,
       onRetry: (info) => {
         if (info.classified.category === 'rate_limit') {
           callbacks.onRateLimit?.(info.classified.retryDelayMs)

--- a/src/api/rate-limiter.ts
+++ b/src/api/rate-limiter.ts
@@ -1,0 +1,122 @@
+/**
+ * Client-side request rate limiter — opt-in token bucket, one bucket per
+ * provider.
+ *
+ * Why this exists: retries only react to a 429 the server already sent. Under
+ * concurrency (multiple subagents / a team wave), several workers can stampede
+ * the same provider quota and every one of them eats a 429 plus its backoff,
+ * which is strictly slower than pacing the requests in the first place. The
+ * limiter lets a user declare "this provider tolerates N req/s" and paces
+ * requests before they leave the process.
+ *
+ * Semantics:
+ * - Off by default. `retry.rateLimit.requestsPerSecond` absent/<= 0 = no
+ *   behavior change at all.
+ * - Buckets are keyed by provider and stored in a module-level registry, so a
+ *   freshly constructed client (the factory builds one per request) joins the
+ *   bucket its siblings are already using instead of getting a private one.
+ * - Acquisitions are FIFO-serialized: a caller that must wait holds the queue
+ *   until it has consumed its token, so N simultaneous callers are released
+ *   one per token period rather than all at once on the next refill.
+ */
+
+import { abortableDelay } from './retry-engine.js'
+import { isRateLimitEnabled, type RetryRateLimitConfig } from './retry-policy.js'
+
+class TokenBucket {
+  private tokens: number
+  private lastRefillMs: number
+  /** Tail of the FIFO acquisition chain (see `acquire`). */
+  private tail: Promise<void> = Promise.resolve()
+
+  constructor(
+    /** Tokens added per millisecond. */
+    private readonly ratePerMs: number,
+    private readonly capacity: number,
+    now: number,
+  ) {
+    this.tokens = capacity
+    this.lastRefillMs = now
+  }
+
+  /** Add the tokens accrued since the last call, capped at `capacity`. */
+  private refill(now: number): void {
+    const elapsed = now - this.lastRefillMs
+    if (elapsed <= 0) return
+    this.tokens = Math.min(this.capacity, this.tokens + elapsed * this.ratePerMs)
+    this.lastRefillMs = now
+  }
+
+  /** Resolve once one token has been consumed (waiting if necessary). */
+  async acquire(signal?: AbortSignal): Promise<void> {
+    if (signal?.aborted) throw new DOMException('Aborted', 'AbortError')
+
+    // Chain onto the previous waiter. Holding the queue across the wait is the
+    // point: it serializes token assignment and preserves call order.
+    const previous = this.tail
+    let release!: () => void
+    this.tail = new Promise<void>(resolve => { release = resolve })
+    await previous
+
+    try {
+      this.refill(Date.now())
+      if (this.tokens < 1) {
+        const waitMs = Math.ceil((1 - this.tokens) / this.ratePerMs)
+        await abortableDelay(waitMs, signal)
+        this.refill(Date.now())
+      }
+      // Clamp rather than assert: Math.ceil on the wait can leave tokens a
+      // hair below 1 after timer rounding, and a sub-millisecond overshoot is
+      // not worth another sleep round.
+      this.tokens = Math.max(0, this.tokens - 1)
+    } finally {
+      release()
+    }
+  }
+}
+
+interface RegisteredBucket {
+  bucket: TokenBucket
+  requestsPerSecond: number
+  burst: number
+}
+
+const registry = new Map<string, RegisteredBucket>()
+
+/**
+ * Consume one request slot for `key`, waiting if the provider is at its
+ * configured rate. No-op when the limiter is disabled.
+ *
+ * `key` should identify the quota being protected — the provider name (two
+ * providers sharing one upstream quota is the user's call to make; we key by
+ * provider so config stays local to the entry that declared it).
+ */
+export function acquireProviderSlot(
+  key: string,
+  config?: RetryRateLimitConfig,
+  signal?: AbortSignal,
+): Promise<void> {
+  if (!isRateLimitEnabled(config)) return Promise.resolve()
+
+  const requestsPerSecond = config.requestsPerSecond
+  const burst = config.burst ?? Math.max(1, Math.ceil(requestsPerSecond))
+  const existing = registry.get(key)
+
+  // Rebuild on config change so an edited rate takes effect without a restart.
+  if (
+    !existing
+    || existing.requestsPerSecond !== requestsPerSecond
+    || existing.burst !== burst
+  ) {
+    const bucket = new TokenBucket(requestsPerSecond / 1000, burst, Date.now())
+    registry.set(key, { bucket, requestsPerSecond, burst })
+    return bucket.acquire(signal)
+  }
+
+  return existing.bucket.acquire(signal)
+}
+
+/** Drop all registry state. Test helper — keeps buckets from leaking across cases. */
+export function resetRateLimiterRegistry(): void {
+  registry.clear()
+}

--- a/src/api/retry-engine.ts
+++ b/src/api/retry-engine.ts
@@ -6,7 +6,13 @@
  */
 
 import { classifyApiError } from './error-classifier.js'
-import type { ClassifiedError } from './error-classifier.js'
+import type { ClassifiedError, ErrorCategory } from './error-classifier.js'
+import {
+  DEFAULT_RETRY_BACKOFF,
+  resolveBackoff,
+  type RetryBackoffConfig,
+  type RetryCategoryOverride,
+} from './retry-policy.js'
 
 // ---------------------------------------------------------------------------
 // Jittered exponential backoff
@@ -78,8 +84,16 @@ export function abortableDelay(ms: number, signal?: AbortSignal): Promise<void> 
   })
 }
 
-function applyDelayJitter(delayMs: number): number {
-  return delayMs + Math.random() * delayMs * 0.5
+/**
+ * Jitter the classifier-supplied base delay. Shares the `jitterRatio` knob with
+ * `jitteredBackoff` so one config value shapes both delay paths; the default
+ * (0.5) is the historical hardcoded value.
+ */
+function applyDelayJitter(
+  delayMs: number,
+  jitterRatio: number = DEFAULT_RETRY_BACKOFF.jitterRatio,
+): number {
+  return delayMs + Math.random() * delayMs * jitterRatio
 }
 
 // ---------------------------------------------------------------------------
@@ -108,6 +122,20 @@ export interface RetryOptions {
    *  When exceeded, the current attempt is abandoned and an error is thrown.
    *  Prevents retry loops from running for tens of minutes on unresponsive providers. */
   maxTotalDurationMs?: number
+  /**
+   * Shape of the jittered exponential backoff. Absent fields fall back to
+   * `DEFAULT_RETRY_BACKOFF` (the historical hardcoded values).
+   */
+  backoff?: RetryBackoffConfig
+  /**
+   * Per-category budget / delay overrides keyed by `ErrorCategory`.
+   *
+   * Precedence for a category's retry budget is
+   * `min(overrides[cat].maxRetries ?? classified.maxRetries, maxTotalRetries)`,
+   * i.e. the override wins over the classifier's built-in cap but the global
+   * ceiling still applies. Without an override the behavior is unchanged.
+   */
+  overrides?: Partial<Record<ErrorCategory, RetryCategoryOverride>>
   /** Called before each retry with diagnostic info. */
   onRetry?: (info: RetryInfo) => void
 }
@@ -128,9 +156,12 @@ export interface RetryInfo {
 /**
  * Execute `fn` with structured retry based on classified errors.
  *
- * - Calls `fn()` once, then retries up to `min(classified.maxRetries, maxTotalRetries)` times.
+ * - Calls `fn()` once, then retries up to `min(categoryMax, maxTotalRetries)` times,
+ *   where `categoryMax` is `overrides[category].maxRetries` when configured and
+ *   `classified.maxRetries` otherwise.
  * - If the classifier says `!retryable`, the error is re-thrown immediately.
- * - Delay uses `classified.retryDelayMs` when > 0, otherwise falls back to `jitteredBackoff`.
+ * - Delay uses the (possibly overridden) category delay when > 0, otherwise
+ *   falls back to `jitteredBackoff`. Both paths honour `options.backoff`.
  * - Respects `AbortSignal` — rejects with `AbortError` if aborted during a delay.
  */
 export async function withStructuredRetry<T>(
@@ -140,6 +171,7 @@ export async function withStructuredRetry<T>(
 ): Promise<T> {
   const maxTotal = options?.maxTotalRetries ?? 5
   const maxDuration = options?.maxTotalDurationMs
+  const backoff = resolveBackoff(options?.backoff)
   const startTime = maxDuration ? Date.now() : 0
 
   // attempt is 1-based and counts *retries* (not the initial call)
@@ -175,9 +207,13 @@ export async function withStructuredRetry<T>(
         throw err
       }
 
-      // The effective ceiling is the lower of the error's maxRetries and
-      // the caller's global maxTotalRetries.
-      const effectiveMax = Math.min(classified.maxRetries, maxTotal)
+      // A user override replaces the classifier's built-in cap for THIS
+      // category; the caller's global ceiling still applies on top. This is
+      // what makes `overrides.rate_limit.maxRetries = 8` effective — before,
+      // raising the provider-level `maxRetries` alone did nothing for 429
+      // because min(5, maxTotal) stayed 5.
+      const override = options?.overrides?.[classified.category]
+      const effectiveMax = Math.min(override?.maxRetries ?? classified.maxRetries, maxTotal)
 
       // +1 because `attempt` starts at 0 (the initial call is attempt 0,
       // first retry is attempt 1, etc.)
@@ -185,12 +221,13 @@ export async function withStructuredRetry<T>(
         throw err
       }
 
-      // Compute delay: prefer classifier-provided delay when present,
-      // otherwise fall back to jittered exponential backoff.
+      // Compute delay: prefer the (possibly overridden) classifier delay when
+      // present, otherwise fall back to jittered exponential backoff.
+      const baseDelayMs = override?.retryDelayMs ?? classified.retryDelayMs
       const nextDelayMs =
-        classified.retryDelayMs > 0
-          ? applyDelayJitter(classified.retryDelayMs)
-          : jitteredBackoff(attempt + 1)
+        baseDelayMs > 0
+          ? applyDelayJitter(baseDelayMs, backoff.jitterRatio)
+          : jitteredBackoff(attempt + 1, backoff.baseDelayMs, backoff.maxDelayMs, backoff.jitterRatio)
 
       // Notify caller
       options?.onRetry?.({

--- a/src/api/retry-policy.ts
+++ b/src/api/retry-policy.ts
@@ -1,0 +1,75 @@
+/**
+ * Retry Policy — runtime view of the user-facing retry knobs.
+ *
+ * `retry-engine.ts` owns the retry *loop*; `error-classifier.ts` owns the
+ * built-in per-category defaults. This module is the seam between them and the
+ * user's `config.json` (`provider.providers.<name>.retry`): it re-exports the
+ * config-schema types under names the engine can use and provides the pure
+ * resolvers that turn a partial user policy into concrete delay parameters.
+ *
+ * Design notes:
+ * - Everything is optional. An absent field (or an absent `retry` block) must
+ *   reproduce the pre-existing behavior exactly — no silent behavior change for
+ *   users who never touch this config.
+ * - `maxTotalRetries` is a hard global *ceiling*; per-category overrides raise a
+ *   category's own budget but are still clamped by the ceiling (see
+ *   `withStructuredRetry`). That preserves the historical
+ *   `min(classified.maxRetries, maxTotalRetries)` semantics while fixing the
+ *   trap where raising the provider-level `maxRetries` alone did nothing for
+ *   429 — the classifier's own cap of 5 won the `Math.min`.
+ * - The types are *derived* from `src/config/schema.ts` rather than redeclared
+ *   so the zod schema and the runtime contract cannot drift.
+ */
+
+import type { ErrorCategory } from './error-classifier.js'
+import type { RetryPolicyConfig } from '../config/schema.js'
+
+export type { RetryPolicyConfig }
+
+/** Shape of the jittered exponential backoff. */
+export type RetryBackoffConfig = NonNullable<RetryPolicyConfig['backoff']>
+/** Opt-in client-side rate limit (token bucket) for one provider. */
+export type RetryRateLimitConfig = NonNullable<RetryPolicyConfig['rateLimit']>
+/** Per-category retry budget override. */
+export type RetryCategoryOverride = NonNullable<NonNullable<RetryPolicyConfig['overrides']>[ErrorCategory]>
+
+// ---------------------------------------------------------------------------
+// Built-in defaults (must match the historical hardcoded values)
+// ---------------------------------------------------------------------------
+
+/** Historical defaults of `jitteredBackoff()`. Do not change without a
+ *  migration note — every session that never sets `retry` depends on these. */
+export const DEFAULT_RETRY_BACKOFF = {
+  baseDelayMs: 1000,
+  maxDelayMs: 30_000,
+  jitterRatio: 0.5,
+} as const
+
+export interface ResolvedBackoff {
+  baseDelayMs: number
+  maxDelayMs: number
+  jitterRatio: number
+}
+
+/**
+ * Fill in missing backoff fields with the built-in defaults.
+ *
+ * `??` (not `||`) everywhere: `jitterRatio: 0` and `baseDelayMs: 0` are legal,
+ * meaningful values (disable jitter / retry immediately) that a truthy check
+ * would silently drop — the same class of bug called out in
+ * `applyAdvancedConfig()`.
+ */
+export function resolveBackoff(backoff?: RetryBackoffConfig): ResolvedBackoff {
+  return {
+    baseDelayMs: backoff?.baseDelayMs ?? DEFAULT_RETRY_BACKOFF.baseDelayMs,
+    maxDelayMs: backoff?.maxDelayMs ?? DEFAULT_RETRY_BACKOFF.maxDelayMs,
+    jitterRatio: backoff?.jitterRatio ?? DEFAULT_RETRY_BACKOFF.jitterRatio,
+  }
+}
+
+/** True when the user asked for a client-side rate limit. */
+export function isRateLimitEnabled(
+  config?: RetryRateLimitConfig,
+): config is RetryRateLimitConfig & { requestsPerSecond: number } {
+  return typeof config?.requestsPerSecond === 'number' && config.requestsPerSecond > 0
+}

--- a/src/config/__tests__/retry-policy-schema.test.ts
+++ b/src/config/__tests__/retry-policy-schema.test.ts
@@ -1,0 +1,53 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { retryPolicySchema } from '../schema.js'
+
+// ---------------------------------------------------------------------------
+// provider.providers.<name>.retry — user-facing retry policy config surface
+// ---------------------------------------------------------------------------
+
+describe('retryPolicySchema', () => {
+  it('parses a full policy', () => {
+    const parsed = retryPolicySchema.parse({
+      maxTotalRetries: 8,
+      maxTotalDurationMs: 600_000,
+      backoff: { baseDelayMs: 250, maxDelayMs: 30_000, jitterRatio: 0.3 },
+      overrides: { rate_limit: { maxRetries: 8, retryDelayMs: 1000 } },
+      rateLimit: { requestsPerSecond: 10, burst: 20 },
+    })
+    assert.equal(parsed.maxTotalRetries, 8)
+    assert.equal(parsed.maxTotalDurationMs, 600_000)
+    assert.equal(parsed.backoff?.jitterRatio, 0.3)
+    assert.equal(parsed.overrides?.rate_limit?.maxRetries, 8)
+    assert.equal(parsed.rateLimit?.requestsPerSecond, 10)
+  })
+
+  it('accepts an empty object — every field is optional', () => {
+    const parsed = retryPolicySchema.parse({})
+    assert.deepEqual(parsed, {})
+  })
+
+  it('rejects a typo\'d category key instead of silently ignoring it', () => {
+    assert.throws(
+      () => retryPolicySchema.parse({ overrides: { rate_limt: { maxRetries: 3 } } }),
+      /Unrecognized key|rate_limt/,
+    )
+  })
+
+  it('rejects out-of-range values', () => {
+    assert.throws(() => retryPolicySchema.parse({ maxTotalRetries: 51 }))
+    assert.throws(() => retryPolicySchema.parse({ maxTotalDurationMs: -1 }))
+    assert.throws(() => retryPolicySchema.parse({ backoff: { jitterRatio: 6 } }))
+    assert.throws(() => retryPolicySchema.parse({ rateLimit: { requestsPerSecond: 0 } }))
+    assert.throws(() => retryPolicySchema.parse({ rateLimit: { burst: 0 } }))
+  })
+
+  it('accepts a zero budget (disables retries) and a zero jitter ratio', () => {
+    const parsed = retryPolicySchema.parse({
+      maxTotalRetries: 0,
+      backoff: { jitterRatio: 0 },
+    })
+    assert.equal(parsed.maxTotalRetries, 0)
+    assert.equal(parsed.backoff?.jitterRatio, 0)
+  })
+})

--- a/src/config/manager.ts
+++ b/src/config/manager.ts
@@ -1758,6 +1758,7 @@ function applyAdvancedConfig(target: ProviderConfig, advanced?: ProviderAdvanced
   if (advanced.maxRetries !== undefined) target.maxRetries = advanced.maxRetries
   if (advanced.temperature !== undefined) target.temperature = advanced.temperature
   if (advanced.proxy !== undefined) target.proxy = advanced.proxy
+  if (advanced.retry !== undefined) target.retry = advanced.retry
 }
 
 /** Persist the config first; a failed secret write must not leave a dangling keyRef. */

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -126,6 +126,72 @@ export const authConfigSchema = z.discriminatedUnion('type', [
   }),
 ])
 
+/**
+ * Per-category retry budget override (`retry.overrides.<category>`).
+ * Keys mirror `ErrorCategory` in src/api/error-classifier.ts. Declared
+ * explicitly rather than as `z.record()` so config.json gets key completion
+ * and a typo'd category is rejected instead of silently ignored.
+ */
+export const retryCategoryOverrideSchema = z.object({
+  /** Retry budget for this category. Still clamped by the global ceiling
+   *  (`retry.maxTotalRetries` / `maxRetries`). */
+  maxRetries: z.number().int().min(0).max(50).optional(),
+  /** Base delay (ms) before a retry of this category; replaces the built-in
+   *  classifier value. 0 = retry immediately (still jittered). */
+  retryDelayMs: z.number().int().min(0).max(600_000).optional(),
+})
+
+export const retryOverridesSchema = z.object({
+  rate_limit: retryCategoryOverrideSchema.optional(),
+  overloaded: retryCategoryOverrideSchema.optional(),
+  server_error: retryCategoryOverrideSchema.optional(),
+  timeout: retryCategoryOverrideSchema.optional(),
+  client_error: retryCategoryOverrideSchema.optional(),
+  context_overflow: retryCategoryOverrideSchema.optional(),
+  image_strip: retryCategoryOverrideSchema.optional(),
+  stream_parse: retryCategoryOverrideSchema.optional(),
+  reasoning_repetition: retryCategoryOverrideSchema.optional(),
+  auth_error: retryCategoryOverrideSchema.optional(),
+  unknown: retryCategoryOverrideSchema.optional(),
+})
+// Strict: a typo'd category key must fail loudly, not be stripped by zod's
+// default unknown-key handling — a silently-ignored override looks like it is
+// in effect while the built-in budget keeps winning.
+.strict()
+
+/**
+ * `provider.providers.<name>.retry` — user-level retry policy.
+ *
+ * Entirely optional: every field absent = the built-in hardcoded behavior
+ * (see src/api/retry-policy.ts), so existing configs are unaffected.
+ * Consumption points: src/api/retry-engine.ts (backoff + overrides),
+ * src/api/rate-limiter.ts (rateLimit), openai-client / anthropic-client
+ * (composition + maxTotalDurationMs).
+ */
+export const retryPolicySchema = z.object({
+  /** Hard ceiling on retries, all categories. Takes precedence over the legacy
+   *  top-level `maxRetries`. undefined = client built-in default. */
+  maxTotalRetries: z.number().int().min(0).max(50).optional(),
+  /** Ceiling on total elapsed retry time (ms). undefined = built-in per-protocol
+   *  default (10min, glm 20min). Prevents a slow provider from retrying for
+   *  tens of minutes. */
+  maxTotalDurationMs: z.number().int().positive().max(86_400_000).optional(),
+  /** Jittered exponential backoff shape. */
+  backoff: z.object({
+    baseDelayMs: z.number().int().min(0).max(600_000).optional(),
+    maxDelayMs: z.number().int().min(0).max(3_600_000).optional(),
+    /** Jitter fraction added on top of the computed delay (0 = none). */
+    jitterRatio: z.number().min(0).max(5).optional(),
+  }).optional(),
+  /** Per-category overrides. */
+  overrides: retryOverridesSchema.optional(),
+  /** Opt-in client-side token bucket. Absent / requestsPerSecond <= 0 = off. */
+  rateLimit: z.object({
+    requestsPerSecond: z.number().positive().max(1000).optional(),
+    burst: z.number().int().min(1).max(10_000).optional(),
+  }).optional(),
+})
+
 export const providerBaseSchema = z.object({
   name: z.string(),
   apiKey: z.string().nullable().optional().transform(value => value ?? undefined),
@@ -179,8 +245,16 @@ export const providerBaseSchema = z.object({
    */
   requestTimeoutMs: z.number().int().positive().optional(),
   /** Max retry attempts for retryable API errors (0 disables). undefined =
-   *  保留客户端内置默认。消费点：openai/anthropic 重试预算。 */
-  maxRetries: z.number().int().min(0).max(10).optional(),
+   *  保留客户端内置默认。消费点：openai/anthropic 重试预算。
+   *  注意：这是全局「上限」，某个 category 自带的重试次数（error-classifier）
+   *  会先与它取 min，所以单靠抬高本值无法放宽 429（rate_limit 内置 5）——
+   *  需要配合 `retry.overrides.rate_limit.maxRetries`。 */
+  maxRetries: z.number().int().min(0).max(20).optional(),
+  /**
+   * 重试策略（退避曲线 / 分类覆盖 / 客户端限速）。整块可选，缺省即保持
+   * 内置硬编码行为。详见 src/api/retry-policy.ts。
+   */
+  retry: retryPolicySchema.optional(),
   /** Provider-level sampling temperature default。思考模式下不注入（推理服务端
    *  拒绝调温 / Anthropic 要求 thinking temperature=1）；per-model 覆盖为后续波次。 */
   temperature: z.number().min(0).max(2).optional(),
@@ -994,8 +1068,9 @@ export type Config = {
 }
 
 export type ProviderConfig = z.infer<typeof providerSchema>
+export type RetryPolicyConfig = z.infer<typeof retryPolicySchema>
 /** Optional advanced knobs carried through wizard commits and drafts. */
-export type ProviderAdvancedConfig = Pick<ProviderConfig, 'requestTimeoutMs' | 'maxRetries' | 'temperature' | 'proxy'>
+export type ProviderAdvancedConfig = Pick<ProviderConfig, 'requestTimeoutMs' | 'maxRetries' | 'temperature' | 'proxy' | 'retry'>
 export type AuthConfig = z.infer<typeof authConfigSchema>
 export type ProviderCapabilitiesConfig = z.infer<typeof providerCapabilitiesSchema>
 export type ModelConfig = z.infer<typeof modelConfigSchema>


### PR DESCRIPTION
## 背景

重试策略目前是**硬编码**的：`withStructuredRetry` 只认 `maxRetries`（全局上限）+ 分类器内置的每类预算与延迟（429 最多 5 次、500/503 最多 3 次、延迟 2s/3s……），退避曲线也写死在 `jitteredBackoff` 里。这带来两个实际问题：

1. **429 无法通过配置放宽**：`maxRetries` 是全局「上限」，与分类器内置预算取 `min`。即便把 provider 级 `maxRetries` 调到 10，rate_limit 的分类器上限 5 仍然胜出——用户无法对 429 这类「服务商常见、且 Retry-After 有时很长」的错误单独加大重试次数或调整延迟。
2. **多 worker 并发时对同一配额打雷**：重试只能被动响应服务端已返回的 429。多个 subagent/team wave 同时向同一 provider 发请求时，每个请求都会吃一个 429 加一次背压，比「出发前先限速」慢得多。

## 需求

提供 `provider.providers.<name>.retry` 配置块（**整块可选，缺省即完全保持内置硬编码行为**）：

- `maxTotalRetries`：全局重试次数硬上限（覆盖旧 `maxRetries`，0 = 禁用）；
- `maxTotalDurationMs`：总重试时长上限；
- `backoff`：退避曲线（`baseDelayMs` / `maxDelayMs` / `jitterRatio`）；
- `overrides.<category>`：按错误分类覆盖重试预算与基础延迟（仍受全局上限钳制）；
- `rateLimit`：可选的客户端令牌桶限速（按 provider 分桶、FIFO 排队），请求出发前限速，防并发打雷。

## 实现中修复的两个缺陷

1. **`applyAdvancedConfig` 丢弃 `retry` 字段**：`ProviderAdvancedConfig` 类型已包含 `retry`，但 `src/config/manager.ts` 的实现只转发 `requestTimeoutMs/maxRetries/temperature/proxy`——通过 wizard/setup 高级配置路径设置的 `retry` 会被静默丢弃。已补上转发。
2. **schema 声明「拼错 category 会被拒绝」但实际静默忽略**：`retryOverridesSchema` 注释承诺拒绝拼错的分类键，但 zod `z.object` 默认对未知键是**静默剥离**——`overrides: { rate_limt: {...} }` 会被悄悄丢掉，用户以为覆盖生效、实际内置预算继续生效。已改为 `.strict()`，拼错即报错。

## 验收

- 不配置 `retry` 时，所有既有行为（含默认退避、分类预算、延迟）逐字节不变；
- `overrides.rate_limit.maxRetries: 8` 能让 429 重试 8 次（受 `maxTotalRetries` 钳制）；
- `overrides.<cat>.retryDelayMs` 替换分类器延迟；
- `backoff` 形状作用于无分类延迟的路径；
- 客户端限速按 provider 共享一个桶、FIFO 放行、可被 AbortSignal 中断；
- 拼错 category 键时配置校验报错。

实现与测试见关联 PR。
