### PR TITLE
fix(agent): durable claims 跨会话继承恒返回空——<id>.claims 附属文件被 listSessions 剥成伪会话且字典序恒大于真 id

### DIFF
--- a/src/agent/__tests__/session-persist.test.ts
+++ b/src/agent/__tests__/session-persist.test.ts
@@ -843,3 +843,100 @@ describe('SessionPersist — getHandoffPath', () => {
     assert.ok(existsSync(p), 'writeHandoff 与 getHandoffPath 同路径')
   })
 })
+
+describe('SessionPersist — loadPreviousDurableClaims（跨会话继承）', () => {
+  let tempDir: string
+
+  // UUID 形态 id（SESSION_ID_RE 只认 [a-zA-Z0-9_-]）。字典序刻意设计：
+  // NEWER < CURRENT < OLDER，即「时间上最近的会话」字典序反而最小——
+  // 老实现 sort().pop() 取字典序最大，必然错过它。
+  const OLDER = 'ffff0001-0000-4000-8000-000000000001'
+  const NEWER = 'bbbb0002-0000-4000-8000-000000000002'
+  const CURRENT = 'cccc0003-0000-4000-8000-000000000003'
+  const ORPHAN = 'eeee0004-0000-4000-8000-000000000004'
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'rivet-durable-claims-'))
+    process.env.RIVET_SESSION_DIR = tempDir
+    SessionPersist.invalidateListCache()
+  })
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true })
+    delete process.env.RIVET_SESSION_DIR
+    SessionPersist.invalidateListCache()
+  })
+
+  /**
+   * 按真实磁盘形态种一个会话：转录 .jsonl（write-behind 批）+ meta.json
+   * （updatedAt 由时钟参数决定，保证排序断言确定性）+ durable claims 落盘
+   * （write-behind 写链）。claims 文件本身 `<id>.claims.jsonl` 就是
+   * listSessions 剥出一层后缀后 `<id>.claims` 伪会话条目的来源。
+   */
+  async function seedSession(id: string, label: string, clockMs: number, withClaims = true): Promise<void> {
+    const now = mock.method(Date, 'now', () => clockMs)
+    try {
+      const persist = new SessionPersist(id, tempDir)
+      await persist.appendOaiWithChecksum({ role: 'user', content: `session ${label}` })
+      persist.initMetadata({ model: 'deepseek-v4' })
+      persist.updateMetadata({ title: `session ${label}` })
+      await persist.flushSessionBuffer()
+      if (!withClaims) return
+
+      const store = persist.createClaimStore()
+      const claim = store.propose({
+        kind: 'user_constraint',
+        scope: 'session',
+        text: `durable-claim-of-${label}`,
+        confidence: 0.9,
+        fitness: 5,
+        source: { actor: 'user', sessionId: id, turn: 1, eventId: `turn-1:${id}` },
+        evidence: [{ id: 'e1', kind: 'user_message', summary: label, createdAt: clockMs }],
+        createdAt: clockMs,
+        tags: [],
+      })
+      store.updateClaimStatus(claim.id, 'durable', 'seed: cross-session inheritance fixture')
+      await store.flushWrites()
+    } finally {
+      now.mock.restore()
+    }
+  }
+
+  it('伪会话条目（<id>.claims.jsonl 附属文件被 listSessions 剥成 <id>.claims）不被当成「上一个会话」——继承最近真会话的 durable claims 而非恒 []', async () => {
+    await seedSession(OLDER, 'older', 1_000)
+    await seedSession(NEWER, 'newer', 2_000)
+    await seedSession(CURRENT, 'current', 3_000)
+    // 另造一个孤儿伪条目：转录已清、claims 附属文件残留（崩溃/清理后的真实磁盘形态）
+    writeFileSync(join(getSessionDir(tempDir), `${ORPHAN}.claims.jsonl`), '')
+    SessionPersist.invalidateListCache()
+
+    const persist = new SessionPersist(CURRENT, tempDir)
+    const claims = persist.loadPreviousDurableClaims()
+
+    assert.equal(claims.length, 1, '必须继承到恰好一条 durable claim（带点伪 id 未过滤时恒返回 []）')
+    assert.equal(claims[0]!.text, 'durable-claim-of-newer', '必须是时间上最近的真会话（newer）的 claim')
+  })
+
+  it('字典序最大 ≠ 最近：上一个真会话 id 更大时也必须按 updatedAt 选最近的，而非字典序最大的旧会话', async () => {
+    // OLDER 字典序最大但时间更老、无 claims 文件；NEWER 最近、带 durable claims
+    await seedSession(OLDER, 'older', 1_000, false)
+    await seedSession(NEWER, 'newer', 2_000)
+    await seedSession(CURRENT, 'current', 3_000)
+    SessionPersist.invalidateListCache()
+
+    const persist = new SessionPersist(CURRENT, tempDir)
+    const claims = persist.loadPreviousDurableClaims()
+
+    assert.equal(claims.length, 1, '必须按 updatedAt 选中最近的 NEWER，而不是字典序最大的 OLDER')
+    assert.equal(claims[0]!.text, 'durable-claim-of-newer')
+  })
+
+  it('没有上一个真会话时返回 []（孤儿伪条目不算会话）', async () => {
+    await seedSession(CURRENT, 'current', 1_000)
+    writeFileSync(join(getSessionDir(tempDir), `${ORPHAN}.claims.jsonl`), '')
+    SessionPersist.invalidateListCache()
+
+    const persist = new SessionPersist(CURRENT, tempDir)
+    assert.deepEqual(persist.loadPreviousDurableClaims(), [])
+  })
+})

