### PR TITLE
fix(agent): nullDb 降级桩 run() 报 changes:1——better-sqlite3 缺失时首次独占 claim 不再恒失败

### DIFF
--- a/src/agent/__tests__/session-registry.test.ts
+++ b/src/agent/__tests__/session-registry.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import { mkdtempSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
-import { SessionRegistry } from '../session-registry.js'
+import { SessionRegistry, _setBackendForTest, _resetBackendForTest } from '../session-registry.js'
 
 describe('SessionRegistry', () => {
   let dbDir: string
@@ -262,5 +262,47 @@ describe('SessionRegistry', () => {
       const claims = registry.getActiveClaims('sess-1')
       assert.equal(claims.length, 2)
     })
+  })
+})
+
+// D-2: better-sqlite3 拿不到时 nullDb 降级桩的契约。README 与源码注释承诺
+// 「退化为内存库 / All method calls succeed silently」；曾经 run() 恒报
+// changes:0 导致 acquireClaim 恒 false，R2 写前守卫把全部写入拦死并谎报
+// 「正被另一个会话独占编辑（会话 undefined）」。降级语义 = 写入照常成功、
+// 无跨会话保护，而不是写入全线瘫痪。
+describe('SessionRegistry nullDb degrade path (better-sqlite3 unavailable)', () => {
+  let degradedDir: string
+  let degraded: SessionRegistry
+
+  beforeEach(async () => {
+    _setBackendForTest('null')
+    degradedDir = mkdtempSync(join(tmpdir(), 'sr-null-test-'))
+    degraded = await SessionRegistry.create(degradedDir)
+  })
+
+  afterEach(() => {
+    degraded.close()
+    rmSync(degradedDir, { recursive: true, force: true })
+    _resetBackendForTest()
+  })
+
+  it('register succeeds on the degrade path', () => {
+    assert.doesNotThrow(() => degraded.register('sess-null', '/project'))
+  })
+
+  it('first uncontended acquireClaim returns true (was false: R2 guard blocked all writes)', () => {
+    degraded.register('sess-null', '/project')
+    assert.equal(degraded.acquireClaim('sess-null', 'src/foo.ts', 'exclusive'), true)
+  })
+
+  it('checkClaim returns null so no phantom owner is reported', () => {
+    degraded.acquireClaim('sess-null', 'src/foo.ts', 'exclusive')
+    assert.equal(degraded.checkClaim('src/foo.ts'), null)
+  })
+
+  it('releaseAllClaims does not throw', () => {
+    degraded.register('sess-null', '/project')
+    degraded.acquireClaim('sess-null', 'src/foo.ts', 'exclusive')
+    assert.doesNotThrow(() => degraded.releaseAllClaims('sess-null'))
   })
 })

