### PR TITLE
fix(config): saveConfig 剥掉 profile 临时层——无关设置保存不再把 profile 覆盖值烘焙进全局 config.json

### DIFF
--- a/src/config/__tests__/manager-profile-persist.test.ts
+++ b/src/config/__tests__/manager-profile-persist.test.ts
@@ -1,0 +1,126 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { loadConfig, loadPersistableConfig, setCheckpointConfig, setHookDisabled } from '../manager.js'
+import { userConfigPath } from '../paths.js'
+import { profilePath } from '../profile.js'
+
+/**
+ * C1 回归：profile 层是临时活层（profile.ts「回滚语义：删 profile 文件或换
+ * profile 即回滚（文件即配置，无状态）」），任何 setter 写盘都不得把 profile
+ * 覆盖值烘焙进全局 config.json——此前 saveConfig 把 loadConfig() 的完整合并
+ * 结果落盘，RIVET_PROFILE（--profile 注入 env）活跃期间一次无关设置保存就让
+ * profile 覆盖永久化，删/换 profile 无法回滚。读路径不受影响：getter 仍能看到
+ * profile 覆盖（saveConfig 剥层只作用于写盘内容）。
+ */
+
+/** 隔离环境：RIVET_HOME=临时目录（config.json 与 profiles/ 都落在里面），
+ *  可选写入 profile 文件；结束恢复全部环境变量并清理临时目录。 */
+function withProfileHome(
+  profileName: string | undefined,
+  profileOverlay: Record<string, unknown> | undefined,
+  fn: () => void,
+): void {
+  const home = mkdtempSync(join(tmpdir(), 'rivet-c1-profile-'))
+  const saved: Array<[string, string | undefined]> = [
+    ['RIVET_HOME', process.env.RIVET_HOME],
+    ['RIVET_PROFILE', process.env.RIVET_PROFILE],
+    ['RIVET_CONFIG_PATH', process.env.RIVET_CONFIG_PATH],
+  ]
+  process.env.RIVET_HOME = home
+  delete process.env.RIVET_CONFIG_PATH
+  if (profileName === undefined) delete process.env.RIVET_PROFILE
+  else process.env.RIVET_PROFILE = profileName
+  if (profileOverlay !== undefined) {
+    mkdirSync(join(home, 'profiles'), { recursive: true })
+    writeFileSync(profilePath(profileName!), JSON.stringify(profileOverlay))
+  }
+  try {
+    fn()
+  } finally {
+    for (const [key, val] of saved) {
+      if (val === undefined) delete process.env[key]
+      else process.env[key] = val
+    }
+    rmSync(home, { recursive: true, force: true })
+  }
+}
+
+/** 用户自定义 profile：覆盖两个与 checkpoint 无关的键（数组键 + 标量键）。 */
+const AUDIT_PROFILE = 'audit-profile'
+const AUDIT_OVERLAY = {
+  hooks: { disabled: ['audit-hook-a', 'audit-hook-b'] },
+  network: { proxy: 'http://audit-proxy:7890' },
+}
+
+test('C1: 无关 setter 写盘不得带入 profile 覆盖键；删 profile 后 setter 改动仍在且 profile 值不残留', () => {
+  withProfileHome(AUDIT_PROFILE, AUDIT_OVERLAY, () => {
+    // 前置：profile 活跃时磁盘上还没有 config.json（profile 应是「无状态」活层）
+    assert.equal(existsSync(userConfigPath()), false)
+
+    // 保存一个与 profile 覆盖键（hooks/network）毫无相关的设置
+    setCheckpointConfig({ checkpointEveryTurns: 5 })
+
+    // ① 盘上含 setter 的改动
+    const disk = JSON.parse(readFileSync(userConfigPath(), 'utf-8'))
+    assert.equal(disk.agent?.checkpointEveryTurns, 5, 'setter 的改动必须落盘')
+    // ② 盘上不含 profile 的覆盖键
+    assert.equal(disk.hooks?.disabled, undefined, 'profile 的 hooks.disabled 不得被烘焙进 config.json')
+    assert.equal(disk.network?.proxy, undefined, 'profile 的 network.proxy 不得被烘焙进 config.json')
+
+    // ③a 删 profile：setter 改动保留，profile 覆盖值不残留
+    delete process.env.RIVET_PROFILE
+    const afterRemove = loadConfig()
+    assert.equal(afterRemove.agent.checkpointEveryTurns, 5)
+    assert.equal(afterRemove.hooks.disabled, undefined)
+    assert.equal(afterRemove.network.proxy, undefined)
+
+    // ③b 换 profile（另一个无文件的 profile）：同样只留 setter 的改动
+    process.env.RIVET_PROFILE = 'another-profile'
+    const afterSwitch = loadConfig()
+    assert.equal(afterSwitch.agent.checkpointEveryTurns, 5)
+    assert.equal(afterSwitch.hooks.disabled, undefined)
+    assert.equal(afterSwitch.network.proxy, undefined)
+  })
+})
+
+test('C1: 读路径仍含 profile 层（loadConfig 可见覆盖，loadPersistableConfig 不含）', () => {
+  withProfileHome(AUDIT_PROFILE, AUDIT_OVERLAY, () => {
+    // 内存读：profile 覆盖生效
+    const effective = loadConfig()
+    assert.deepEqual(effective.hooks.disabled, ['audit-hook-a', 'audit-hook-b'])
+    assert.equal(effective.network.proxy, 'http://audit-proxy:7890')
+    // 可持久视图：defaults ⊕ user，profile 层不在其中
+    const persistable = loadPersistableConfig()
+    assert.equal(persistable.hooks.disabled, undefined)
+    assert.equal(persistable.network.proxy, undefined)
+  })
+})
+
+test('C1: 内置 lean profile 同样不被无关 setter 烘焙（审计复现脚本同款场景）', () => {
+  withProfileHome('lean', undefined, () => {
+    assert.equal(existsSync(userConfigPath()), false)
+    setCheckpointConfig({ checkpointEveryTurns: 7 })
+    const disk = JSON.parse(readFileSync(userConfigPath(), 'utf-8'))
+    assert.equal(disk.agent?.checkpointEveryTurns, 7)
+    assert.equal(disk.hooks?.disabled, undefined, 'lean 的 hooks.disabled 不得落盘')
+
+    // 摘掉 RIVET_PROFILE = 回滚（profile.ts:17 承诺的路径）：checkpoint 保留、hook 全回来
+    delete process.env.RIVET_PROFILE
+    const after = loadConfig()
+    assert.equal(after.agent.checkpointEveryTurns, 7)
+    assert.deepEqual(after.hooks.disabled, undefined)
+  })
+})
+
+test('C1 边界：setter 显式编辑 profile 拥有的键时，按写入值落盘（编辑不被还原吞掉）', () => {
+  withProfileHome('lean', undefined, () => {
+    // 生效视图含 lean 的三个 hook；显式追加禁用 kick → 写入值 ≠ overlay 贡献值 → 保留
+    const { disabled } = setHookDisabled('kick', false)
+    assert.deepEqual(disabled, ['dream-distill', 'skill-distill', 'anchor-break-scout', 'kick'])
+    const disk = JSON.parse(readFileSync(userConfigPath(), 'utf-8'))
+    assert.deepEqual(disk.hooks?.disabled, disabled, '显式编辑按生效视图持久化（守卫只还原 setter 未触碰的路径）')
+  })
+})

