### PR TITLE
fix(tools): apply_patch 失败分支回滚 --3way 半套用并清索引毒化——失败不再留下冲突标记/暂存残留/UU 死锁

### DIFF
--- a/src/tools/__tests__/apply-patch.test.ts
+++ b/src/tools/__tests__/apply-patch.test.ts
@@ -226,4 +226,48 @@ diff --git a/gone.txt b/gone.txt
     assert.ok(lines.length <= 602, `expected truncation, got ${lines.length} lines`)
     assert.ok(result.uiContent!.includes('行 diff，Ctrl+O'))
   })
+
+  // `git apply --3way` 报冲突（exit 1）时已经半套用：干净 hunk 落盘、干净文件
+  // 被整体 staged 进索引、冲突文件留 UU 条目。工具报"失败"但磁盘是改过的——
+  // 模型按"失败=没发生"重试死循环，且 UU 索引毒化 `git checkout -- <file>`。
+  it('rolls back the half-applied tree when --3way reports a conflict', async () => {
+    writeFileSync(join(repoDir, 'a.txt'), 'base-a\n')
+    writeFileSync(join(repoDir, 'b.txt'), 'base-b\n')
+    git(repoDir, ['add', '.'])
+    git(repoDir, ['commit', '-m', 'add a b'])
+    // a.txt 本地漂移（未提交）→ 补丁以已提交内容为前置 → --3way 冲突
+    writeFileSync(join(repoDir, 'a.txt'), 'local-edit\n')
+    const diff = `diff --git a/a.txt b/a.txt
+--- a/a.txt
++++ b/a.txt
+@@ -1 +1 @@
+-base-a
++patched-a
+diff --git a/b.txt b/b.txt
+--- a/b.txt
++++ b/b.txt
+@@ -1 +1 @@
+-base-b
++patched-b
+`
+    const result = await APPLY_PATCH_TOOL.execute({
+      input: { diff },
+      toolUseId: 'toolu_test',
+      cwd: repoDir,
+    })
+
+    assert.equal(result.isError, true, 'conflicting patch must fail')
+    assert.match(result.content, /已自动回滚/)
+    // 工作树回到补丁前状态：a.txt 是用户的本地漂移内容，不是冲突标记
+    assert.equal(readFileSync(join(repoDir, 'a.txt'), 'utf-8'), 'local-edit\n')
+    // 干净文件 b.txt 不留补丁内容、不留在暂存区
+    assert.equal(readFileSync(join(repoDir, 'b.txt'), 'utf-8'), 'base-b\n')
+    const status = git(repoDir, ['status', '--porcelain']).stdout ?? ''
+    assert.ok(!status.includes('UU'), `index must not keep unmerged entries:\n${status}`)
+    assert.ok(!/^M  b\.txt$/m.test(status), `b.txt must not stay staged:\n${status}`)
+    // 标准恢复命令不再被毒化（修复前：error: path 'a.txt' is unmerged）
+    const checkout = git(repoDir, ['checkout', '--', 'a.txt'])
+    assert.equal(checkout.status, 0, `git checkout -- a.txt must work after rollback: ${checkout.stderr}`)
+    assert.equal(readFileSync(join(repoDir, 'a.txt'), 'utf-8'), 'base-a\n', 'checkout restores the committed base (drift was unstaged)')
+  })
 })

--- a/src/tools/apply-patch.ts
+++ b/src/tools/apply-patch.ts
@@ -199,8 +199,26 @@ export const APPLY_PATCH_TOOL: Tool = {
     })
 
     if (!result.ok) {
+      // `git apply --3way` reports conflicts as exit 1 AFTER partially applying:
+      // conflict markers + clean hunks are already on disk, cleanly-merged files
+      // are staged into the index, and conflicted files are left unmerged (UU).
+      // Reporting "failed" over that half-applied tree makes the model retry a
+      // patch that "never happened", and the unmerged index poisons standard
+      // recovery (`git checkout -- <file>` dies with "path is unmerged"). Roll
+      // the touched paths back to their pre-patch backups and unstage them —
+      // the same rollback the fatal-syntax path below already performs.
+      const rolledBack = targets.length > 0
+      if (rolledBack) {
+        await rollbackTargets(params.cwd, targets, params.sessionId)
+        await unstagePatchTargets(params.cwd, targets)
+      }
       for (const t of targets) incrementEditFailCount(t.abs)
-      return { content: `补丁应用失败：${result.error}`, isError: true }
+      return {
+        content: rolledBack
+          ? `补丁应用失败（半套用状态已自动回滚）：${result.error}`
+          : `补丁应用失败：${result.error}`,
+        isError: true,
+      }
     }
 
     // Post-apply structural verification: git apply --3way can leave conflict
