### PR TITLE
fix(windows): 隐藏 GUI 派生的控制台子进程窗口（Fixes #103）

### DIFF
--- a/src/lsp/server-registry.ts
+++ b/src/lsp/server-registry.ts
@@ -49,6 +49,7 @@ export function defaultWhich(bin: string): boolean {
     execFileSync(process.platform === 'win32' ? 'where' : 'which', [bin], {
       stdio: ['ignore', 'ignore', 'ignore'],
       timeout: 800,
+      windowsHide: true,
     })
     return true
   } catch {

--- a/src/main.ts
+++ b/src/main.ts
@@ -819,6 +819,7 @@ async function main() {
     gitBranch = execSync('git rev-parse --abbrev-ref HEAD', {
       cwd: process.cwd(),
       stdio: ['ignore', 'pipe', 'ignore'],
+      windowsHide: true,
     }).toString().trim() || undefined
   } catch { /* 非 git 目录 */ }
 
@@ -2086,7 +2087,7 @@ async function main() {
     // --is-inside-work-tree` fails outside a repo even when git is installed.
     const gitAvailable = (() => {
       try {
-        execSync('git --version', { cwd: process.cwd(), stdio: 'pipe' })
+        execSync('git --version', { cwd: process.cwd(), stdio: 'pipe', windowsHide: true })
         return true
       } catch {
         return false

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -6,7 +6,7 @@
  * use these functions instead of platform-dependent Node.js APIs directly.
  */
 import { homedir } from 'node:os'
-import { spawnSync } from 'node:child_process'
+import { spawnSyncHidden } from './tools/spawn-hidden.js'
 import type { ChildProcess } from 'node:child_process'
 import { existsSync } from 'node:fs'
 import { win32 as winPath } from 'node:path'
@@ -161,7 +161,7 @@ export function resolveGitBashPath(deps: GitBashProbeDeps): string | null {
 /** Locate git.exe on PATH via `where` (Windows). Returns first hit or undefined. */
 function whichGitWindows(): string | undefined {
   try {
-    const result = spawnSync('where', ['git'], { stdio: ['ignore', 'pipe', 'ignore'], timeout: 3000 })
+    const result = spawnSyncHidden('where', ['git'], { stdio: ['ignore', 'pipe', 'ignore'], timeout: 3000 })
     if (result.status === 0) {
       const first = result.stdout.toString().split('\n')[0]?.trim()
       return first && first.length > 0 ? first : undefined
@@ -173,7 +173,7 @@ function whichGitWindows(): string | undefined {
 /** Locate bash.exe on PATH via `where` (Windows)。Returns first hit or undefined. */
 function whichBashWindows(): string | undefined {
   try {
-    const result = spawnSync('where', ['bash'], { stdio: ['ignore', 'pipe', 'ignore'], timeout: 3000 })
+    const result = spawnSyncHidden('where', ['bash'], { stdio: ['ignore', 'pipe', 'ignore'], timeout: 3000 })
     if (result.status === 0) {
       const first = result.stdout.toString().split('\n')[0]?.trim()
       return first && first.length > 0 ? first : undefined
@@ -258,7 +258,7 @@ export function resolveShellCommand(deps: ShellProbeDeps): ShellCommand {
 /** True if the named PowerShell executable resolves on PATH (Windows). */
 function hasPwshWindows(cmd: string): boolean {
   try {
-    const result = spawnSync('where', [cmd], { stdio: ['ignore', 'pipe', 'ignore'], timeout: 3000 })
+    const result = spawnSyncHidden('where', [cmd], { stdio: ['ignore', 'pipe', 'ignore'], timeout: 3000 })
     return result.status === 0 && result.stdout.toString().trim().length > 0
   } catch {
     return false
@@ -347,7 +347,7 @@ export function gracefulKill(child: KillableChild): void {
   if (!child.pid) return
   try {
     if (isWin) {
-      spawnSync('taskkill', ['/PID', String(child.pid)], {
+      spawnSyncHidden('taskkill', ['/PID', String(child.pid)], {
         stdio: ['ignore', 'ignore', 'ignore'],
         timeout: 5000,
       })
@@ -361,7 +361,7 @@ export function forceKill(child: KillableChild): void {
   if (!child.pid) return
   try {
     if (isWin) {
-      spawnSync('taskkill', ['/F', '/PID', String(child.pid)], {
+      spawnSyncHidden('taskkill', ['/F', '/PID', String(child.pid)], {
         stdio: ['ignore', 'ignore', 'ignore'],
         timeout: 5000,
       })
@@ -375,7 +375,7 @@ export function gracefulKillTree(child: KillableChild): void {
   if (!child.pid) return
   try {
     if (isWin) {
-      spawnSync('taskkill', ['/T', '/PID', String(child.pid)], {
+      spawnSyncHidden('taskkill', ['/T', '/PID', String(child.pid)], {
         stdio: ['ignore', 'ignore', 'ignore'],
         timeout: 5000,
       })
@@ -385,7 +385,7 @@ export function gracefulKillTree(child: KillableChild): void {
   } catch {
     try {
       if (isWin) {
-        spawnSync('taskkill', ['/F', '/T', '/PID', String(child.pid)], {
+        spawnSyncHidden('taskkill', ['/F', '/T', '/PID', String(child.pid)], {
           stdio: ['ignore', 'ignore', 'ignore'],
           timeout: 5000,
         })
@@ -400,7 +400,7 @@ export function forceKillTree(child: KillableChild): void {
   if (!child.pid) return
   try {
     if (isWin) {
-      spawnSync('taskkill', ['/F', '/T', '/PID', String(child.pid)], {
+      spawnSyncHidden('taskkill', ['/F', '/T', '/PID', String(child.pid)], {
         stdio: ['ignore', 'ignore', 'ignore'],
         timeout: 5000,
       })
@@ -410,7 +410,7 @@ export function forceKillTree(child: KillableChild): void {
   } catch {
     try {
       if (isWin) {
-        spawnSync('taskkill', ['/F', '/PID', String(child.pid)], {
+        spawnSyncHidden('taskkill', ['/F', '/PID', String(child.pid)], {
           stdio: ['ignore', 'ignore', 'ignore'],
           timeout: 5000,
         })

--- a/src/prompt/runtime-env.ts
+++ b/src/prompt/runtime-env.ts
@@ -26,7 +26,7 @@ export type VersionProbe = (command: string, args: string[]) => string | null
 
 const defaultProbe: VersionProbe = (command, args) => {
   try {
-    const r = spawnSync(command, args, { encoding: 'utf-8', timeout: 2000 })
+    const r = spawnSync(command, args, { encoding: 'utf-8', timeout: 2000, windowsHide: true })
     if (r.status !== 0) return null
     const out = `${r.stdout ?? ''}${r.stderr ?? ''}`.trim()
     return out || null

--- a/src/repo/codebase-index.ts
+++ b/src/repo/codebase-index.ts
@@ -336,7 +336,7 @@ export function fullRebuild(
 /** Get current HEAD SHA, or undefined if not in a git repo */
 export function getHeadSha(): string {
   try {
-    return execSync('git rev-parse --short HEAD', { encoding: 'utf-8', timeout: 3000 }).trim()
+    return execSync('git rev-parse --short HEAD', { encoding: 'utf-8', timeout: 3000, windowsHide: true }).trim()
   } catch {
     return ''
   }

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -288,7 +288,7 @@ function rtkExec(): typeof execFileSync {
 
 function probeRtkHealth(): RtkVerdict {
   try {
-    rtkExec()('rtk', ['--version'], { timeout: 1000, encoding: 'utf-8' })
+    rtkExec()('rtk', ['--version'], { timeout: 1000, encoding: 'utf-8', windowsHide: true })
   } catch {
     return 'missing'
   }
@@ -296,7 +296,7 @@ function probeRtkHealth(): RtkVerdict {
   try {
     dir = mkdtempSync(join(tmpdir(), 'rivet-rtk-probe-'))
     writeFileSync(join(dir, 'rivet-rtk-marker'), 'x')
-    const out = rtkExec()('rtk', ['ls', dir], { timeout: 2000, encoding: 'utf-8' })
+    const out = rtkExec()('rtk', ['ls', dir], { timeout: 2000, encoding: 'utf-8', windowsHide: true })
     return out.includes('rivet-rtk-marker') ? 'ok' : 'broken'
   } catch {
     return 'broken'
@@ -339,7 +339,7 @@ function rtkRewrite(command: string, toolUseId?: string): string {
   let result: string
   try {
     result = rtkVerdict() === 'ok'
-      ? rtkExec()('rtk', ['rewrite', command], { timeout: 500, encoding: 'utf-8' }).trim()
+      ? rtkExec()('rtk', ['rewrite', command], { timeout: 500, encoding: 'utf-8', windowsHide: true }).trim()
       : command
   } catch {
     result = command

--- a/src/tools/process-kill.ts
+++ b/src/tools/process-kill.ts
@@ -1,5 +1,5 @@
 import type { ChildProcess } from 'child_process'
-import { spawnSync } from 'node:child_process'
+import { spawnSyncHidden } from './spawn-hidden.js'
 
 type KillFn = (pid: number, signal: NodeJS.Signals) => void
 
@@ -27,7 +27,7 @@ export function killProcessTree(
       ? ['/F', '/T', '/PID', String(child.pid)]
       : ['/T', '/PID', String(child.pid)]
     try {
-      spawnSync('taskkill', args, {
+      spawnSyncHidden('taskkill', args, {
         stdio: ['ignore', 'ignore', 'ignore'],
         timeout: 5000,
       })

--- a/src/tools/resolved-env.ts
+++ b/src/tools/resolved-env.ts
@@ -276,6 +276,7 @@ function readRegistryEnvReal(scope: 'machine' | 'user'): Record<string, string> 
       stdio: ['ignore', 'pipe', 'ignore'],
       timeout: 3000,
       encoding: 'utf8',
+      windowsHide: true,
     })
     if (res.status !== 0 || typeof res.stdout !== 'string') return {}
     return parseRegQuery(res.stdout)

--- a/src/tools/team-orchestrate.ts
+++ b/src/tools/team-orchestrate.ts
@@ -161,7 +161,7 @@ function formatPlanMerge(planMerge: NonNullable<TeamRunSummary['planMerge']>): s
  *  diff-collector.ts 已踩过此坑）。非 git 目录/超时返回 null（调用方降级跳过）。 */
 function gitStatusRows(cwd: string): string[] | null {
   try {
-    const out = execFileSync('git', ['-c', 'core.quotePath=false', 'status', '--short'], { cwd, encoding: 'utf8', timeout: 3000, stdio: ['ignore', 'pipe', 'ignore'] }).toString()
+    const out = execFileSync('git', ['-c', 'core.quotePath=false', 'status', '--short'], { cwd, encoding: 'utf8', timeout: 3000, stdio: ['ignore', 'pipe', 'ignore'], windowsHide: true }).toString()
     return out.split('\n').filter(l => l.trim().length > 0)
   } catch {
     return null


### PR DESCRIPTION
## 摘要

修复 Windows 桌面端（Tauri GUI）频繁弹出又消失的黑色控制台窗口（"黑框一闪而过"）。

## 根因

GUI 子系统进程每次派生控制台子系统子进程（`taskkill` / `where` / `reg` / `git` / `rtk` 等）且未设置 `windowsHide: true` 时，Windows 会为其临时创建可见控制台窗口。bash 工具自身的主 spawn 已正确设置 `windowsHide: true`，并非闪窗来源；真正的闪窗来自大量辅助性探测 / 清理调用。

详细根因与受影响文件清单见 #103。

## 改动

- `src/tools/process-kill.ts`、`src/platform.ts`：`taskkill` / `where` 统一走 `src/tools/spawn-hidden.ts` 的 `spawnSyncHidden`（强制 `windowsHide: true`）。
- `src/tools/bash.ts`：`rtk --version` / `ls` / `rewrite` 探针补 `windowsHide: true`。
- `src/prompt/runtime-env.ts`、`src/tools/resolved-env.ts`、`src/lsp/server-registry.ts`、`src/repo/codebase-index.ts`、`src/tools/team-orchestrate.ts`、`src/main.ts`：各 `git` / `reg` 探测调用补 `windowsHide: true`。

## 验证

- `npm run typecheck`：本 PR 自身无类型错误（仓库存在一处与本次改动无关的既有 `zod-to-json-schema` 依赖类型问题，不在本 PR 范围）。
- 预期效果：Windows 桌面端不再出现一闪而过的控制台窗口。

Fixes #103