--- a/src/config/manager.ts
+++ b/src/config/manager.ts
@@ -314,6 +314,10 @@ export function loadConfig(options?: {
   sessionOverlay?: Record<string, unknown>
   /** 显式 profile 名（优先于 RIVET_PROFILE env）。见 profile.ts。 */
   profile?: string
+  /** 内部守卫专用：跳过 profile 层，得到可持久视图（defaults ⊕ user）。
+   *  只应经 loadPersistableConfig() 被 saveConfig 的持久化守卫消费——
+   *  对外读取一律走含 profile 层的完整合并。 */
+  skipProfileOverlay?: boolean
 }): Config {
   // Layer 1: defaults
   let base = DEFAULT_CONFIG as unknown as Record<string, unknown>
@@ -373,7 +377,9 @@ export function loadConfig(options?: {
   // Layer 3.5: profile overlay（RIVET_PROFILE env / --profile flag，见 profile.ts）。
   // 命名配置覆盖块：$RIVET_HOME/profiles/<name>.json 或内置 lean。位于 project 与
   // session overlay 之间——profile 可覆盖项目配置，session overlay 可覆盖 profile。
-  const profileOverlay = resolveProfileOverlay(resolveProfileName(options?.profile))
+  const profileOverlay = options?.skipProfileOverlay
+    ? {}
+    : resolveProfileOverlay(resolveProfileName(options?.profile))
   if (Object.keys(profileOverlay).length > 0) {
     base = deepMerge(base, profileOverlay)
   }
@@ -446,6 +452,68 @@ export function loadConfigDefault(): Config {
   return loadConfig()
 }
 
+/**
+ * 可持久视图（defaults ⊕ user，无 profile 层）。saveConfig 的写盘源以它为
+ * 基准剥掉 profile 临时层——profile 的覆盖值只活在内存读路径（C1 守卫）。
+ */
+export function loadPersistableConfig(): Config {
+  return loadConfig({ skipProfileOverlay: true })
+}
+
+function jsonDeepEqual(a: unknown, b: unknown): boolean {
+  return JSON.stringify(a) === JSON.stringify(b)
+}
+
+/**
+ * 沿 profile 覆盖块的路径，把写入对象还原为可持久层（defaults ⊕ user）现值。
+ * 只动「写入值与 overlay 贡献值不可区分」的路径（setter 本轮没碰它）；
+ * setter 显式改过的路径（写入值 ≠ overlay 值）保持写入值，编辑不被吞掉。
+ */
+function restorePersistableValues(
+  node: Record<string, unknown>,
+  overlay: Record<string, unknown>,
+  persistable: Record<string, unknown>,
+): void {
+  for (const [key, ov] of Object.entries(overlay)) {
+    if (ov !== null && typeof ov === 'object' && !Array.isArray(ov)) {
+      const child = node[key]
+      if (child === null || typeof child !== 'object' || Array.isArray(child)) continue
+      const perChild = persistable[key]
+      restorePersistableValues(
+        child as Record<string, unknown>,
+        ov as Record<string, unknown>,
+        perChild !== null && typeof perChild === 'object' && !Array.isArray(perChild)
+          ? perChild as Record<string, unknown>
+          : {},
+      )
+      // 整条路径都还原自 overlay 时容器会变空——{} 深合并等于不存在，删掉保持写盘整洁
+      if (Object.keys(child as Record<string, unknown>).length === 0) delete node[key]
+      continue
+    }
+    if (jsonDeepEqual(node[key], ov)) {
+      const per = persistable[key]
+      if (per === undefined) delete node[key]
+      else node[key] = structuredClone(per)
+    }
+  }
+}
+
+/**
+ * C1 持久化守卫：profile 层是临时活层（profile.ts「回滚语义：删 profile 文件
+ * 或换 profile 即回滚（文件即配置，无状态）」），与 sessionOverlay 的
+ * 「never persisted here」同一纪律。此前 saveConfig 把 loadConfig() 的完整
+ * 合并结果写盘——RIVET_PROFILE（--profile 注入 env）活跃期间，任何一次无关
+ * setter 都会把 profile 覆盖值永久烘焙进 config.json，此后删/换 profile 无法
+ * 回滚。写盘前在此剥掉：profile 覆盖的路径还原为可持久层现值。
+ * 读路径不受影响——getter/setter 计算仍走含 profile 的完整合并。
+ */
+function unBakeProfileOverlay(toWrite: Config): void {
+  const overlay = resolveProfileOverlay(resolveProfileName())
+  if (Object.keys(overlay).length === 0) return
+  const persistable = structuredClone(loadPersistableConfig()) as unknown as Record<string, unknown>
+  restorePersistableValues(toWrite as unknown as Record<string, unknown>, overlay, persistable)
+}
+
 export function saveConfig(config: Config): void {
   // provider.apiKey is a runtime-only materialized value. Persisted provider
   // credentials must be either keyRef or apiKeyEnv; config.json never receives
@@ -462,6 +530,7 @@ export function saveConfig(config: Config): void {
       delete (provider as unknown as { protocol?: string }).protocol
     }
   }
+
   // 墓碑保全：用户层 providers[name]=null 是「删除内置预设」的标记
   // （deepMerge null=删键，见 deepMerge）。saveConfig 整体重写用户层——不带回
   // 磁盘上既有墓碑的话，下一次任意写配置都会让被删预设从 DEFAULT_CONFIG 复活。
@@ -474,6 +543,8 @@ export function saveConfig(config: Config): void {
       }
     }
   }
+  // profile 层只活在内存——写盘内容永远是 defaults ⊕ user ⊕ setter 本轮的显式改动
+  unBakeProfileOverlay(toWrite)
   writeFileAtomicSync(configPath, JSON.stringify(toWrite, null, 2) + '\n')
 }
 


