### PR TITLE
fix(server): sidecar 启动收割崩溃会话的 claims——硬杀后的幽灵独占锁不再永久阻断写入

### DIFF
--- a/src/server/__tests__/serve-registry-reap.test.ts
+++ b/src/server/__tests__/serve-registry-reap.test.ts
@@ -1,0 +1,67 @@
+/**
+ * R1 companion — sidecar 启动收割崩溃会话的 claims。
+ *
+ * 回归背景：sidecar 被 kill -9/断电后，独占 claims 留在 desktopDir 的
+ * registry.db 里，而 serve 启动路径从不调用 detectCrashedSessions（TUI 侧
+ * bootstrap.ts 有收割、sidecar 没有＝守卫不对称）——死会话的幽灵 claim 永久
+ * 阻断后续会话对同名文件的写入，且 owner 是死会话，用户无法自救。
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { SessionRegistry } from '../../agent/session-registry.js'
+import { initServeSessionRegistry } from '../serve.js'
+
+test('sidecar 启动收割：崩溃会话的独占 claim 不再锁死新会话写入', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'serve-reap-'))
+  try {
+    // 播种：一个已死会话（不可能存活的 pid）持有 src/index.ts 的独占 claim
+    {
+      const seed = await SessionRegistry.create(dir)
+      seed.register('sess-dead', '/project')
+      seed.updatePid('sess-dead', 99999)
+      assert.equal(seed.acquireClaim('sess-dead', 'src/index.ts', 'exclusive'), true)
+      seed.close()
+    }
+
+    const registry = await initServeSessionRegistry(dir)
+    try {
+      // 修复前：acquireClaim 恒 false——幽灵 claim 永久锁死写入
+      assert.equal(registry.acquireClaim('sess-new', 'src/index.ts', 'exclusive'), true)
+      assert.equal(registry.checkClaim('src/index.ts')?.sessionId, 'sess-new')
+      // 死会话行连同 claims 一起被清掉
+      assert.equal(registry.listActive().some((s) => s.id === 'sess-dead'), false)
+    } finally {
+      registry.close()
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('sidecar 启动收割：活会话的 claim 不受影响', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'serve-reap-alive-'))
+  try {
+    {
+      const seed = await SessionRegistry.create(dir)
+      // register 记录当前进程 pid——测试进程活着，即活会话
+      seed.register('sess-alive', '/project')
+      assert.equal(seed.acquireClaim('sess-alive', 'a.ts', 'exclusive'), true)
+      seed.close()
+    }
+
+    const registry = await initServeSessionRegistry(dir)
+    try {
+      // 活会话没被误清：claim 仍被持有，其他会话依然要排队
+      assert.equal(registry.acquireClaim('sess-other', 'a.ts', 'exclusive'), false)
+      assert.equal(registry.checkClaim('a.ts')?.sessionId, 'sess-alive')
+      assert.equal(registry.listActive().some((s) => s.id === 'sess-alive'), true)
+    } finally {
+      registry.close()
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})

--- a/src/server/serve.ts
+++ b/src/server/serve.ts
@@ -499,6 +499,23 @@ const DEFAULT_PORT = 3100
  * all in-flight work, and the RuntimeSessionManager backing the multi-session
  * API. Throws if no token is available (fail-closed).
  */
+/**
+ * Create the sidecar's shared SessionRegistry and reap crashed sessions'
+ * rows/claims first. A hard-killed sidecar leaves its exclusive claims behind
+ * in the shared desktopDir database; without this sweep every later session is
+ * permanently blocked from writing those files (the TUI does the same reap
+ * against its own stateDir database at bootstrap). No auto-resume: crashed
+ * sessions stay recoverable explicitly via `--continue` / `--resume`.
+ */
+export async function initServeSessionRegistry(registryDir: string): Promise<SessionRegistry> {
+  const registry = await SessionRegistry.create(registryDir)
+  const crashed = registry.detectCrashedSessions()
+  if (crashed.length > 0) {
+    console.error(`[serve] ↺ 已清理 ${crashed.length} 个异常退出会话的锁定`)
+  }
+  return registry
+}
+
 export async function runServe(opts: RunServeOptions = {}): Promise<RunningServer> {
   // Pro 扩展点加载（spec 3b）：桌面 sidecar 生产路径。必须在 config-routes
   // 首次查询之前完成——否则 spark 节点不可见（合并视图查不到注册项）。
@@ -522,8 +539,7 @@ export async function runServe(opts: RunServeOptions = {}): Promise<RunningServe
   // pre-built registry. Ephemeral mode (tests) skips it → behavior unchanged.
   let sessionRegistry: SessionRegistry | undefined = opts.sessionRegistry
   if (!sessionRegistry && !opts.ephemeral) {
-    const registryDir = desktopDir()
-    void SessionRegistry.create(registryDir)
+    void initServeSessionRegistry(desktopDir())
       .then((r) => { sessionRegistry = r })
       .catch((err) => {
         // Registry init failed (e.g. better-sqlite3 native build missing).


### PR DESCRIPTION

## 动机（病灶）
sidecar（桌面端宿主）被 kill -9 / 断电 / 崩溃时，它在共享 registry.db（desktopDir）里的独占 claims 和会话行不会被打扫。R2 写前守卫看到"文件被会话 X 独占"就拒绝写入——但会话 X 已经死了，永远不会有 release。后续任何会话写这些文件都会被永久阻断，且 owner 是死会话，用户无从自救（重启 sidecar 也没用，行还在库里）。
守卫不对称：TUI 侧 bootstrap.ts 启动时已调用 detectCrashedSessions() 收割自己的 stateDir 库，sidecar 的 desktopDir 库无人收割——两个库还是分库的（见 issue 线索 D-5），所以 TUI 的收割救不了 sidecar。

## 修法
- 新增导出函数 `initServeSessionRegistry(registryDir)`：create 之后先 `detectCrashedSessions()` 再交付，有清理时打一行 `[serve] ↺ 已清理 N 个异常退出会话的锁定`（与 bootstrap.ts 的 TUI 侧行为一致；不自动恢复——`--continue`/`--resume` 仍是显式入口）。
- `runServe()` 的注册表初始化改走该函数（一行替换，行为不变）。

## 不修的后果
崩溃一次 → 相关文件的独占锁永久生效 → 新会话写入被拒、错误信息指向一个已死的会话号；用户唯一解法是手删 registry.db（还会连带丢掉活会话的锁）。

## 验证
- 新增 `src/server/__tests__/serve-registry-reap.test.ts`（node:test）：①播种死会话+独占 claim → initServeSessionRegistry → 新会话 acquireClaim 成功、死行被清；②活会话 claim 不受误清。修复后 2/2 绿；还原修复 1 红（阴性对照）。
- `npx tsc --noEmit` 绿；`npm run typecheck`（守卫版）绿。

## 影响范围
仅 `runServe` 非注入注册表的启动路径（生产 sidecar）；ephemeral/测试注入路径与 CLI 单会话路径零改动。🟢 src/server/ 不在审查/保护区。
