### PR TITLE
fix(council): 议事会席位透明化实际命中模型 + v4pro 弃用标记（#105）

### DIFF
--- a/src/config/provider-presets.ts
+++ b/src/config/provider-presets.ts
@@ -77,6 +77,10 @@ export const PROVIDER_PRESETS: Record<ProviderPresetKey, ProviderPreset> = {
           // effort routing; users who need max can set it in config / Settings.
           reasoningEffort: 'high',
           tier: 'strong',
+          // 2026-09-14 下线：strong 档默认只解析到这一张 strong 卡，议事会/
+          // 路由会静默命中它——显式标弃用，命中处告警而非无提示回落。
+          deprecated: true,
+          deprecationNote: '2026-09-14 下线；strong 档默认仍指向它，建议切换 strong 档默认模型（如 GLM-5.2）。',
           pricing: { input: 3, output: 6, cacheRead: 0.025, cacheWrite: 3 },
         },
         {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -103,6 +103,11 @@ export const modelConfigSchema = z.object({
   }).optional(),
   /** Model tier for routing/fallback decisions. Overrides name-based inference. */
   tier: z.enum(['cheap', 'balanced', 'strong']).optional(),
+  /** 模型已弃用（如下线/切换为新代）：strong 档默认仍可能静默解析到它，
+   *  议事会/路由命中时应显式告警而非无提示回落。 */
+  deprecated: z.boolean().optional(),
+  /** 弃用说明（下线日期 / 替代模型），展示在告警中。 */
+  deprecationNote: z.string().optional(),
   /** Per-model capability overrides (e.g. Qwen3-max supports thinking, Qwen-plus
    *  does not). Semantic fields only — endpoint wire behavior lives at provider
    *  level. Merged on top of provider-level capabilities in `resolveCapabilities`. */

--- a/src/tools/council-convene.ts
+++ b/src/tools/council-convene.ts
@@ -5,6 +5,7 @@ import { runCouncil, runCouncilDebate, buildSeatObjective, type CouncilDeps } fr
 import { starDomainRegistry } from '../agent/star-domain-registry.js'
 import { summarizeCouncilPlan } from '../agent/council/council-render.js'
 import { encodeCouncilPanel, type CouncilPanelModel } from '../tui/council-panel-model.js'
+import { PROVIDER_PRESETS } from '../config/provider-presets.js'
 import { DEFAULT_COUNCIL_SEATS, THREE_PILLAR_COUNCIL_SEATS, mergeSeatOverrides, type CouncilSeat, type CouncilRoutingShadowEvent } from '../agent/council/council-routing.js'
 import { isCouncilEnabled } from '../agent/council/council-gate.js'
 import { buildCouncilSessionEvent, type CouncilSessionEvent } from '../agent/council/council-telemetry.js'
@@ -18,6 +19,23 @@ import { storePlan } from '../agent/plan-store.js'
 import { executePlan, type PlanExecutorDeps } from '../agent/plan-executor.js'
 import { createDelegationActivityMapper, terminalActivity } from './worker-activity-stream.js'
 import type { Tool, ToolCallParams, ToolResult } from './types.js'
+
+/** 弃用模型 → 告警说明。议事会/路由会静默命中弃用模型（如 deepseek-v4-pro——
+ *  2026-09-14 下线，且是 DeepSeek preset 唯一的 strong 卡），用于显式提示，
+ *  避免「会话默认显示 v4.1f，实际却走了 v4pro」的错觉与下线前无预警调用。 */
+const DEPRECATED_MODEL_NOTES: ReadonlyMap<string, string> = (() => {
+  const m = new Map<string, string>()
+  for (const preset of Object.values(PROVIDER_PRESETS)) {
+    for (const model of preset.provider.models) {
+      if (model.deprecated) m.set(model.id, model.deprecationNote ?? '该模型已标记弃用')
+    }
+  }
+  return m
+})()
+
+function modelDeprecation(modelId?: string): string | undefined {
+  return modelId ? DEPRECATED_MODEL_NOTES.get(modelId) : undefined
+}
 
 /** Coordinator surface the council tool needs — only `delegateBatch` drives the
  *  single-round seat fanout. Telemetry/shadow recorders are optional旁路.
@@ -344,7 +362,8 @@ export function createCouncilConveneTool(
             if (!seatId) continue
             const round = seatId.endsWith('-r2') ? 2 : 1
             const authority = seatId.replace(/(-(r2|retry|reconvene))+$/, '')
-            degradedSeats.push({ authority, status: r.status, round, modelUsed: modelMap.get(r.workOrderId) })
+            const seatModel = modelMap.get(r.workOrderId)
+            degradedSeats.push({ authority, status: r.status, round, modelUsed: seatModel, deprecated: modelDeprecation(seatModel) != null })
           }
         }
         const degradedPanel: CouncilPanelModel = {
@@ -531,7 +550,8 @@ export function createCouncilConveneTool(
           const authority = seatId.replace(/(-(r2|retry|reconvene))+$/, '')
           // merge: later batch results for same authority overwrite earlier
           const existing = councilPanelSeats.findIndex(s => s.authority === authority)
-          const seat = { authority, status: r.status, round, modelUsed: modelMap.get(r.workOrderId) }
+          const seatModel = modelMap.get(r.workOrderId)
+          const seat = { authority, status: r.status, round, modelUsed: seatModel, deprecated: modelDeprecation(seatModel) != null }
           if (existing >= 0) councilPanelSeats[existing] = seat
           else councilPanelSeats.push(seat)
         }
@@ -557,6 +577,17 @@ export function createCouncilConveneTool(
         failedSeats: plan.meta.failedSeats,
         qliphothCount: plan.meta.qliphoth?.length,
       }
+
+      // 透明化：把每个席位「实际命中的模型」摊开给用户看，避免「会话默认显示
+      // v4.1f，实际却静默走了 v4pro」的错觉。命中弃用模型额外标 ⚠ + 说明。
+      // （strong 档默认只解析到 deepseek-v4-pro 这一张 strong 卡，且 09-14 下线。）
+      const modelLines: string[] = []
+      for (const s of councilPanelSeats) {
+        const note = modelDeprecation(s.modelUsed)
+        const flag = note ? ` ⚠ 弃用模型：${note}` : ''
+        modelLines.push(`- ${s.authority}: ${s.modelUsed ?? '未知'}${flag}`)
+      }
+      parts.push('', '## 席位实际调用模型（与会话默认模型可能不同）', ...modelLines)
 
       return {
         content: parts.join('\n') + proGateNote,

--- a/src/tui/council-panel-model.ts
+++ b/src/tui/council-panel-model.ts
@@ -20,6 +20,8 @@ export interface CouncilPanelSeat {
   status: string        // running / passed / failed / escalated
   round: number         // 1 | 2（-r2 席）
   modelUsed?: string
+  /** 实际命中的模型已弃用（如下线）——桌面端/终端应显式告警。 */
+  deprecated?: boolean
 }
 
 export interface CouncilPanelModel {


### PR DESCRIPTION
## 关联 Issue

Closes #105

## 问题

议事会 strong 档席位（默认 `天府`；三柱模式 `天权`/`华盖`/`瑶光`）按 tier 路由，**静默解析**到 DeepSeek 唯一的 strong 卡 `deepseek-v4-pro`，与会话默认显示的 `v4.1f` 不一致；且该模型 **2026-09-14 下线**，下线前无预警持续被调用（用户实测 DeepSeek 后台 180+ 次 v4pro 调用）。TUI 概览条只显示会话 `defaultModel`，每席实际命中模型未摊开，造成「以为用 v4.1f 实际走 v4pro」的误诊与空转。

## 修复

- `src/config/schema.ts`：`modelConfigSchema` 增加 `deprecated` / `deprecationNote` 可选字段。
- `src/config/provider-presets.ts`：`deepseek-v4-pro` 标记 `deprecated: true` + 下线说明。
- `src/tools/council-convene.ts`：
  - 新增「席位实际调用模型」文本小节，逐席列出 `modelUsed`，命中弃用模型标 ⚠，直接解决误诊。
  - 枚举 preset 构建弃用模型→说明映射，命中处告警。
- `src/tui/council-panel-model.ts`：`CouncilPanelSeat` 增加 `deprecated?: boolean`（桌面端可据此告警）。

## 说明 / 后续

- 本 PR 只做**透明化 + 弃用标记**，不改变路由默认值。建议维护者在 `v4pro` 下线前把 DeepSeek strong 档默认切到非弃用 strong 卡（如 `GLM-5.2`），并在 `council-routing.ts` / `model-tier-policy.ts` 解析 strong 卡时对弃用卡显式告警、优先选非弃用卡。
- 类型检查：本仓库 `tsc` 仅 `src/agent/worker-session.ts` 一处既有的 `zod-to-json-schema` 导入报错（与本 PR 无关，预存问题）。本 PR 4 文件无类型错误。

🤖 Generated with WorkBuddy