### PR DESCRIPTION
# PR-C1 fix(config): saveConfig 剥掉 profile 临时层——无关设置保存不再把 profile 覆盖值烘焙进全局 config.json

## 动机（病灶）
profile 是设计上的临时活层（profile.ts:17-19 自述「回滚语义：删 profile 文件或换 profile 即回滚（文件即配置，无状态）」），由 `RIVET_PROFILE` env（`--profile` flag 经 main.ts:171 注入）激活。但 `saveConfig`（manager.ts:445-462）写盘的内容是 `loadConfig()` 的完整合并结果，而合并链（:369-375）含 profile 层——于是 profile 活跃期间，任何一次 setter 保存（全部 ~30 个 setter 都是 `loadConfig()` → 改一个键 → `saveConfig`）都会把 profile 档案里的全部覆盖值从「临时活层」变成持久配置：此后删 profile / 换 profile 都无法回滚，用户也无从分辨 config.json 里的哪些键是哪次写入带进来的。守卫不对称：sessionOverlay 有显式「never persisted here」纪律（manager.ts:302），项目层不写盘（:365 NOTE），唯独 profile 层没有。现实触发面：`rivet --profile lean` 跑轻量模式的 TUI/sidecar 里随手改个设置 → `hooks.disabled=[dream-distill, skill-distill, anchor-break-scout]` 从此写死，回到默认 profile 后三个 hook 依然被禁。