--- a/src/agent/session-persist.ts
+++ b/src/agent/session-persist.ts
@@ -571,13 +571,21 @@ export class SessionPersist {
     return new ContextClaimStore(getSessionDir(this.cwd), this.sessionId)
   }
 
-  /** Load durable claims from the most recent previous session. */
+  /**
+   * Load durable claims from the most recent previous main session.
+   *
+   * 必须走 listMainSessions（主会话名单、按 updatedAt 降序），不能 listSessions +
+   * sort().pop()，两个坑：
+   * - listSessions 对 `<id>.claims.jsonl` 附属文件只剥一层 .jsonl，产出 `<id>.claims`
+   *   伪会话条目；`.claims` 后缀按字典序恒大于裸 id → pop() 恒选中伪 id，
+   *   loadDurableClaims 找 `<伪id>.claims.jsonl` 不存在 → 继承恒返回 []（确定性恒死）。
+   * - UUID 无时序，字典序最大 ≠ 最近会话。
+   * 与 evictOldSessionsInternal 的主会话名单语义对齐（同坑它已修：worker-/带点 id 不算会话）。
+   */
   loadPreviousDurableClaims(): ContextClaim[] {
-    const sessions = SessionPersist.listSessions(this.cwd)
-    const previous = sessions
-      .filter(s => s !== this.sessionId)
-      .sort()
-      .pop()
+    const previous = SessionPersist.listMainSessions(this.cwd)
+      .map(s => s.id)
+      .find(id => id !== this.sessionId)
     if (!previous) return []
     return ContextClaimStore.loadDurableClaims(getSessionDir(this.cwd), previous)
   }


### PR DESCRIPTION
# PR-D3 fix(agent): durable claims 跨会话继承改走主会话名单+updatedAt 排序——伪会话条目不再让继承恒返回空

## 动机（病灶）
`SessionPersist.loadPreviousDurableClaims`（session-persist.ts:576-584）选「上一个会话」用的是 `SessionPersist.listSessions(cwd).filter(自身).sort().pop()`，两个 bug 叠加：

1. `listSessions`（:667-677）对 claims 附属文件 `<id>.claims.jsonl` 只剥一层 `.jsonl`，产出 `<id>.claims` 伪会话条目；`.claims` 后缀按字典序恒大于裸 id → `pop()` 恒选中伪 id → `loadDurableClaims` 去找 `<伪id>.claims.jsonl`（不存在，existsSync 守卫直接返回空）→ **继承确定性恒返回 []**。
2. 即便没有伪条目，`sort()` 取的是 max-UUID 而非注释声称的「the most recent previous session」——UUID 无时序，字典序最大可能是任意一个老会话。

同文件 `evictOldSessionsInternal`（:834-843）对同一个坑已经自己写了 `!id.startsWith('worker-') && !id.includes('.')` 过滤，并注释「带点的 id（\<id\>.claims 等）是主会话附属文件，不是会话；被误计还会被当作最老会话驱逐」——同一个坑修了一半，这里漏了。注释假承诺双重实锤：576 行「the most recent previous session」既非最近、选中的也往往不是会话。

## 修法
- 选「上一个会话」改走既有 `SessionPersist.listMainSessions(cwd)`（与驱逐代码、`--resume` 前缀解析同一份主会话名单语义：剔除 `worker-*` 子会话与带点附属伪条目，按元数据 updatedAt 降序），取第一个非当前会话 id。diff ~10 行。
- 注释改为与实现一致的诚实描述（中文，随文件近期注释风格）。

## 不修的后果
每次会话重启/回连，durable claims 继承（`injectDurableClaims`，生产入口 bootstrap.ts:2013 与 serve-agent.ts:305）都确定性拿到空列表——「上一会话的结论不重推」的记忆连续性静默失效，用户感知为「每次开新会话全忘」。且当字典序最大的条目恰好是真会话时，还会继承到任意老会话的过期 claims（7 天 TTL 门拦不住 6 天前的结论），继承方向都不对——要么空继承、要么错继承。

## 验证
- 扩展 `src/agent/__tests__/session-persist.test.ts` 新增 3 例（真 SessionPersist + 真 ContextClaimStore + 真临时目录，按真实磁盘形态种转录 .jsonl + meta.json + durable claims，时钟 mock 保证 updatedAt 排序确定性）：
  - ①两个历史会话（较旧+较近）各带 durable claims 文件 + 孤儿 `<id>.claims.jsonl` 伪条目 → 断言继承到「较近真会话」的 claim 而非 []；
  - ②上一个真会话字典序更大（时间更老、无 claims）→ 断言仍按 updatedAt 选最近的，而非字典序最大的旧会话；
  - ③没有上一个真会话（仅当前会话+孤儿伪条目）→ 返回 []。
- **阴性对照**：`git stash push src/agent/session-persist.ts` 还原修复 → 3 例中 2 红（①②：`assert.equal(claims.length, 1)` 拿到 0）→ `git stash pop` 恢复；修复在位 3/3 绿。
- 会话持久化 4 个测试文件（session-persist / -async / -codec / -listener）78/78 全绿；claim 套件（src/context/__tests__/claim*）经官方 runner（`npm run test:unit`）全绿。
- `npx tsc --noEmit` 绿；`npm run typecheck`（守卫版，78.4s）绿。

## 影响范围
仅 `loadPreviousDurableClaims` 一个方法（唯一调用方 `injectDurableClaims`）；`listSessions`、驱逐、`--resume` 解析零改动。附带语义收紧：`worker-*` 子会话不再可能被当成「上一个会话」继承其 claims——与驱逐代码及 `listMainSessions` 的既有「主会话」语义对齐（子会话 claims 本不该沿主线继承，A4 污染门的初衷即如此）。🟢 src/agent/ 不在审查/保护区。
