### PR TITLE
fix(agent): /cd 换工作区后按新 cwd 重建 FileHistory/claimStore——撤销不再静默失效、往返 /cd 不再砖化

### DIFF
--- a/src/agent/__tests__/session-cd-rebuild-stores.test.ts
+++ b/src/agent/__tests__/session-cd-rebuild-stores.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { migrateSessionFiles, rebuildStoresAfterCwdMove } from '../session-cd.js'
+import { getSessionDir, SessionPersist } from '../session-persist.js'
+import { FileHistory } from '../file-history.js'
+
+/**
+ * D-1 回归：/cd 换工作区后必须按新 cwd 重建 FileHistory/ContextClaimStore
+ * （bootstrap 的 switchAgentCwd 经 rebuildStoresAfterCwdMove 重建并同步 ctx）。
+ *
+ * 病灶链（repro-d-1-cd-filehistory-brick.ts 5/5 红，语义搬进 node:test）：
+ *  ① 复用旧 FileHistory（备份根焊死旧 cwd）→ 迁移后 rewind 读旧路径备份
+ *     ENOENT 被当「missing」静默 skip → 撤销无声丢失；
+ *  ② 新编辑 trackEdit 在旧路径 mkdir(recursive) → 旧项目会话目录原地复活
+ *     （跨项目状态脑裂）；
+ *  ③ 旧目录复活后切回旧项目，会话目录 rename 落在非空目录上 = ENOTEMPTY
+ *     → 迁移抛错 → /cd 被拒（往返 /cd 确定性砖化）。
+ */
+
+describe('rebuildStoresAfterCwdMove (/cd 后重建 fileHistory/claimStore)', () => {
+  let home: string
+  let oldCwd: string
+  let newCwd: string
+  let prevHome: string | undefined
+  let prevSessionDir: string | undefined
+
+  const sid = 'd1rebuild-sess'
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), 'rivet-cd-rebuild-'))
+    oldCwd = mkdtempSync(join(tmpdir(), 'rivet-cd-projA-'))
+    newCwd = mkdtempSync(join(tmpdir(), 'rivet-cd-projB-'))
+    prevHome = process.env.RIVET_HOME
+    prevSessionDir = process.env.RIVET_SESSION_DIR
+    process.env.RIVET_HOME = home
+    // RIVET_SESSION_DIR 会压过 slug 派生（所有 cwd 共用一个目录）——本测试
+    // 验证的正是跨 slug 迁移，必须确保它未设置。
+    delete process.env.RIVET_SESSION_DIR
+  })
+
+  afterEach(() => {
+    if (prevHome === undefined) delete process.env.RIVET_HOME
+    else process.env.RIVET_HOME = prevHome
+    if (prevSessionDir === undefined) delete process.env.RIVET_SESSION_DIR
+    else process.env.RIVET_SESSION_DIR = prevSessionDir
+    rmSync(home, { recursive: true, force: true })
+    rmSync(oldCwd, { recursive: true, force: true })
+    rmSync(newCwd, { recursive: true, force: true })
+  })
+
+  /**
+   * 复刻 bootstrap 的构造与 /cd 时序：旧项目编辑（留备份）→ 会话文件整体迁移
+   * （bootstrap 第 4 步）→ 新 persist + 容器重建（第 5 步，被测函数）。
+   */
+  async function setupSwitch(): Promise<{ fhOld: FileHistory; rebuilt: ReturnType<typeof rebuildStoresAfterCwdMove>; f1: string }> {
+    const persistOld = new SessionPersist(sid, oldCwd)
+    const fhOld = new FileHistory(persistOld.getBackupDir(), sid)
+    // /cd 前在旧项目的一次编辑（备份落在旧 slug 目录，随迁移搬走）
+    const f1 = join(oldCwd, 'src.txt')
+    writeFileSync(f1, 'v0-original\n')
+    await fhOld.trackEdit(f1, 'msg-1')
+    writeFileSync(f1, 'v1-edited-by-agent\n')
+    // /cd（bootstrap 第 4 步）：会话文件整体迁到新 slug 目录
+    migrateSessionFiles(sid, oldCwd, newCwd)
+    // /cd（bootstrap 第 5 步）：新 persist + 容器重建
+    const persistNew = new SessionPersist(sid, newCwd)
+    const rebuilt = rebuildStoresAfterCwdMove(fhOld, persistNew)
+    return { fhOld, rebuilt, f1 }
+  }
+
+  /** FileHistory 备份文件的真实落盘层：<slug>/<sid>/backups/<sid>/<hash>@vN>。 */
+  function backupFilesDir(projectCwd: string): string {
+    return join(getSessionDir(projectCwd), sid, 'backups', sid)
+  }
+
+  it('① /cd 后 rewind 恢复迁移前快照（备份随目录迁移可读，不再静默空转）', async () => {
+    const persistOld = new SessionPersist(sid, oldCwd)
+    const fhOld = new FileHistory(persistOld.getBackupDir(), sid)
+    const f = join(oldCwd, 'src.txt')
+    writeFileSync(f, 'v0-original\n')
+    await fhOld.trackEdit(f, 'msg-1')
+    writeFileSync(f, 'v1-edited-by-agent\n')
+
+    migrateSessionFiles(sid, oldCwd, newCwd)
+    const persistNew = new SessionPersist(sid, newCwd)
+    const rebuilt = rebuildStoresAfterCwdMove(fhOld, persistNew)
+
+    // 重建实例接管内存快照（tracked 名单与快照随迁）
+    assert.notEqual(rebuilt.fileHistory, fhOld)
+    assert.equal(rebuilt.fileHistory.getAllSnapshots().length, 1)
+    assert.ok(rebuilt.fileHistory.hasSnapshot('msg-1'))
+
+    // 修复语义：undo 实际恢复 v0（旧实例在此静默 skip——备份按旧路径读 ENOENT）
+    const changed = await rebuilt.fileHistory.rewind('msg-1')
+    assert.deepEqual(changed, [f])
+    assert.equal(readFileSync(f, 'utf-8'), 'v0-original\n')
+  })
+
+  it('② /cd 后新编辑的备份落在新 slug 目录，旧项目会话目录不复活', async () => {
+    const { rebuilt, f1 } = await setupSwitch()
+
+    const f2 = join(newCwd, 'new.txt')
+    writeFileSync(f2, 'brand-new-file\n')
+    await rebuilt.fileHistory.trackEdit(f2, 'msg-2')
+
+    const newBackups = backupFilesDir(newCwd)
+    assert.ok(existsSync(newBackups), '新项目会话目录应有备份落盘')
+    const backupContents = readdirSync(newBackups).map(name => readFileSync(join(newBackups, name), 'utf-8'))
+    assert.ok(backupContents.includes('v0-original\n'), '/cd 前的旧备份应随迁移落在新 slug 目录')
+    assert.ok(backupContents.includes('brand-new-file\n'), '/cd 后的新备份应落在新 slug 目录')
+
+    // 脑裂断言：旧项目会话目录不再被新编辑原地复活
+    assert.equal(existsSync(join(getSessionDir(oldCwd), sid)), false)
+    assert.equal(existsSync(f1), true, '旧项目用户文件本体不受影响')
+  })
+
+  it('③ 切回旧项目不再 ENOTEMPTY（旧目录未复活，会话目录可整体迁回）', async () => {
+    const { rebuilt } = await setupSwitch()
+    const f2 = join(newCwd, 'new.txt')
+    writeFileSync(f2, 'brand-new-file\n')
+    await rebuilt.fileHistory.trackEdit(f2, 'msg-2')
+
+    // 回程 /cd（旧病灶：幽灵目录让 rename ENOTEMPTY → 迁移抛错 → 拒绝切换）
+    const back = migrateSessionFiles(sid, newCwd, oldCwd)
+    assert.ok(back.moved.includes(`${sid}/`), '会话子目录（含 backups/）应整体迁回旧 slug')
+    const oldBackups = backupFilesDir(oldCwd)
+    const backupContents = readdirSync(oldBackups).map(name => readFileSync(join(oldBackups, name), 'utf-8'))
+    assert.ok(backupContents.includes('v0-original\n') && backupContents.includes('brand-new-file\n'),
+      '两代备份随会话完整迁回')
+  })
+
+  it('claimStore 重建：新编辑记账指向新项目目录，旧 claims 文件留守旧项目（设计语义）', async () => {
+    const persistOld = new SessionPersist(sid, oldCwd)
+    const fhOld = new FileHistory(persistOld.getBackupDir(), sid)
+    const oldStore = persistOld.createClaimStore()
+    migrateSessionFiles(sid, oldCwd, newCwd)
+    const persistNew = new SessionPersist(sid, newCwd)
+    const rebuilt = rebuildStoresAfterCwdMove(fhOld, persistNew)
+
+    assert.notEqual(rebuilt.claimStore.path, oldStore.path)
+    assert.ok(rebuilt.claimStore.path.startsWith(getSessionDir(newCwd)), '新 claimStore 记账到新 slug 目录')
+    assert.ok(oldStore.path.startsWith(getSessionDir(oldCwd)), '旧 claims 文件刻意不迁移，留守旧项目')
+  })
+})

