### PR TITLE
fix(agent): R2 写前独占守卫扩到全部写工具——hash_edit/ast_edit/apply_patch/plan_close 不再绕过跨会话冲突拦截

### DIFF
--- a/src/agent/__tests__/tool-pipeline.test.ts
+++ b/src/agent/__tests__/tool-pipeline.test.ts
@@ -921,6 +921,120 @@ describe('executeToolUse', () => {
     assert.doesNotMatch((result.toolResult as any).content as string, /阻断/, 'must not be the R2 block message')
   })
 
+  it('R2: blocks hash_edit when another session holds an exclusive claim (fail-closed)', async () => {
+    let executed = false
+    const fakeRegistry = {
+      acquireClaim: (_sid: string, _path: string, _type: string) => false,
+      checkClaim: (filePath: string) => ({ sessionId: 'peer-1234abcd', claimType: 'exclusive', filePath }),
+    }
+    const deps = makeDeps({
+      sessionRegistry: fakeRegistry as any,
+      sessionId: 'mine',
+      harness: {
+        executeTool: async ({ execute }: any) => { executed = true; const r = await execute(); return { content: r.content, isError: false, retried: false } },
+      } as any,
+    })
+
+    const result = await executeToolUse(
+      { id: 'tu-hash', name: 'hash_edit', input: { file_path: 'foo.ts', anchors: [], new_string: 'x' } },
+      deps, noopCallbacks as any, 1, false,
+    )
+
+    assert.equal((result.toolResult as any).is_error, true, 'hash_edit must hit the same R2 guard as write_file')
+    assert.equal(executed, false, 'harness must NOT execute the contested hash_edit')
+    assert.match((result.toolResult as any).content as string, /另一个会话/)
+  })
+
+  it('R2: blocks apply_patch when another session claims a patch target (path parsed from diff)', async () => {
+    const claimed: string[] = []
+    let executed = false
+    const fakeRegistry = {
+      acquireClaim: (_sid: string, path: string, _type: string) => { claimed.push(path); return false },
+      checkClaim: (filePath: string) => ({ sessionId: 'peer-1234abcd', claimType: 'exclusive', filePath }),
+    }
+    const deps = makeDeps({
+      sessionRegistry: fakeRegistry as any,
+      sessionId: 'mine',
+      harness: {
+        executeTool: async ({ execute }: any) => { executed = true; const r = await execute(); return { content: r.content, isError: false, retried: false } },
+      } as any,
+    })
+
+    const diff = ['--- a/src/foo.ts', '+++ b/src/foo.ts', '@@ -1,1 +1,1 @@', '-a', '+b'].join('\n')
+    const result = await executeToolUse(
+      { id: 'tu-patch', name: 'apply_patch', input: { diff } },
+      deps, noopCallbacks as any, 1, false,
+    )
+
+    assert.deepEqual(claimed, ['src/foo.ts'], 'claim must target the path parsed from the diff header')
+    assert.equal((result.toolResult as any).is_error, true, 'contested patch target must be blocked pre-write')
+    assert.equal(executed, false, 'harness must NOT execute the contested apply_patch')
+  })
+
+  it('R2: apply_patch check_only is read-only — no claim, reaches the harness', async () => {
+    let claims = 0
+    let executed = false
+    const fakeRegistry = {
+      acquireClaim: () => { claims++; return true },
+      checkClaim: () => null,
+    }
+    const deps = makeDeps({
+      sessionRegistry: fakeRegistry as any,
+      sessionId: 'mine',
+      harness: {
+        executeTool: async ({ execute }: any) => { executed = true; const r = await execute(); return { content: r.content, isError: r.isError ?? false, retried: false } },
+      } as any,
+    })
+
+    await executeToolUse(
+      { id: 'tu-patch-check', name: 'apply_patch', input: { diff: '--- a/x.ts\n+++ b/x.ts\n', check_only: true } },
+      deps, noopCallbacks as any, 1, false,
+    )
+
+    assert.equal(claims, 0, 'check_only never writes — must not claim')
+    assert.equal(executed, true)
+  })
+
+  it('R2: blocks contested ast_edit target; plan_close without apply never claims', async () => {
+    let executed = false
+    const fakeRegistry = {
+      acquireClaim: (_sid: string, path: string, _type: string) => path !== 'src/renamed.ts',
+      checkClaim: (filePath: string) => ({ sessionId: 'peer-1234abcd', claimType: 'exclusive', filePath }),
+    }
+    const deps = makeDeps({
+      sessionRegistry: fakeRegistry as any,
+      sessionId: 'mine',
+      harness: {
+        executeTool: async ({ execute }: any) => { executed = true; const r = await execute(); return { content: r.content, isError: false, retried: false } },
+      } as any,
+    })
+
+    const blocked = await executeToolUse(
+      { id: 'tu-ast', name: 'ast_edit', input: { paths: ['src/renamed.ts'], code: 'x' } },
+      deps, noopCallbacks as any, 1, false,
+    )
+    assert.equal((blocked.toolResult as any).is_error, true, 'contested ast_edit target must be blocked pre-write')
+    assert.equal(executed, false)
+
+    let claims = 0
+    const spyRegistry = {
+      acquireClaim: () => { claims++; return true },
+      checkClaim: () => null,
+    }
+    const deps2 = makeDeps({
+      sessionRegistry: spyRegistry as any,
+      sessionId: 'mine',
+      harness: {
+        executeTool: async ({ execute }: any) => { const r = await execute(); return { content: r.content, isError: false, retried: false } },
+      } as any,
+    })
+    await executeToolUse(
+      { id: 'tu-plan', name: 'plan_close', input: { file_path: 'docs/plans/p.md' } },
+      deps2, noopCallbacks as any, 1, false,
+    )
+    assert.equal(claims, 0, 'plan_close without apply must not pre-claim')
+  })
+
   it('executes a tool and returns result', async () => {
     const deps = makeDeps()
     const result = await executeToolUse(

--- a/src/agent/tool-pipeline.ts
+++ b/src/agent/tool-pipeline.ts
@@ -99,6 +99,42 @@ export function patchTargetPaths(diff: string): string[] {
   return [...out]
 }
 
+/**
+ * Paths a tool call is about to write, in the same cwd-relative key form the
+ * post-write claim path uses. Covers every workspace-writing tool — a pre-write
+ * guard keyed to write_file/edit_file alone left hash_edit / ast_edit /
+ * apply_patch / plan_close as unguarded side doors around the peer-session
+ * exclusive claim. Read-only variants (apply_patch check_only, ast_edit dry
+ * run, plan_close without apply) never claim.
+ */
+function preWriteClaimPaths(
+  tu: { id: string; name: string; input: Record<string, unknown> },
+  cwd: string,
+): string[] {
+  const norm = (p: string): string =>
+    p.startsWith(cwd + '/') || p.startsWith(cwd + '\\') ? p.slice(cwd.length + 1) : p
+  const one = (v: unknown): string[] =>
+    typeof v === 'string' && v.length > 0 ? [norm(v)] : []
+  switch (tu.name) {
+    case 'write_file':
+    case 'edit_file':
+    case 'hash_edit':
+      return one(tu.input.file_path)
+    case 'ast_edit':
+      if (tu.input.dryRun === true || !Array.isArray(tu.input.paths)) return []
+      return tu.input.paths
+        .filter((p): p is string => typeof p === 'string' && p.length > 0)
+        .map(norm)
+    case 'apply_patch':
+      if (tu.input.check_only === true || typeof tu.input.diff !== 'string') return []
+      return patchTargetPaths(tu.input.diff).map(norm)
+    case 'plan_close':
+      return tu.input.apply === true ? one(tu.input.file_path) : []
+    default:
+      return []
+  }
+}
+
 /** Infer the workspace_mutation `kind` from a git destructive command.
  *  Used by B1 cross-session stash awareness to differentiate stash / reset / checkout / clean. */
 function gitMutationKind(cmd: string): string | undefined {
@@ -1329,32 +1365,25 @@ async function executeToolUseInner(
 
     // R2 — concurrent write conflict block (desktop multi-session). When a live
     // SessionRegistry is wired and another active session holds an exclusive
-    // claim on the target file, fail-closed: refuse the write instead of
+    // claim on a target file, fail-closed: refuse the write instead of
     // clobbering a peer session's in-flight edit. acquireClaim is idempotent for
     // the same session, so an uncontended write also stakes our claim here.
-    // Only active when a registry is present — CLI / single-session / no-registry
-    // paths are completely unaffected.
-    if (
-      deps.sessionRegistry &&
-      deps.sessionId &&
-      (tu.name === 'write_file' || tu.name === 'edit_file') &&
-      typeof tu.input.file_path === 'string'
-    ) {
-      // Normalize to the same key form the post-write claim path uses (relative
-      // to cwd when inside the workspace) so claims compare consistently.
-      let claimPath = tu.input.file_path
-      if (claimPath.startsWith(deps.cwd + '/') || claimPath.startsWith(deps.cwd + '\\')) {
-        claimPath = claimPath.slice(deps.cwd.length + 1)
-      }
-      const acquired = deps.sessionRegistry.acquireClaim(deps.sessionId, claimPath, 'exclusive')
-      if (!acquired) {
-        const owner = deps.sessionRegistry.checkClaim(claimPath)
-        const ownerTag = owner?.sessionId ? `（会话 ${owner.sessionId.slice(0, 8)}）` : ''
-        const blockMsg =
-          `文件「${claimPath}」正被另一个会话${ownerTag}独占编辑，已阻断本次写入以避免并发冲突。` +
-          `请等待对方完成，或改写其它文件。`
-        callbacks.onToolResult(tu.id, tu.name, blockMsg, true)
-        return { toolResult: { type: 'tool_result', tool_use_id: tu.id, content: blockMsg, is_error: true }, traceStore, importGraph, lastConflictCheckCount, checkpointCreated, latestRisk }
+    // Covers every workspace-writing tool via preWriteClaimPaths — a guard
+    // keyed to write_file/edit_file alone left the other four write tools as
+    // an unguarded side door. Only active when a registry is present — CLI /
+    // single-session / no-registry paths are completely unaffected.
+    if (deps.sessionRegistry && deps.sessionId) {
+      for (const claimPath of preWriteClaimPaths(tu, deps.cwd)) {
+        const acquired = deps.sessionRegistry.acquireClaim(deps.sessionId, claimPath, 'exclusive')
+        if (!acquired) {
+          const owner = deps.sessionRegistry.checkClaim(claimPath)
+          const ownerTag = owner?.sessionId ? `（会话 ${owner.sessionId.slice(0, 8)}）` : ''
+          const blockMsg =
+            `文件「${claimPath}」正被另一个会话${ownerTag}独占编辑，已阻断本次写入以避免并发冲突。` +
+            `请等待对方完成，或改写其它文件。`
+          callbacks.onToolResult(tu.id, tu.name, blockMsg, true)
+          return { toolResult: { type: 'tool_result', tool_use_id: tu.id, content: blockMsg, is_error: true }, traceStore, importGraph, lastConflictCheckCount, checkpointCreated, latestRisk }
+        }
       }
     }
 


### PR DESCRIPTION

## 动机（病灶）
R2 写前守卫（tool-pipeline.ts，desktop 多会话并发写冲突拦截）的门槛条件写死 `write_file || edit_file`。v3.x 新增的 hash_edit / ast_edit / apply_patch / plan_close 四个写工具全部从旁门进：A 会话在 B 持独占 claim 编辑同一文件期间，一条 apply_patch / hash_edit 直接落盘冲掉 B 的在途编辑——注释里"refuse the write instead of clobbering a peer session's in-flight edit"的承诺对 6 个写门中的 4 个是空话。写后账本段对 apply_patch/hash_edit 有补 stake 但①在写之后（拦不住第一次冲撞）②无视返回值③ast_edit 连补都不补。

## 修法
- 新增模块级 `preWriteClaimPaths(tu, cwd)`：把"这次调用要写哪些路径"统一归一为 cwd 相对键（与写后 claim 键同形），覆盖六个写门；只读变体不认领（apply_patch `check_only`、ast_edit `dryRun`、plan_close 无 `apply`）。
- R2 守卫改为对路径列表逐个 acquireClaim，拦截行为/文案与原 write_file/edit_file 完全一致；多文件补丁逐路径检查。
- 已知边界（注释内声明）：ast_edit 的目录级路径按原样认领，目录 claim 与文件 claim 键不交叉（claim 键cwd 相对化的问题另见 D-6 线索，不混入本 PR）。

## 不修的后果
桌面多会话场景下，"用新工具的会话"可以对"用老工具编辑中的会话"随意写入覆盖，守卫形同虚设；被覆盖方毫无感知，其 claim 还挂着（以为自己是安全的）。

## 验证
- `src/agent/__tests__/tool-pipeline.test.ts` 新增 4 条：hash_edit 被拦、apply_patch 目标从 diff 头解析并按解析路径被拦、check_only 不认领且放行、ast_edit 竞争目标被拦 + plan_close 无 apply 不认领。修复后全文件 98/98 绿（含原 2 条 R2 不回归）；还原修复 3 红（阴性对照）。
- `npx tsc --noEmit` 绿；`npm run typecheck` 绿。

## 影响范围
仅 R2 守卫的触发面扩大（多会话 registry 场景）；CLI / 单会话 / 无 registry 路径零改动；写后账本段未动。src/agent/tool-pipeline.ts 不在 🟡 名单内；既有 R2 测试全数保持绿。