## 修法（~40 行，src/config/manager.ts）
- `loadConfig` 新增内部选项 `skipProfileOverlay`；新增导出 `loadPersistableConfig()` = defaults ⊕ user（无 profile 层）。
- `saveConfig` 写盘前经 `unBakeProfileOverlay` 守卫：解析当前 profile 覆盖块（与 loadConfig 同源：`resolveProfileOverlay(resolveProfileName())`），沿覆盖块路径把写入对象里的值还原为可持久层（`loadPersistableConfig()`）现值；persistable 层没有的键直接删除（磁盘原本就没有）。**只还原「写入值与 overlay 贡献值不可区分」的路径**（setter 本轮没碰它）；setter 显式改过的路径（写入值 ≠ overlay 值）保持写入值，显式编辑不被吞掉。
- 读路径零改动：getter / setter 计算仍走含 profile 层的完整合并——profile 照旧只活在内存。overlay 为空（绝大多数用户）时守卫直接返回，零额外开销。

## 不修的后果
`--profile lean` 会话里随手保存任何无关设置 → lean 禁用的三个 hook 永久写进全局 config.json → 回到默认 profile 后 hook 依然被禁，且删 profile 文件、换 profile、重启都救不回来；用户只能手改 config.json，还未必知道要删哪些键。profile 的「文件即配置，无状态」契约对每个 setter 持续失效。

## 验证
- 新增 `src/config/__tests__/manager-profile-persist.test.ts`（node:test，RIVET_HOME/RIVET_PROFILE + tmpdir 隔离，4 用例）：①自定义 profile 文件（hooks.disabled + network.proxy 两覆盖键）下 `setCheckpointConfig` 写无关键 → 盘上含 setter 改动、不含 profile 覆盖键，删 profile / 换 profile 后重新 loadConfig 改动仍在且 profile 值不残留；②读路径正向：loadConfig 可见 profile 覆盖、loadPersistableConfig 不含；③内置 lean 同款场景（审计复现脚本同口径）；④边界文档化：setter 显式编辑 profile 拥有的键（setHookDisabled）时按写入值落盘。修复后 4/4 绿。
- 阴性对照：`git stash push src/config/manager.ts` 后新测试 **fail 1**（缺 loadPersistableConfig 导入即红）；行为级复现（与 repro-c1-profile-bake.ts 检查①同语义）：原码 2 红（`hooks.disabled=["dream-distill","skill-distill","anchor-break-scout"]` 被烘焙且摘 profile 后不回滚）→ pop 恢复后 2 PASS。
- 回归：`src/config/__tests__` 全套 476 tests = 475 pass / 0 fail / 1 skipped（存量环境跳过——verify-config 的「config file exists」在本机无 ~/.rivet/config.json，原码同样跳过）；`npx tsc --noEmit` 绿；`npm run typecheck` 绿。

## 影响范围
仅 `saveConfig` 的写盘内容（剥 profile 层）+ `loadConfig` 一个内部选项。所有 setter 的入参/返回值/读值行为不变；sessionOverlay / 项目层写盘语义零改动（setter 本就不带这两层）；loadConfig 的迁移写回路径（manager.ts:333-339）未触碰。已知边界（测试④钉住）：setter 显式编辑 profile 同键时按生效视图落盘，该路径上 profile 值随显式编辑一起持久化——profile 契约约束的是「无关写入不烘焙」。🟢 src/config/ 有既有测试惯例，非审查/保护区。