--- a/src/agent/file-history.ts
+++ b/src/agent/file-history.ts
@@ -59,6 +59,20 @@ export class FileHistory {
     private sessionId: string,
   ) {}
 
+  /**
+   * /cd 换工作区后按新备份根重建实例（备份根焊死构造期 cwd，不能原地复用）。
+   * 备份文件已随 migrateSessionFiles 整体迁到新 slug 目录，内存快照与 tracked
+   * 名单原样随迁——新实例对接管前的全部 undo 历史仍然可读可回滚，无缝接管。
+   * 继续复用旧实例的后果：rewind 读旧路径备份 ENOENT 被当「missing」静默跳过
+   * （撤销无声丢失）、新编辑在旧项目路径 mkdir 复活旧会话目录（跨项目状态脑裂）。
+   */
+  withBackupRoot(backupDir: string): FileHistory {
+    const next = new FileHistory(backupDir, this.sessionId)
+    next.snapshots = this.snapshots
+    next.trackedFiles = this.trackedFiles
+    return next
+  }
+
   async trackEdit(filePath: string, messageId: string): Promise<void> {
     this.trackedFiles.add(filePath)
 

--- a/src/agent/session-cd.ts
+++ b/src/agent/session-cd.ts
@@ -18,6 +18,9 @@
 import { cpSync, existsSync, mkdirSync, renameSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
 import { getSessionDir } from './session-persist.js'
+import type { SessionPersist } from './session-persist.js'
+import type { FileHistory } from './file-history.js'
+import type { ContextClaimStore } from '../context/claim-store.js'
 
 /** Flat files that make up a session's on-disk state (claims excluded, see above). */
 const SESSION_FLAT_FILES = ['.jsonl', '.meta.json', '.memory.json', '.handoff.md', '.goal.json', '.frozen.json'] as const
@@ -68,4 +71,31 @@ export function migrateSessionFiles(sessionId: string, oldCwd: string, newCwd: s
     result.moved.push(`${sessionId}/`)
   }
   return result
+}
+
+/** rebuildStoresAfterCwdMove 的返回值：随会话迁到新 cwd 的两个内存状态容器。 */
+export interface RebuiltCwdStores {
+  fileHistory: FileHistory
+  claimStore: ContextClaimStore
+}
+
+/**
+ * /cd 换工作区后按新 cwd 重建 cwd 绑定的内存状态容器（switchAgentCwd 专用，
+ * 与 migrateSessionFiles 配对——文件搬过去，容器也要跟过去）。
+ *
+ * - FileHistory：备份根焊死构造期 cwd（persist.getBackupDir()）。复用旧实例的
+ *   后果：undo/rewind 读旧路径备份 ENOENT 被当「missing」静默跳过（撤销无声
+ *   丢失）、新编辑在旧项目路径 mkdir 复活旧会话目录（跨项目状态脑裂），旧目录
+ *   搬不空更让回程 /cd 的目录 rename ENOTEMPTY 确定性砖化。备份文件已随上面
+ *   的迁移整体落到新 slug 目录，按新备份根重建即无缝接管（内存快照随迁）。
+ * - ContextClaimStore：镜像原始构造点（bootstrap 的 persist.createClaimStore()），
+ *   新编辑的 claim 从此记账到新项目目录。claims 文件刻意不迁移（见本模块头部
+ *   说明），旧项目的在途 claim 留守旧目录、随会话删除回收——与「从新 cwd 重启
+ *   后重建空账本」的既定语义一致。
+ */
+export function rebuildStoresAfterCwdMove(prevFileHistory: FileHistory, newPersist: SessionPersist): RebuiltCwdStores {
+  return {
+    fileHistory: prevFileHistory.withBackupRoot(newPersist.getBackupDir()),
+    claimStore: newPersist.createClaimStore(),
+  }
 }

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -34,7 +34,7 @@ import { SessionContext } from './agent/context.js'
 import { SessionPersist, evictOldSessions, getSessionDir } from './agent/session-persist.js'
 import { runGateCompletion } from './agent/gate-completion.js'
 import { memoryBackfillEnabled, runMemoryBackfill } from './memory/backfill.js'
-import { migrateSessionFiles } from './agent/session-cd.js'
+import { migrateSessionFiles, rebuildStoresAfterCwdMove } from './agent/session-cd.js'
 import { decideStartupSession, RESUME_FRESHNESS_MS } from './agent/session-recovery.js'
 import { runResumePreflightOai } from './context/resume-preflight.js'
 import {
@@ -1819,6 +1819,12 @@ export async function switchAgentCwd(ctx: BootstrapContext, target: string): Pro
   const oldEngine = ctx.agent.config.promptEngine
   const oldCoordinator = ctx.refs.coordinator
   const newPersist = new SessionPersist(sessionId, newCwd)
+  // D-1：fileHistory/claimStore 的磁盘根都焊死构造期 cwd（备份根 persist.getBackupDir()、
+  // claims 根 getSessionDir(cwd)），原引用直接复用会让 undo 读旧路径备份 ENOENT 被
+  // 当「missing」静默跳过（撤销无声丢失）、新编辑在旧项目路径复活旧会话目录（脑裂），
+  // 旧目录搬不空更让回程 /cd rename ENOTEMPTY 确定性砖化。会话文件已整体迁到新 slug
+  // 目录（第 4 步），容器按 newPersist 重建即无缝接管。
+  const rebuiltStores = rebuildStoresAfterCwdMove(ctx.fileHistory, newPersist)
 
   const { agent } = createAgentRuntime({
     provider: ctx.provider,
@@ -1829,8 +1835,8 @@ export async function switchAgentCwd(ctx: BootstrapContext, target: string): Pro
     cwd: newCwd,
     toolRegistry: ctx.toolRegistry,
     persist: newPersist,
-    claimStore: ctx.claimStore,
-    fileHistory: ctx.fileHistory,
+    claimStore: rebuiltStores.claimStore,
+    fileHistory: rebuiltStores.fileHistory,
     refs: ctx.refs,
     domainKnowledgeStore: ctx.domainKnowledgeStore,
     modelId: currentModelId,
@@ -1843,6 +1849,8 @@ export async function switchAgentCwd(ctx: BootstrapContext, target: string): Pro
   const oldLspManager = ctx.refs.lspManager
   ctx.agent = agent
   ctx.persist = newPersist
+  ctx.fileHistory = rebuiltStores.fileHistory
+  ctx.claimStore = rebuiltStores.claimStore
   ctx.cwd = newCwd
   ctx.refs.promptEngine = agent.config.promptEngine
   wireFrozenSnapshotPersist(newPersist, agent.config.promptEngine)

--- a/src/tui/slash-commands.ts
+++ b/src/tui/slash-commands.ts
@@ -3915,7 +3915,9 @@ export function registerTuiSlashCommands(app: TuiApp, ctx: BootstrapContext): vo
       setCacheHitRate: (v: number) => { cacheHitRate = v },
       setSummaryState: () => {},
       mcpManagerRef: { current: ctx.refs.mcpManager },
-      claimStoreRef: { current: ctx.claimStore },
+      // getter 惰性读 ctx——/cd 重建 claimStore 后（bootstrap switchAgentCwd 原地
+      // 更新 ctx.claimStore），/context claims* 等检视命令读到的仍是当前 store。
+      claimStoreRef: { get current() { return ctx.claimStore } },
       banditState: ctx.refs.banditState ?? undefined,
       onDomainChange: (domainName: string | undefined) => {
         app.setSessionStarDomain(domainName)


### PR DESCRIPTION
# PR-D1 fix(agent): /cd 换工作区后按新 cwd 重建 FileHistory/claimStore——撤销不再静默失效、旧项目目录不复活、往返 /cd 不再 ENOTEMPTY 砖化

## 动机（病灶）
`switchAgentCwd` 重建 runtime 时把**同一个** `ctx.fileHistory` / `ctx.claimStore` 原引用传进新 agent（bootstrap.ts:1817-1818），而两者的磁盘根都焊死在构造期 cwd（备份根 `persist.getBackupDir()`、claims 根 `getSessionDir(cwd)`）。同时 `migrateSessionFiles` 已把 `<旧slug>/<id>/` 会话目录整体搬到新 slug 下——实例没跟着换，磁盘根却换了，三重后果：

1. **undo 静默失效**：/cd 后 rewind 按旧路径读备份 → ENOENT 被 file-history 的「backup missing, skip」静默吞掉（file-history.ts:141-147）——撤销能力无声丢失，用户以为 undo 了其实什么都没发生；
2. **跨项目状态脑裂**：/cd 后新编辑 trackEdit 在旧项目路径 `mkdir(recursive)`（file-history.ts:82），旧项目的会话目录原地复活——一个项目里出现另一个项目的会话残骸；
3. **往返 /cd 确定性砖化**：切回旧项目时会话目录 rename 落在复活的非空目录上 = ENOTEMPTY（session-cd.ts `movePath` 只兜 EXDEV），迁移抛错、switchAgentCwd 按设计拒绝切换——A→B→A 一次往返就把 /cd 功能砖死，只能重启。

审计复现 repro/repro-d-1-cd-filehistory-brick.ts 在 node24 下 5/5 红。

## 修法
提取为可测的小导出函数，与 `migrateSessionFiles` 同居 session-cd.ts（文件搬过去，容器跟过去）：
- `FileHistory.withBackupRoot(newBackupDir)`：按新备份根重建实例，**内存快照与 tracked 名单随迁**——备份文件已随会话目录整体迁移到新路径，接管前的全部 undo 历史仍可读可回滚，无缝接管；
- `rebuildStoresAfterCwdMove(prevFileHistory, newPersist)`：配对重建 fileHistory + claimStore。claimStore 镜像原始构造点（`persist.createClaimStore()`）；claims 文件按既有设计刻意不迁移、留守旧项目（与本模块头部「从新 cwd 重启后重建空账本」语义一致）；
- `switchAgentCwd` 改传新实例并同步 `ctx.fileHistory` / `ctx.claimStore`（第 5/6 步各两行），切换的其余语义零改动；
- TUI `claimStoreRef` 改 getter 惰性读 ctx（1 行）：/cd 后 `/context claims*` 检视命令仍指向当前 store。

## 不修的后果
任何一次跨项目 /cd 之后：①undo/rewind 全部静默空转（备份按旧路径读，恢复不发生也不报错）；②旧项目目录长出幽灵会话目录；③想切回去直接被 ENOTEMPTY 拒绝，/cd 往返一次即砖化，只能重启进程。

## 验证
- 新增 `src/agent/__tests__/session-cd-rebuild-stores.test.ts`（node:test，repro 语义搬入）：①/cd 后 rewind 实际恢复迁移前快照（备份随迁移可读）；②新编辑备份落在新 slug 目录、旧项目会话目录不复活；③切回旧项目迁移成功（不再 ENOTEMPTY）；④claimStore 记账指向新项目、旧 claims 留守旧项目。修复后 4/4 绿。
- 阴性对照：`git stash push` 四个源文件 → 新测试红（`rebuildStoresAfterCwdMove` 导出缺席）；同 stash 态用修复前已有 API 跑病灶语义脚本，四项全部复现（undo 未发生且静默、rewind 返回空、旧项目目录复活、切回 errno=ENOTEMPTY）→ `git stash pop` 恢复后 4/4 绿。
- 门：`npx tsc --noEmit` 绿；`npm run typecheck`（守卫版）绿；既有 session-cd / file-history / session-persist 三套测试合计 77 全绿，switch-agent-session / bootstrap / session-persist-async 合计 25 全绿，file-history-persist / slash-commands 合计 109 全绿；oxlint 对四个改动文件 0 错误、0 新增警告。

## 影响范围
仅 TUI `/cd` 路径（`switchAgentCwd`）与 FileHistory/ContextClaimStore 的构造接缝；`/model`、`/resume`、sidecar per-session 装配、migrateSessionFiles 迁移语义均零改动。FileHistory 新增方法为纯增量 API，既有构造调用不变。🟢 bootstrap 接缝处两行参数替换为重建实例，属审计清单第 9 项预期形态（8-15 行核心 diff）。
