### PR TITLE
fix(config): config-watcher 改 watch 父目录修复首次原子写后永久失聪 + 丢弃 AgentLoop 时关闭僵尸 watcher

### DIFF
--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -538,7 +538,8 @@ export class AgentLoop {
   vigorState: VigorState = createVigorState()
   runtimeHooks: RuntimeHookPipeline
   /** P2 Wave 2: config HMR watcher（非 headless 模式装配）。persistent:false
-   *  不阻塞进程退出；AgentLoop 会话结束即随实例回收。 */
+   *  不阻塞进程退出；但不会随实例 GC 自动消失（FSWatcher 持有原生句柄），整个
+   *  AgentLoop 被丢弃时须经 stopConfigWatcher() 显式 close（switch 三路径）。 */
   configWatcher: ConfigWatcherHandle | null = null
   perception: TurnPerceptionController
   intent: TurnIntentController
@@ -2331,6 +2332,17 @@ export class AgentLoop {
   stopFsWatcher(): void {
     this.fsWatcher?.stop()
     this.latestFsWatcherState = { eventRate: 0, eventCount: 0, active: false }
+  }
+
+  /** 释放 config 热载 watcher。configWatcher 生命周期=实例（构造期装配，无
+   *  per-run start/stop），因此只能在整个 AgentLoop 被丢弃时关闭（/model、
+   *  /resume、/cd 三条 switch 路径统一纪律，与 stopFsWatcher 同源调用）——
+   *  不能并入 stopFsWatcher（那个每轮 run() 的 finally 都会跑，会把热载在
+   *  第一条用户消息后关死）。不关则旧实例的 watcher 僵尸存活，继续回调死
+   *  管线的 setDisabledHookIds。 */
+  stopConfigWatcher(): void {
+    try { this.configWatcher?.close() } catch { /* best-effort */ }
+    this.configWatcher = null
   }
 
   isRunning(): boolean {

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -1439,6 +1439,8 @@ export function switchAgentRuntime(ctx: BootstrapContext, modelId: string, targe
     const oldCoordinator = ctx.refs.coordinator
     // 旧 agent 的 fs.watch 句柄随丢弃释放（三条 switch 路径统一纪律）。
     try { ctx.agent.stopFsWatcher() } catch { /* best-effort */ }
+    // config 热载 watcher 同款释放：不关则旧实例 watcher 僵尸存活，继续回调死管线。
+    try { ctx.agent.stopConfigWatcher() } catch { /* best-effort */ }
 
     const { agent } = createAgentRuntime({
       provider,
@@ -1628,6 +1630,8 @@ export function switchAgentSession(ctx: BootstrapContext, targetId: string): Swi
   try { ctx.agent.stigmergyStore.flushSync() } catch { /* best-effort */ }
   // 旧 agent 的 fs.watch 句柄随丢弃释放（三条 switch 路径统一纪律）。
   try { ctx.agent.stopFsWatcher() } catch { /* best-effort */ }
+  // config 热载 watcher 同款释放：不关则旧实例 watcher 僵尸存活，继续回调死管线。
+  try { ctx.agent.stopConfigWatcher() } catch { /* best-effort */ }
 
   const oldId = ctx.sessionId
   // Wave K (P0 同源修复): 与 switchAgentRuntime 同源——createAgentRuntime 会
@@ -1857,6 +1861,8 @@ export async function switchAgentCwd(ctx: BootstrapContext, target: string): Pro
   }
   // 旧 agent 的 fs.watch 句柄随丢弃释放（/model、/resume 同款统一纪律）。
   try { oldAgent.stopFsWatcher() } catch { /* best-effort */ }
+  // config 热载 watcher 同款释放：不关则旧实例 watcher 僵尸存活，继续回调死管线。
+  try { oldAgent.stopConfigWatcher() } catch { /* best-effort */ }
 
   // 7. 会话归属账本：meta.cwd（跨 cwd resume 守卫读它）+ pointer + registry。
   try { newPersist.updateMetadata({ cwd: newCwd }) } catch { /* best-effort */ }

--- a/src/config/__tests__/config-watcher.test.ts
+++ b/src/config/__tests__/config-watcher.test.ts
@@ -4,6 +4,7 @@ import { mkdtempSync, writeFileSync, rmSync, existsSync, mkdirSync } from 'node:
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { watchConfigForHooks } from '../config-watcher.js'
+import { writeFileAtomicSync } from '../../fs-atomic.js'
 import { loadConfig } from '../manager.js'
 
 function sleep(ms: number): Promise<void> {
@@ -76,24 +77,28 @@ test('watchConfigForHooks: hooks.disabled 变更触发回调，无变化不回�
     // 等 watcher 就绪（kqueue 注册前的写入不触发事件）
     await sleep(200)
 
-    // 变更：写入 hooks.disabled
-    writeFileSync(t.cfgPath, withHooks(t.base, { disabled: ['dream', 'kick'] }))
+    // 变更模拟一律走 writeFileAtomicSync（生产同款：saveConfig/setHookDisabled
+    // 都经 fs-atomic 的 tmp+rename）。此前这里用 writeFileSync 原位写，恰好绕开
+    // 生产写方式，rename 换 inode 后 watcher 永久失聪的结构性盲区 CI 测不出（C2）。
+    // watch 之前的基线放置仍用 writeFileSync——watcher 只对 watch 时刻已存在的
+    // 路径生效，基线写法不参与失聪判定。
+    writeFileAtomicSync(t.cfgPath, withHooks(t.base, { disabled: ['dream', 'kick'] }))
     assert.equal(await waitFor(() => calls.length >= 1), true, '应收到一次回调')
     assert.deepEqual(calls[0], { disabled: ['dream', 'kick'] })
 
     // 无变化：相同内容再写，不应回调
     const before = calls.length
-    writeFileSync(t.cfgPath, withHooks(t.base, { disabled: ['dream', 'kick'] }))
+    writeFileAtomicSync(t.cfgPath, withHooks(t.base, { disabled: ['dream', 'kick'] }))
     await sleep(300)
     assert.equal(calls.length, before, '无变化不应回调')
 
     // 坏 JSON：fail-closed 保留旧值，不回调
-    writeFileSync(t.cfgPath, '{{{not json')
+    writeFileAtomicSync(t.cfgPath, '{{{not json')
     await sleep(300)
     assert.equal(calls.length, before, '坏 JSON 不应回调')
 
     // 恢复合法且变更：回调新值
-    writeFileSync(t.cfgPath, withHooks(t.base, { disabled: ['dream'] }))
+    writeFileAtomicSync(t.cfgPath, withHooks(t.base, { disabled: ['dream'] }))
     assert.equal(await waitFor(() => calls.length === before + 1), true, '恢复后应回调')
     assert.deepEqual(calls[calls.length - 1], { disabled: ['dream'] })
 
@@ -132,8 +137,9 @@ test('watchConfigForHooks: 生效中的 profile 文件变更触发热更（M1 �
     })
     await sleep(200) // 等 watcher 就绪
 
-    writeFileSync(profileCfg, JSON.stringify({ hooks: { disabled: ['kick', 'dream-distill'] } }))
-    assert.equal(await waitFor(() => calls.length >= 1), true, 'profile 文件变更应触发回调')
+    // 变更模拟走生产同款原子写（理由见上一测试注释）
+    writeFileAtomicSync(profileCfg, JSON.stringify({ hooks: { disabled: ['kick', 'dream-distill'] } }))
+    assert.equal(await waitFor(() => calls.length >= 1, 8000), true, 'profile 文件变更应触发回调')
     assert.deepEqual(calls[0], { disabled: ['kick', 'dream-distill'] })
     handle.close()
   } finally {
@@ -144,5 +150,39 @@ test('watchConfigForHooks: 生效中的 profile 文件变更触发热更（M1 �
     if (prevConfigPath === undefined) delete process.env.RIVET_CONFIG_PATH
     else process.env.RIVET_CONFIG_PATH = prevConfigPath
     rmSync(home, { recursive: true, force: true })
+  }
+})
+
+test('watchConfigForHooks: 首次原子写之后第二次原子写仍触发热载（rename 换 inode 不失聪，C2 回归）', async () => {
+  // 病灶回归：全仓 config 写盘走 writeFileAtomicSync（tmp+rename 原子替换），
+  // 按文件路径 watch 的 vnode 钉在 watch 时刻的旧 inode 上——第一次原子替换
+  // （往往就是 TUI 自己 setHookDisabled→saveConfig）后 watcher 永久失聪，
+  // manager.ts 的「TUI 交互会话经 config-watcher 即时热更」承诺自毁。
+  // 修复 = watch 父目录 + 文件名过滤（目录 inode 稳定）。阴性对照：stash 掉
+  // config-watcher.ts 的修复后本测试第二段断言必红。
+  const t = setup()
+  const calls: Array<{ disabled?: string[] }> = []
+  try {
+    const handle = watchConfigForHooks({
+      cwd: t.dir,
+      debounceMs: 50,
+      onHooksChange: hooks => calls.push(hooks),
+    })
+    await sleep(200) // 等 watcher 就绪
+
+    // 第一次原子写（生产同款）：触发热载
+    writeFileAtomicSync(t.cfgPath, withHooks(t.base, { disabled: ['atomic-1'] }))
+    assert.equal(await waitFor(() => calls.length >= 1, 8000), true, '第一次原子写应触发热载')
+    assert.deepEqual(calls[0], { disabled: ['atomic-1'] })
+
+    // 第二次原子写：此时目标路径下的 inode 已被第一次 rename 换掉——watch 仍须存活
+    // （修复前在 darwin kqueue / linux inotify 上都钉死旧 vnode → 此断言红）
+    writeFileAtomicSync(t.cfgPath, withHooks(t.base, { disabled: ['atomic-1', 'atomic-2'] }))
+    assert.equal(await waitFor(() => calls.length >= 2, 8000), true, '第二次原子写仍应触发热载（watcher 未失聪）')
+    assert.deepEqual(calls[calls.length - 1], { disabled: ['atomic-1', 'atomic-2'] })
+
+    handle.close()
+  } finally {
+    t.restore()
   }
 })

--- a/src/config/config-watcher.ts
+++ b/src/config/config-watcher.ts
@@ -1,4 +1,5 @@
 import { watch, existsSync, readFileSync, type FSWatcher } from 'node:fs'
+import { dirname, basename } from 'node:path'
 import { loadConfig, findProjectConfig } from './manager.js'
 import { userConfigPath } from './paths.js'
 import { resolveProfileName, profilePath } from './profile.js'
@@ -108,7 +109,25 @@ export function watchConfigForHooks(options: ConfigWatcherOptions): ConfigWatche
 
   for (const p of paths) {
     try {
-      watchers.push(watch(p, { persistent: false }, schedule))
+      // Watch 父目录而非文件本身：全仓 config 写盘走 fs-atomic 的 tmp+rename
+      // 原子替换（writeFileAtomicSync/Async），rename 会把被 watch 路径下的
+      // inode 整个换掉——kqueue/inotify 的 vnode watch 钉在旧 inode 上，第一
+      // 次（往往就是 TUI 自己的 setHookDisabled→saveConfig）原子保存后 watcher
+      // 永久失聪（nodejs/node#3428 同类问题）。目录 inode 稳定，文件被整体替
+      // 换后依然能收到事件。回调按文件名过滤：只有目标文件本身（或平台拿不到
+      // 文件名时的 null——宽松放行，宁可多跑一次有 diff 门兜底的 reload）才
+      // schedule，同目录的 *.tmp 原子写中间产物与其他无关文件不触发。
+      const dir = dirname(p)
+      const base = basename(p)
+      const w = watch(dir, { persistent: false }, (_event, filename) => {
+        if (filename === null || filename === base) schedule()
+      })
+      // 目录被删（如会话内 rm -rf 项目目录/RIVET_HOME）时部分平台会 emit
+      // 'error'；无监听器会变成 uncaughtException 打崩会话，降级为日志。
+      w.on('error', e => {
+        debugLog(`[config-watcher] watch ${dir} error: ${e instanceof Error ? e.message : String(e)}`)
+      })
+      watchers.push(w)
     } catch (e) {
       debugLog(`[config-watcher] watch ${p} failed: ${e instanceof Error ? e.message : String(e)}`)
     }


### PR DESCRIPTION
# PR-C2 fix(config): config-watcher 改 watch 父目录修复首次原子写后永久失聪 + 丢弃 AgentLoop 时关闭僵尸 watcher

## 动机（病灶）
全仓 config 写盘走 fs-atomic 的 tmp+rename 原子替换（`writeFileAtomicSync/Async`，fs-atomic.ts:11-27），rename 会把被 watch 路径下的 inode 整个换掉。config-watcher.ts 按文件路径 `watch(p, ...)`，kqueue/inotify 的 vnode 钉在 watch 时刻的旧 inode 上——第一次原子保存后 watcher 永久失聪，之后原子写、原位写全部零事件。而第一次原子保存往往就是 TUI 自己的 `setHookDisabled→saveConfig`，即用户切一次 hook 开关就把热载通道亲手关死；manager.ts:2291「TUI 交互会话中经 config-watcher 即时热更（下一轮生效）」的承诺自毁。darwin 实测事件矩阵：原子写#1 触发（+413ms），原子写#2=false、后续原位写也=false（watch 整体死，非只对 rename 死）；linux inotify 同病（上游 nodejs/node#3428 同类问题，chokidar 为此存在）。
附带病灶：loop.ts 构造期装配的 configWatcher 全文件无任何 close/teardown，/model、/resume、/cd 三条 switch 路径只按既有纪律释放 fsWatcher，旧 AgentLoop 的 config watcher 僵尸存活并继续回调死管线的 `setDisabledHookIds`。
fixture 盲区（本 PR 一并修）：config-watcher.test.ts 模拟变更全用 `writeFileSync` 原位写在既有文件上——恰好绕开生产写方式，CI 结构性测不出失聪。

## 修法
- **watch 父目录 + 文件名过滤**（config-watcher.ts）：`watch(dirname(p))`，回调里 `filename === basename(p)` 才 schedule。目录 inode 稳定，目标文件被整体替换后依然能收到事件。filename 为 null 时宽松放行（部分平台/事件拿不到文件名）——宁可多跑一次 reload，apply() 的数组 diff 门 + 坏 JSON fail-closed 门兜底，不会误回调；同目录的 `*.tmp` 原子写中间产物与其他无关文件被过滤，不触发。watcher 挂 error 监听降级为 debugLog——目录被删（会话内 `rm -rf` 项目目录/RIVET_HOME）时部分平台会 emit 'error'，无监听器会变成 uncaughtException 打崩会话。
- **teardown**：AgentLoop 新增 `stopConfigWatcher()`（close + 置 null），bootstrap 三条 switch 路径（switchAgentRuntime / switchAgentSession / switchAgentCwd）在既有的 `stopFsWatcher()` 纪律行旁边同源调用。
- **测试修正**：config-watcher.test.ts 所有变更模拟从 writeFileSync 原位写改为 `writeFileAtomicSync`（生产同款；watch 之前的基线放置仍用 writeFileSync，基线不参与失聪判定）；新增回归测试「首次原子写之后第二次原子写仍触发热载」。等待沿用既有 waitFor 轮询风格、超时放大到 8s（macOS FSEvents 延迟容忍），测试结束必关 watcher。

## 不修的后果
TUI 里第一次切 hook 开关后热载通道整体死掉，用户后续所有 hooks.disabled 变更（无论经 TUI setter 还是手编 config.json）都要重启会话才生效，且无任何报错提示；每次 /model、/resume、/cd 再泄漏一个僵尸 watcher，长会话切换场景持续累积原生句柄并回调死管线。

## 为何必须动 loop.ts（🟡 审查区说明）
configWatcher 的生命周期=AgentLoop 实例（构造期 :870 装配，无 per-run start/stop），它的关闭时机只能是「整个实例被丢弃」的时刻，这个时刻只存在于 bootstrap 三条 switch 路径。对 loop.ts 的改动仅为：新增 6 行 `stopConfigWatcher()` 方法（与相邻的 `stopFsWatcher()` 同构）+ 修正 configWatcher 字段上一条不实注释（原注释称「会话结束即随实例回收」——FSWatcher 持有原生句柄不会随 GC 消失，正是本次僵尸病灶的认知根源）。特意**没有**把 close 并入 `stopFsWatcher()`：那个方法每轮 run() 的 finally 都会跑（turn-orchestrator.ts:1497），并入会把热载在第一条用户消息后关死，造出同款失聪。

## 验证
- 新增回归测试修复后绿：`npm test src/config/__tests__/config-watcher` → **4/4 pass**（含新回归 411ms）。
- 阴性对照：`git stash push src/config/config-watcher.ts` 还原修复 → **4 tests / 2 pass / 2 fail**——红的正是两条原子写测试：①「hooks.disabled 变更触发回调…fail-closed」（writeFileSync→原子写后的首测，约 5s 超时）②新回归测试「第二次原子写仍应触发热载（watcher 未失聪）」`false !== true`（8.3s 轮询超时）；stash pop 恢复后复绿。审计复现脚本 repro-c2-watcher-atomic-rename.ts 修复前 1 RED（darwin 矩阵：atomic#1=true / atomic#2=false）。
- `npx tsc --noEmit` 绿（exit 0）；`npm run typecheck`（守卫版）绿（实跑 15.4s，exit 0）。
- `npm test src/config/__tests__` 全绿：473 tests / 472 pass / 0 fail / 1 skipped（基线 472/471/0/1，+1 即新增回归）。
- loop 相关不回归：`src/agent/__tests__/loop*` 117/117 pass；switch-agent-runtime + switch-agent-session（覆盖本 PR 接线的三条 switch 路径）14/14 pass；tui disconnect-flow 16/16 pass。
- tool-pipeline：95 pass / 3 fail——与未改动的干净基线（stash 后复跑）逐字相同，系本 worktree 环境预存问题（`.test-tmp` mkdtemp ENOENT），与本 PR 无关。
- oxlint（4 个改动文件）：0 errors；9 warnings 全部位于 loop.ts/bootstrap.ts 预存行（import 等），无一来自本次新增代码。

## 影响范围
config 热载通道（非 headless 交互会话）：watcher 的注册方式、回调过滤与实例丢弃时序；headless/serve 路径不装配 watcher 零影响；RIVET_CONFIG_WATCH=0 关闭路径零影响。行为变化仅两点：热载在任意次连续原子写后仍存活（修复目标）；watcher 对同目录无关文件事件的过滤（原按文件 watch 天然只收本文件事件，过滤后语义不变）。🟡 loop.ts 改动见上节（6 行方法+注释修正）；bootstrap.ts 为既有「三条 switch 路径统一纪律」行的同源追加（各 +2 行）。