@@ -333,6 +351,26 @@ async function rollbackTargets(cwd: string, targets: PatchTarget[], sessionId?: 
       try { await unlink(t.abs) } catch { /* already gone */ }
     }
   }
+}
+
+/** Best-effort index cleanup after a failed `git apply --3way`: the failed
+ *  apply can leave cleanly-merged targets staged and conflicted targets
+ *  unmerged (UU). `git reset -- <path>` takes index entries back to HEAD
+ *  (worktree untouched — content restore is rollbackTargets' job), un-poisoning
+ *  recovery commands like `git checkout -- <file>`. Trade-off: pre-patch staged
+ *  changes on those same paths are unstaged too — acceptable in the failure
+ *  path, where the patch itself staged the entries. No-ops outside a git
+ *  workspace (non-zero exit) — the worktree rollback already ran above. */
+async function unstagePatchTargets(cwd: string, targets: PatchTarget[]): Promise<void> {
+  if (targets.length === 0) return
+  await new Promise<void>((resolve) => {
+    const child = spawnGit(['reset', '-q', '--', ...targets.map((t) => t.rel)], {
+      cwd,
+      stdio: 'ignore',
+    })
+    child.on('close', () => resolve())
+    child.on('error', () => resolve())
+  })
 }
 
 const APPLY_PATCH_MAX_UI_LINES = 600


### PR DESCRIPTION

## 动机（病灶）
`git apply --3way` 用 exit 1 报告冲突——但退出前已经把状态改了：冲突文件的冲突标记和干净 hunk 已落盘、干净文件被整体套用并 staged 进索引、冲突文件留 UU（unmerged）索引条目。工具的失败分支只报「补丁应用失败」就返回：模型按"失败=没发生"重试同一补丁（撞 "does not exist in index" 死循环），标准恢复命令 `git checkout -- <file>` 被 UU 索引挡死（"path is unmerged"）。更糟的是注释声称失败会"roll the whole patch back"，但语法回滚守卫只在 exit 0 路径运行——而 --3way 留下半套用状态的主通道恰恰是 exit 1（注释假承诺）。

## 修法
- 失败分支（targets 非空，即 verify 默认开启时）调用既有的 `rollbackTargets()`——与语法致命错误的回滚完全同一条路（工作树恢复备份/删除新建文件）。
- 新增 `unstagePatchTargets()`：对涉及路径 `git reset -q -- <paths>`，把索引条目收回 HEAD、清掉 UU——工作树内容由 rollbackTargets 负责，索引归它。权衡已写进注释：这些路径上补丁前若有已暂存改动会一并退回（失败路径下补丁本身就在动这些条目，可接受）；非 git 工作区静默跳过。
- 失败文案区分「半套用状态已自动回滚」与原样失败（verify 关闭时 targets 为空，保持 legacy 行为不变）。

## 不修的后果
一次冲突 = 磁盘半套用 + 索引毒化 + 模型重试死循环；用户手工救场要先看懂 UU 状态。磁盘上的冲突标记还会被后续语法检查当作"已应用"的输入——错误越滚越远。

## 验证
- `src/tools/__tests__/apply-patch.test.ts` 新增端到端用例：真 git 仓、a.txt 本地漂移 + b.txt 干净，冲突补丁打两个文件 → 断言 ①报失败且带「已自动回滚」②a.txt 恢复为用户本地漂移内容（无冲突标记）③b.txt 无补丁内容、不在暂存区 ④porcelain 无 UU ⑤`git checkout -- a.txt` 可用（毒化解除）。修复后 15/15 绿；还原修复 1 红（阴性对照）。
- `npx tsc --noEmit` 绿；`npm run typecheck` 绿；oxlint 无新增告警。

## 影响范围
仅 APPLY_PATCH_TOOL 的失败分支（默认 verify 开启时生效；RIVET_APPLY_PATCH_VERIFY=0 的 legacy 关闭态行为不变）；成功路径、check_only、E4 client-delegate 路径零改动。🟢 src/tools/ 开放区。
