### PR TITLE
fix(agent): 回滚成功后 journal 写失败不再把已成功的恢复误报为失败

### DIFF
--- a/src/agent/__tests__/recovery-stack.test.ts
+++ b/src/agent/__tests__/recovery-stack.test.ts
@@ -9,7 +9,6 @@ import {
   __resetEvictDebounceForTest,
 } from '../recovery-stack.js'
 import { readUnacknowledged } from '../recovery-journal.js'
-
 /** 造 N 个数字命名的备份目录（名字 = Date.now() 格式的时间戳，越早越旧）。 */
 function seedBackupDirs(backupsDir: string, count: number, startTs: number): void {
   for (let i = 0; i < count; i++) {
@@ -156,5 +155,77 @@ describe('recovery-stack', () => {
 
   after(() => {
     rmSync(cwd, { recursive: true, force: true })
+  })
+})
+
+// ── E5：journal 写失败不得把已成功的回滚报成失败（undo.ts 同纪律）──
+describe('restoreLatestBackup journal 容错（fail-open）', () => {
+  // 每用例独立临时 cwd：本组用例要把 journal 路径造成同名目录（EISDIR），
+  // 共享 cwd 会把损坏状态泄漏给后续用例。
+  const cwds: string[] = []
+  function makeCwd(): string {
+    const dir = mkdtempSync(join(tmpdir(), 'rivet-recovery-journal-'))
+    cwds.push(dir)
+    return dir
+  }
+
+  /** 把 journal 文件路径变成同名目录——appendFileSync 必抛 EISDIR（跨平台：Windows chmod 不可靠勿用）。 */
+  function breakJournal(cwd: string): void {
+    mkdirSync(join(cwd, '.rivet', 'recovery-journal.jsonl'), { recursive: true })
+  }
+
+  it('journal 写失败（EISDIR）：内存分支回滚仍返回 true 且内容已恢复', async () => {
+    const cwd = makeCwd()
+    const target = join(cwd, 'src', 'mem.ts')
+    mkdirSync(join(cwd, 'src'), { recursive: true })
+    writeFileSync(target, 'v1-good', 'utf-8')
+    await trackFileChange(cwd, { filePath: 'src/mem.ts', action: 'write', toolCallId: 'j1' })
+    writeFileSync(target, 'v2-broken', 'utf-8')
+
+    breakJournal(cwd)
+    const restored = await restoreLatestBackup(cwd, 'src/mem.ts')
+
+    assert.equal(restored, true, '文件已恢复成功，journal 写失败不得翻转返回值')
+    assert.equal(readFileSync(target, 'utf-8'), 'v1-good', '目标文件内容确实已恢复为旧版本')
+  })
+
+  it('journal 写失败（EISDIR）：磁盘分支（copyFile 兜底）同样返回 true 且内容已恢复', async () => {
+    const cwd = makeCwd()
+    const target = join(cwd, 'src', 'disk.dat')
+    mkdirSync(join(cwd, 'src'), { recursive: true })
+    const bytes = Buffer.from([0x00, 0xde, 0xad, 0xbe, 0xef, 0x00])
+    writeFileSync(target, bytes)
+    // 二进制内容退回 copyFile 旧路径（不进内存备份）→ restoreLatestBackup 走磁盘分支。
+    const rec = await trackFileChange(cwd, { filePath: 'src/disk.dat', action: 'write', toolCallId: 'j2' })
+    assert.ok(rec.backupPath)
+    writeFileSync(target, Buffer.from([0x00, 0x0b, 0xad, 0x00]))
+
+    breakJournal(cwd)
+    const restored = await restoreLatestBackup(cwd, 'src/disk.dat')
+
+    assert.equal(restored, true, '磁盘分支语义必须与内存分支一致：回滚已成功即返回 true')
+    assert.deepEqual(readFileSync(target), bytes, '目标文件字节确实已恢复为旧版本')
+  })
+
+  it('正常路径：journal 可写时行为不变——返回 true 且 recordRecovery 确实落账', async () => {
+    const cwd = makeCwd()
+    const target = join(cwd, 'src', 'normal.ts')
+    mkdirSync(join(cwd, 'src'), { recursive: true })
+    writeFileSync(target, 'normal-v1', 'utf-8')
+    await trackFileChange(cwd, { filePath: 'src/normal.ts', action: 'write', toolCallId: 'j3' })
+    writeFileSync(target, 'normal-v2-broken', 'utf-8')
+
+    const restored = await restoreLatestBackup(cwd, 'src/normal.ts')
+
+    assert.equal(restored, true)
+    assert.equal(readFileSync(target, 'utf-8'), 'normal-v1')
+    const entries = readUnacknowledged(cwd).filter(e => e.file === 'src/normal.ts')
+    assert.equal(entries.length, 1, '恢复事件必须记录进 journal')
+    assert.equal(entries[0]!.action, 'restore latest backup')
+    assert.ok(entries[0]!.ts, 'journal 条目应带时间戳')
+  })
+
+  after(() => {
+    for (const dir of cwds) rmSync(dir, { recursive: true, force: true })
   })
 })

--- a/src/agent/recovery-stack.ts
+++ b/src/agent/recovery-stack.ts
@@ -19,6 +19,7 @@
 import { readUnacknowledged, recordRecovery, type RecoveryEntry } from './recovery-journal.js'
 import { access, copyFile, mkdir, readdir, readFile, rm, writeFile } from 'node:fs/promises'
 import { join, dirname } from 'node:path'
+import { debugLog } from '../utils/debug.js'
 
 /** Lightweight record of a file mutation with a backup for undo. */
 export interface FileChangeRecord {
@@ -138,26 +139,27 @@ export async function restoreLatestBackup(cwd: string, filePath: string, session
   const key = backupKey(cwd, filePath)
   // 内存优先：覆写前捕获的旧内容直接在手里（后台磁盘落盘可能仍在途）。
   const memory = memoryBackups.get(key)
-  if (memory) {
-    try {
+  try {
+    if (memory) {
       await memory.flush // 收尾后台落盘（不依赖其结果——回滚用内存内容）
       await writeFile(join(cwd, filePath), memory.content, 'utf-8')
-      recordRecovery(cwd, { file: filePath, action: 'restore latest backup', linesLost: 0 }, sessionId)
-      return true
-    } catch {
-      return false
+    } else {
+      const backupPath = latestBackups.get(key)
+      if (!backupPath || !(await pathExists(backupPath))) return false
+      await copyFile(backupPath, join(cwd, filePath))
     }
-  }
-  const backupPath = latestBackups.get(key)
-  if (!backupPath || !(await pathExists(backupPath))) return false
-  const absPath = join(cwd, filePath)
-  try {
-    await copyFile(backupPath, absPath)
-    recordRecovery(cwd, { file: filePath, action: 'restore latest backup', linesLost: 0 }, sessionId)
-    return true
   } catch {
     return false
   }
+  // Recovery-journal 记账是 best-effort 审计副作用：journal 写失败（如 cwd 不可写）
+  // 不得把已成功的回滚伪装成失败——文件此刻已恢复，向调用方报 false 会诱发重复
+  // 编辑，把刚恢复的旧内容又盖掉（与 undo.ts 的既有纪律一致）。
+  try {
+    recordRecovery(cwd, { file: filePath, action: 'restore latest backup', linesLost: 0 }, sessionId)
+  } catch (err) {
+    debugLog('[recovery-stack] recovery-journal 写失败（回滚已成功，忽略）：', err)
+  }
+  return true
 }
 
 /**


### PR DESCRIPTION
# PR-E5 fix(agent): 回滚成功后 recovery-journal 写失败不再把已成功的恢复误报为失败

## 动机（病灶）
`restoreLatestBackup`（src/agent/recovery-stack.ts:143-160）把 journal 记账（`recordRecovery` → `appendFileSync`）和真正的恢复（内存分支 `writeFile` / 磁盘分支 `copyFile`）放在**同一个 try** 里：journal 不可写时（cwd 只读、`.rivet/recovery-journal.jsonl` 被占用等），整个 catch 落 `return false`——工具向模型/用户报告「自动回滚失败」，而文件此刻**已经恢复成功**。返回值与磁盘真实状态背离，模型收到失败信号后倾向于重试编辑，正好把刚恢复的旧内容又盖掉——审计线索（journal）不可写这个次要故障，被放大成破坏已成功回滚的主要故障。
姐妹文件 undo.ts:57-64 注释明写「a write failure must not mask an already-successful restore」并为此把 journal 写放进独立 try——同一原则在 recovery-stack 被违反。

## 修法
- `restoreLatestBackup` 重排为：恢复动作（内存 writeFile / 磁盘 copyFile，两分支共用一个 try）成功后 `return true`；`recordRecovery` 挪进收尾的独立 try，失败最多 `debugLog`，**不翻转返回值**（best-effort 审计副作用，与 undo.ts 既有纪律一致）。
- 内存/磁盘两分支语义保持一致；无行为面变化——journal 可写时输出与原先完全相同。

## 不修的后果
journal 一旦不可写，每次自动回滚都被报成失败：模型重复编辑覆盖刚恢复的内容（用户数据二次破坏）；用户被告知「回滚失败」后手动介入，实际文件却已是恢复后的状态，人机对磁盘状态的认知分叉。

## 验证
- 扩展 `src/agent/__tests__/recovery-stack.test.ts`（+3 例，node:test）：①journal 文件路径先造成同名目录（appendFileSync 必抛 EISDIR——跨平台技巧，Windows chmod 不可靠勿用）→ 内存分支回滚仍返回 true 且目标文件内容确实已恢复；②磁盘分支（二进制走 copyFile 兜底）同样断言；③正常路径 journal 可写时行为不变，`readUnacknowledged` 断言 recordRecovery 确实落账（file/action/ts）。
- 阴性对照：`git stash push src/agent/recovery-stack.ts` 后新测试 **2 红**（两条 EISDIR 用例 fail，10 中 fail 2；正常路径用例绿）→ `git stash pop` 恢复后 **10/10 绿**。
- 门禁：`npx tsc --noEmit` 绿；`npm run typecheck`（守卫版）绿；`npm test src/agent/__tests__` 全量 exit 0、0 fail（两段汇总 6687+258=6945 tests，1 skipped 为存量）。

## 影响范围
仅 `src/agent/recovery-stack.ts` 的 `restoreLatestBackup` 返回值语义（journal 写失败不再污染它）与测试文件；`trackFileChange`/备份链/淘汰逻辑零改动；undo.ts 既有 fail-open 路径不受影响。🟢 src/agent/ 不在审查/保护区。