--- a/src/agent/session-registry.ts
+++ b/src/agent/session-registry.ts
@@ -111,10 +111,23 @@ CREATE INDEX IF NOT EXISTS idx_fingerprints_created ON retrospect_fingerprints(c
 CREATE INDEX IF NOT EXISTS idx_fingerprints_project ON retrospect_fingerprints(project_hash);
 `
 
+// Test-only seam: force create() onto the nullDb degrade path so the fallback
+// contract can be regression-tested without uninstalling the native module
+// (same style as _setSandboxBackendForTest). Never set in production code.
+let _forceNullDbForTest = false
+export function _setBackendForTest(kind: 'null' | 'native'): void {
+  _forceNullDbForTest = kind === 'null'
+}
+export function _resetBackendForTest(): void {
+  _forceNullDbForTest = false
+}
+
 export class SessionRegistry {
   private db: any
 
   static async create(stateDir: string): Promise<SessionRegistry> {
+    // Test-only degrade-path injection; production never takes this branch.
+    if (_forceNullDbForTest) return new SessionRegistry(createNullDb())
     if (!existsSync(stateDir)) mkdirSync(stateDir, { recursive: true })
     let db: any
     try {
@@ -548,10 +561,18 @@ export class SessionRegistry {
 /**
  * Creates a no-op database proxy when better-sqlite3 is unavailable.
  * All method calls succeed silently — session features degrade gracefully.
+ *
+ * run() must report changes:1, not 0: acquireClaim() interprets changes>0 as
+ * "claim staked". Reporting 0 made the R2 pre-write guard (tool-pipeline) block
+ * EVERY write_file/edit_file with a bogus「正被另一个会话独占编辑」error — the
+ * opposite of the documented degrade contract (README + comment above).
+ * changes:1 = writes/claims succeed with no cross-session protection, which is
+ * what degrade-to-in-memory means here. get()/all() still return nothing, so
+ * checkClaim() stays null and no phantom owner is ever reported.
  */
 function createNullDb(): any {
   const noopStmt = {
-    run: () => ({ changes: 0, lastInsertRowid: 0 }),
+    run: () => ({ changes: 1, lastInsertRowid: 0 }),
     all: () => [] as any[],
     get: () => undefined,
   }


### PR DESCRIPTION
# PR-D2 fix(agent): nullDb 降级桩 run() 报 changes:1——better-sqlite3 缺失时首次独占 claim 不再恒失败，R2 守卫不再拦死全部写入

> 定级说明（如实）：桌面正常安装用户碰不到这个病灶——这是**降级路径契约违约**（README 与源码注释承诺 vs 实现相反），不是日常主路径 bug。审计 v03 D-2（=A4），09-12 node24 校准定级 P2：node24+真库下三断言不复发，触发前提=打包漏带预编译产物 / 非支持运行时 / 无构建工具链的损坏安装。

## 动机（病灶）
better-sqlite3 动态加载失败时，`SessionRegistry.create()` 走 `createNullDb()` 降级桩（session-registry.ts）。桩内 `noopStmt.run` 恒返回 `{changes: 0}`，而 `acquireClaim()` 以 `changes > 0` 判定 claim 是否占位成功 → **恒 false，连无竞争的首次独占也失败**。R2 写前守卫（tool-pipeline.ts）见 false 即拦写，用户看到「文件 X 正被另一个会话独占编辑（会话 undefined）」的谎报——守卫查 `checkClaim` 拿到的是 null，连"对方"是谁都说不出来。

这与两处承诺直接相反：
- README 手机端说明：「`better-sqlite3` 拿不到预编译时退化为内存库」；
- 源码注释：「Session history & cross-session memory will NOT persist (in-memory only, lost on exit)」「All method calls succeed silently — session features degrade gracefully」。

承诺的语义是**写入照常成功、只丢持久化与跨会话保护**；实现却是**写入全线瘫痪**。文档说的降级，代码做的是断电。

## 修法（方案 A，最小 diff，≤1 行核心改动）
- `noopStmt.run` 返回 `{changes: 1}`：`acquireClaim` 判 `changes > 0` → 无竞争首次独占返回 true；降级语义 = 单会话视角"写入成功、无跨会话保护"，与文档承诺一致。选方案 A 而非方案 B（registry 暴露 degraded 标志、acquireClaim 分支 return true）的理由：① 改动只在降级桩单点，`acquireClaim` 生产逻辑零改动、零分支；② 与桩上既有注释「All method calls succeed silently」契约完全对齐——是桩违反契约，修桩即可；③ `checkClaim` 走 `noopStmt.get` 恒 null 天然一致，不会制造幽灵 owner。
- 新增测试 seam `_setBackendForTest` / `_resetBackendForTest`（照 `_setSandboxBackendForTest` 风格）：测试可强制 `create()` 走 nullDb 路径，无需卸载 native 模块。生产路径仅新增一个布尔分支，不影响正常库。
- serve.ts:528 的显式诊断 `.catch` console.error 路径未动（那是 ESQLITE_BUNDLE_BROKEN 等硬失败的正道，本修只管"库缺失→降级"软路径的内部契约）。

## 不修的后果
打包事故/不支持运行时的用户：所有 write_file/edit_file 被守卫拦死，报错指向一个不存在的会话——模型重试死循环，用户以为项目被锁，实际库里一行 claim 都没有。降级承诺（核心对话与编码工具链完整可用）失效。

## 验证
- 新增 4 个降级路径回归测试（session-registry.test.ts，强制 nullDb）：register 成功、**无竞争 acquireClaim 首次返回 true**、checkClaim 返回 null、releaseAllClaims 不抛。修复后该文件 **33/33 绿**（29 既有真库互斥语义用例零回归 + 4 新增）。
- 阴性对照①（精确）：仅把 `changes: 1` 还原为 `0`（保留 seam）→ 新测试恰好 1 红（acquireClaim 断言），其余 32 绿；恢复后复绿 33/33。
- 阴性对照②（stash）：`git stash push src/agent/session-registry.ts` → 测试文件因缺 `_setBackendForTest` 导出整体红（SyntaxError）；`git stash pop` 恢复。
- `npx tsc --noEmit` 绿；`npm run typecheck`（守卫版）绿。
- tool-pipeline.test.ts **95/98**，与基线 e8fdf1b1 完全持平（3 红为上游存量 stall-observer/deliver_task 用例，stash 后基线同样 95/98）——R2 守卫消费方零回归。

## 影响范围
仅降级桩一行语义 + 测试 seam 与测试文件。真库路径（正常安装）行为零改动：`acquireClaim`/`checkClaim` 代码原样，真库互斥语义由既有 29 用例背书。🟢 src/agent/session-registry.ts 不在审查/保护区。
