### PR TITLE
fix(browser): pin the chromium install to the embedded playwright-core version

### DIFF
--- a/src/cli/__tests__/browser-cli.test.ts
+++ b/src/cli/__tests__/browser-cli.test.ts
@@ -1,3 +1,4 @@
+import { createRequire } from 'node:module'
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import {
@@ -8,10 +9,23 @@ import {
 } from '../browser-cli.js'
 
 test('buildInstallPlan injects the CN mirror host by default', () => {
-  const plan = buildInstallPlan([], 'darwin')
+  const plan = buildInstallPlan([], 'darwin', null)
   assert.deepEqual(plan.args, ['playwright', 'install', 'chromium'])
   assert.equal(plan.env.PLAYWRIGHT_DOWNLOAD_HOST, PLAYWRIGHT_MIRROR_HOST)
   assert.equal(plan.command, 'npx')
+})
+
+test('buildInstallPlan pins playwright to the given version (#102)', () => {
+  // 就绪检测按内嵌 playwright-core 的 browsers.json 找 revision；不钉版本的 npx
+  // 会装最新 playwright 的另一个 revision，装完仍报未安装。
+  const plan = buildInstallPlan([], 'darwin', '1.62.0')
+  assert.deepEqual(plan.args, ['playwright@1.62.0', 'install', 'chromium'])
+})
+
+test('buildInstallPlan defaults to the embedded playwright-core version', () => {
+  const embedded = createRequire(import.meta.url)('playwright-core/package.json') as { version: string }
+  const plan = buildInstallPlan([], 'darwin')
+  assert.deepEqual(plan.args, [`playwright@${embedded.version}`, 'install', 'chromium'])
 })
 
 test('buildInstallPlan --no-mirror drops the mirror env (official source)', () => {

--- a/src/cli/browser-cli.ts
+++ b/src/cli/browser-cli.ts
@@ -12,6 +12,7 @@
  */
 import { spawn } from 'node:child_process'
 import { probeChromium, formatBrowserMissingBanner } from '../tools/net/browser-readiness.js'
+import { playwrightInstallSpec, resolvePlaywrightCoreVersion } from '../tools/net/playwright-driver.js'
 
 /** 国内镜像 host——与 net/playwright-driver 的 PLAYWRIGHT_INSTALL_HINT 文案同源。 */
 export const PLAYWRIGHT_MIRROR_HOST = 'https://registry.npmmirror.com/-/binary/playwright'
@@ -36,14 +37,20 @@ export interface BrowserInstallPlan {
  * 默认注入 npmmirror 镜像 host；--no-mirror 时不注入（走官方源）。
  * Windows 上 npx 是 .cmd shim，用 shell 执行以正确解析。
  */
-export function buildInstallPlan(args: readonly string[], platform: NodeJS.Platform = process.platform): BrowserInstallPlan {
+export function buildInstallPlan(
+  args: readonly string[],
+  platform: NodeJS.Platform = process.platform,
+  playwrightVersion: string | null = resolvePlaywrightCoreVersion() ?? null,
+): BrowserInstallPlan {
   const noMirror = args.includes('--no-mirror')
   const env: Record<string, string> = noMirror ? {} : { PLAYWRIGHT_DOWNLOAD_HOST: PLAYWRIGHT_MIRROR_HOST }
-  // npx playwright install chromium —— playwright-core 不含下载器，但 playwright
-  // （meta 包）的 install 子命令会下浏览器到 registry 缓存；npx 按需拉取 playwright。
+  // npx playwright@<内嵌版本> install chromium —— playwright-core 不含下载器，但
+  // playwright（meta 包）的 install 子命令会下浏览器到 registry 缓存。版本钉在
+  // 内嵌 playwright-core 上：就绪检测按它的 browsers.json 找 revision，不钉版本
+  // 时 npx 拉最新 playwright、装出别的 revision，装完仍报未安装（#102）。
   return {
     command: platform === 'win32' ? 'npx.cmd' : 'npx',
-    args: ['playwright', 'install', 'chromium'],
+    args: [playwrightInstallSpec(playwrightVersion), 'install', 'chromium'],
     env,
   }
 }

--- a/src/tools/net/__tests__/browser-readiness.test.ts
+++ b/src/tools/net/__tests__/browser-readiness.test.ts
@@ -11,7 +11,8 @@ test('browser-missing banner points to the one-shot command + manual fallback', 
   assert.match(b, /rivet browser install/)
   assert.match(b, /chromium/)
   // manual fallback carries the mirror env for CN users
-  assert.match(b, /npx playwright install chromium/)
+  // the manual command is pinned to the embedded playwright-core version (#102)
+  assert.match(b, /npx playwright(@\d+\.\d+\.\d+)? install chromium/)
 })
 
 test('module-missing banner does NOT tell the user to install a browser', () => {

--- a/src/tools/net/playwright-driver.ts
+++ b/src/tools/net/playwright-driver.ts
@@ -12,6 +12,8 @@
  * 解析 playwright-core 的类型。
  */
 
+import { createRequire } from 'node:module'
+
 /** playwright-core 模块缺失时的安装引导——区分 CLI 安装用户 / 仓库内开发 / 桌面端。 */
 export const PLAYWRIGHT_CORE_INSTALL_HINT = [
   'CLI 安装用户：npm install -g tianshu-tui（重新安装以补齐依赖），',
@@ -21,9 +23,29 @@ export const PLAYWRIGHT_CORE_INSTALL_HINT = [
 ].join('\n')
 
 /** 手动安装命令（含国内镜像 env）——banner 的兜底行复用它，避免文案漂移。 */
+/**
+ * 内嵌 playwright-core 的版本。就绪检测按这个版本的 browsers.json 推 chromium
+ * revision，所以安装也必须钉在同一版本：不带版本的 `npx playwright install`
+ * 会拉 registry 最新的 playwright，装出另一个 revision，检测永远报未安装（#102）。
+ * 模块缺失时返回 undefined（此时提示的是装 playwright-core，不是装浏览器）。
+ */
+export function resolvePlaywrightCoreVersion(): string | undefined {
+  try {
+    const pkg = createRequire(import.meta.url)('playwright-core/package.json') as { version?: unknown }
+    return typeof pkg.version === 'string' && pkg.version ? pkg.version : undefined
+  } catch {
+    return undefined
+  }
+}
+
+/** `npx` 的包 spec：能解析到内嵌版本就钉版本，否则（或显式传 null）退回裸包名。 */
+export function playwrightInstallSpec(version: string | null | undefined = resolvePlaywrightCoreVersion()): string {
+  return version ? `playwright@${version}` : 'playwright'
+}
+
 export const PLAYWRIGHT_MANUAL_INSTALL_HINT =
-  'npx playwright install chromium' +
-  '（国内网络：PLAYWRIGHT_DOWNLOAD_HOST=https://registry.npmmirror.com/-/binary/playwright npx playwright install chromium）'
+  `npx ${playwrightInstallSpec()} install chromium` +
+  `（国内网络：PLAYWRIGHT_DOWNLOAD_HOST=https://registry.npmmirror.com/-/binary/playwright npx ${playwrightInstallSpec()} install chromium）`
 
 // 两条入口都要给：只装了桌面端的用户没有 `rivet` 命令可敲，只报 CLI 命令等于把他
 // 们指向一条走不通的路。


### PR DESCRIPTION
Fixes #102

## Problem

The readiness probe (`probeChromium` in `src/tools/net/browser-readiness.ts`) asks the embedded `playwright-core` for `chromium.executablePath()`, so the expected revision comes from that package's `browsers.json` (1.62.0 → chromium-1234). The install plan (`buildInstallPlan` in `src/cli/browser-cli.ts`, also used by the desktop install route) ran an unpinned `npx playwright install chromium`; npx resolves the latest `playwright` on the registry (1.63.0 → chromium-1243). The two never meet, so the panel keeps saying "not installed" after every install, exactly as measured in the report.

## Change

`src/tools/net/playwright-driver.ts`

- `resolvePlaywrightCoreVersion()` reads the embedded `playwright-core/package.json` version (undefined when the module is missing, which is the separate "install playwright-core" case).
- `playwrightInstallSpec(version)` returns `playwright@<version>`, or the plain package name when there is no version to pin to (or `null` is passed).
- `PLAYWRIGHT_MANUAL_INSTALL_HINT` (the manual fallback shown in the missing-browser banner) uses the pinned spec too, so a user copying the command gets the matching revision.

`src/cli/browser-cli.ts`

- `buildInstallPlan(args, platform, playwrightVersion = embedded version)` builds `npx playwright@<version> install chromium`. The CLI, `rivet browser install`, and the desktop route in `src/server/browser-routes.ts` go through it and need no change of their own. The mirror env handling is untouched.

## Tests

- `buildInstallPlan` pins to a given version, defaults to the embedded `playwright-core` version, and still yields the plain `playwright` spec when explicitly unpinned.
- The banner test accepts the pinned command.

`npx tsx --test src/cli/__tests__/browser-cli.test.ts src/tools/net/__tests__/browser-readiness.test.ts`: 12 pass. `tsc --noEmit` and `oxlint` on the touched files are clean.

I could only verify the plan and the probe on macOS; the report's Windows measurements (1.62.0 embedded vs 1.63.0 from npx) are what the pin addresses.
