### PR TITLE
fix(agent): hash_edit/ast_edit/apply_patch 的编辑接入撤销/回溯/LSP 三处名单——写工具记账以 WRITE_TOOL_NAMES 为单一事实源

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/zoujie/.zcode/workspace/default/Tianshu-harness/node_modules

--- a/src/agent/__tests__/file-history.test.ts
+++ b/src/agent/__tests__/file-history.test.ts
@@ -2,7 +2,7 @@ import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
 import { mkdirSync, rmSync, writeFileSync, readFileSync, existsSync } from 'node:fs'
 import { join } from 'node:path'
-import { FileHistory } from '../file-history.js'
+import { FileHistory, collectPostBoundaryEditIds } from '../file-history.js'
 
 const TMP = join(import.meta.dirname, '.fh-test-tmp')
 const BACKUP = join(import.meta.dirname, '.fh-test-backup')
@@ -189,5 +189,73 @@ describe('FileHistory', () => {
 
     const afterClean = readdirSync(sessionDir)
     assert.ok(!afterClean.includes('orphan_file'))
+  })
+})
+
+describe('collectPostBoundaryEditIds — E4 名单收口', () => {
+  let e4History: FileHistory
+
+  beforeEach(() => {
+    rmSync(TMP, { recursive: true, force: true })
+    rmSync(BACKUP, { recursive: true, force: true })
+    mkdirSync(TMP, { recursive: true })
+    mkdirSync(BACKUP, { recursive: true })
+    e4History = new FileHistory(BACKUP, 'test-session')
+  })
+
+  afterEach(() => {
+    rmSync(TMP, { recursive: true, force: true })
+    rmSync(BACKUP, { recursive: true, force: true })
+  })
+
+  // E4(=A2)：边界回溯名单此前只认 write_file/edit_file，hash_edit/ast_edit/
+  // apply_patch 的编辑对精确回溯全盲。名单收口为 WRITE_TOOL_NAMES 后，
+  // 五件写工具的 tool_use id 都要被收集——这是 rewindToBoundary 的输入。
+  it('collects post-boundary tool_use ids of all five write tools', () => {
+    const messages = [
+      { role: 'user', content: 'go' },
+      { role: 'assistant', content: '', tool_calls: [
+        { id: 'pre_write', function: { name: 'write_file', arguments: '{}' } },
+        { id: 'pre_read', function: { name: 'read_file', arguments: '{}' } },
+      ] },
+      { role: 'tool', tool_call_id: 'pre_write', content: 'ok' },
+      { role: 'user', content: 'boundary message' },
+      { role: 'assistant', content: '', tool_calls: [
+        { id: 'post_write', function: { name: 'write_file', arguments: '{}' } },
+        { id: 'post_edit', function: { name: 'edit_file', arguments: '{}' } },
+        { id: 'post_hash', function: { name: 'hash_edit', arguments: '{}' } },
+        { id: 'post_ast', function: { name: 'ast_edit', arguments: '{}' } },
+        { id: 'post_patch', function: { name: 'apply_patch', arguments: '{}' } },
+        { id: 'post_bash', function: { name: 'bash', arguments: '{}' } },
+      ] },
+    ] as any
+
+    const ids = collectPostBoundaryEditIds(messages, 4)
+    assert.deepEqual(
+      [...ids].sort(),
+      ['post_ast', 'post_edit', 'post_hash', 'post_patch', 'post_write'],
+      '边界之后的五件写工具 id 都应被收集；非写工具（bash/read_file）不收',
+    )
+    assert.ok(!ids.has('pre_write'), '边界之前的写不计入')
+
+    // 从第一个 assistant（更早边界）起算：只含截至切片末尾的写
+    const fromEarlier = collectPostBoundaryEditIds(messages.slice(0, 4), 1)
+    assert.deepEqual([...fromEarlier].sort(), ['pre_write'])
+  })
+
+  it('ids feed rewindToBoundary: a hash_edit snapshot key is honored', async () => {
+    const file = join(TMP, 'hash-target.txt')
+    writeFileSync(file, 'before-hash')
+    // 模拟 pipeline 对 hash_edit 的记账：trackEdit(messageId = tool_use id)
+    await e4History.trackEdit(file, 'post_hash')
+    writeFileSync(file, 'after-hash')
+
+    const ids = collectPostBoundaryEditIds([
+      { role: 'assistant', content: '', tool_calls: [
+        { id: 'post_hash', function: { name: 'hash_edit', arguments: '{}' } },
+      ] },
+    ] as any, 0)
+    await e4History.rewindToBoundary(ids)
+    assert.equal(readFileSync(file, 'utf-8'), 'before-hash', 'hash_edit 的记账应可被边界回溯恢复')
   })
 })

--- a/src/agent/__tests__/tool-pipeline.test.ts
+++ b/src/agent/__tests__/tool-pipeline.test.ts
@@ -5,6 +5,7 @@ import { execFileSync } from 'node:child_process'
 import { join, resolve as resolvePath } from 'node:path'
 import { tmpdir } from 'node:os'
 import { executeToolUse, patchTargetPaths, type ToolPipelineDeps } from '../tool-pipeline.js'
+import { FileHistory } from '../file-history.js'
 import { createTurnBudget } from '../turn-budget.js'
 import { fingerprintToolCall } from '../trace-store.js'
 import { createPermissionOverlay } from '../permissions.js'
@@ -3602,5 +3603,229 @@ describe('TDD gate suggest annotation', () => {
     )
     assert.equal((result.toolResult as any).is_error ?? false, false)
     assert.equal(seen.length, 0, '空库时不得查询 meridian（analyzeImpact 各方法都不该被调）')
+  })
+})
+
+// ── E4 写工具记账与 LSP 通知收口（hash_edit / ast_edit / apply_patch）──────
+// 病灶：trackEdit 门槛、边界回溯名单、LSP changeFile 通知三处只认
+// write_file/edit_file。修复后以 WRITE_TOOL_NAMES + extractWriteFilePaths
+// （write-tool-helpers，单一事实源）接通五件写工具。
+describe('E4 写工具记账与 LSP 通知收口', () => {
+  const noopCb = { onToolResult: () => {}, onApprovalRequired: async () => true }
+
+  function makeDeps(cwd: string, overrides?: Partial<ToolPipelineDeps>): ToolPipelineDeps {
+    return {
+      config: {
+        toolRegistry: {
+          execute: async () => ({ content: 'ok', isError: false }),
+          get: () => ({ definition: { input_schema: {} }, isConcurrencySafe: () => false }),
+          needsApproval: () => false,
+          resolveName: (n: string) => n,
+        },
+        hooks: null,
+        lspEnabled: false,
+        fileHistory: undefined,
+        contextClaimStore: undefined,
+        sessionId: 'e4-test-session',
+        promptEngine: { markGitDirty: () => {}, getModel: () => 'test-model' },
+      } as any,
+      cwd,
+      harness: {
+        executeTool: async ({ execute }: any) => {
+          const r = await execute()
+          return { content: r.content, isError: r.isError ?? false, retried: false }
+        },
+      } as any,
+      prewarm: { get: () => null, invalidate: () => {} } as any,
+      evidence: mockEvidence,
+      traceStore: { events: [], toolFingerprints: [] } as any,
+      repairHintTracker: { recordSuccess: () => {}, recordFailure: () => {} } as any,
+      repairPipeline: { run: (input: any) => ({ output: input, telemetry: [] }) } as any,
+      importGraph: null,
+      lastConflictCheckCount: 0,
+      trajectory: { getEntries: () => [] } as any,
+      getDoomLoopLevel: () => 'none' as const,
+      latestRisk: { level: 'none' as const, reasons: [], suggestedAction: '' },
+      sessionTurnCount: 1,
+      sessionId: 'e4-test-session',
+      recordToolHistory: () => {},
+      turnBudget: createTurnBudget(0),
+      ...overrides,
+    }
+  }
+
+  function recordingLsp() {
+    const notified: string[] = []
+    const mgr = {
+      isReady: () => false, // 只测 changeFile 通知，诊断段不参与
+      changeFile: (p: string) => { notified.push(p) },
+    }
+    return { notified, mgr }
+  }
+
+  it('hash_edit 执行成功后 file-history 出现对应记账，且备份为编辑前内容', async () => {
+    const dir = mkdtempSync(join(testTmp(), 'e4-hashedit-'))
+    try {
+      const target = join(dir, 'a.ts')
+      writeFileSync(target, 'hello', 'utf-8')
+      const fh = new FileHistory(join(dir, '.backups'), 'e4-session')
+      const deps = makeDeps(dir, { config: { ...makeDeps(dir).config, fileHistory: fh } as any })
+
+      const result = await executeToolUse(
+        { id: 'tu-e4-hash', name: 'hash_edit', input: { file_path: target, old_string: 'hello', new_string: 'world' } },
+        deps, noopCb as any, 1, false,
+      )
+      assert.equal((result.toolResult as any).is_error ?? false, false, 'hash_edit 应执行成功')
+      const snap = fh.getAllSnapshots().find(s => s.messageId === 'tu-e4-hash')
+      assert.ok(snap, 'hash_edit 的 tool_use id 应进 file-history 快照（/undo 与回溯的记账源头）')
+      const backup = snap!.trackedFileBackups[target]
+      assert.ok(backup, '目标文件应被记账')
+      assert.ok(backup!.backupFileName, '应有实体备份文件（写前版本化）')
+      assert.equal(
+        readFileSync(join(dir, '.backups', 'e4-session', backup!.backupFileName!), 'utf-8'),
+        'hello',
+        '备份内容应为编辑前内容',
+      )
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('apply_patch 执行成功后按 diff 目标逐文件记账（备份粒度=文件）；纯删除补丁保持跳过', async () => {
+    const dir = mkdtempSync(join(testTmp(), 'e4-applypatch-'))
+    try {
+      const target = join(dir, 'b.ts')
+      writeFileSync(target, 'one\n', 'utf-8')
+      const fh = new FileHistory(join(dir, '.backups'), 'e4-session')
+      const deps = makeDeps(dir, { config: { ...makeDeps(dir).config, fileHistory: fh } as any })
+
+      // diff 头带绝对路径：extractWriteFilePaths 剥 b/ 前缀后即目标本身
+      const diffText = [
+        `--- a/${target}`,
+        `+++ b/${target}`,
+        '@@ -1 +1,2 @@',
+        ' one',
+        '+two',
+      ].join('\n')
+      const result = await executeToolUse(
+        { id: 'tu-e4-patch', name: 'apply_patch', input: { diff: diffText } },
+        deps, noopCb as any, 1, false,
+      )
+      assert.equal((result.toolResult as any).is_error ?? false, false, 'apply_patch 应执行成功')
+      const snap = fh.getAllSnapshots().find(s => s.messageId === 'tu-e4-patch')
+      assert.ok(snap, 'apply_patch 的 tool_use id 应进 file-history 快照')
+      const backup = snap!.trackedFileBackups[target]
+      assert.ok(backup, 'diff 目标应被逐文件记账')
+      assert.ok(backup!.backupFileName, '应有实体备份文件')
+      assert.equal(
+        readFileSync(join(dir, '.backups', 'e4-session', backup!.backupFileName!), 'utf-8'),
+        'one\n',
+        '备份应为打补丁前的文件内容',
+      )
+
+      // 纯删除补丁（+++ /dev/null）：与既有 targets 提取保持一致的跳过语义
+      const delDiff = [
+        `--- a/${target}`,
+        '+++ /dev/null',
+        '@@ -1 +0,0 @@',
+        '-one',
+      ].join('\n')
+      await executeToolUse(
+        { id: 'tu-e4-patch-del', name: 'apply_patch', input: { diff: delDiff } },
+        deps, noopCb as any, 1, false,
+      )
+      assert.ok(
+        !fh.getAllSnapshots().some(s => s.messageId === 'tu-e4-patch-del'),
+        '纯删除补丁不应产生记账',
+      )
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('LSP changeFile：apply_patch 的 diff 目标被逐个通知（删除经 --- 回退也在内）', async () => {
+    const dir = mkdtempSync(join(testTmp(), 'e4-lsp-patch-'))
+    try {
+      const { notified, mgr } = recordingLsp()
+      const deps = makeDeps(dir, { getLspManager: () => mgr as any })
+
+      const diffText = [
+        '--- a/src/a.ts',
+        '+++ b/src/a.ts',
+        '@@ -1 +1,2 @@',
+        '+x',
+        '--- a/src/gone.ts',
+        '+++ /dev/null',
+        '@@ -1 +0,0 @@',
+        '-y',
+      ].join('\n')
+      await executeToolUse(
+        { id: 'tu-e4-lsp-patch', name: 'apply_patch', input: { diff: diffText } },
+        deps, noopCb as any, 1, false,
+      )
+      assert.deepEqual(
+        notified.sort(),
+        ['src/a.ts', 'src/gone.ts'],
+        'diff 的每个目标都应逐个 changeFile（此前读恒为 undefined 的 input.file_path，通知从未到达）',
+      )
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('LSP changeFile：ast_edit 按 paths 通知、hash_edit 通知 file_path；dryRun/失败/缺路径不通知', async () => {
+    const dir = mkdtempSync(join(testTmp(), 'e4-lsp-paths-'))
+    try {
+      const { notified, mgr } = recordingLsp()
+      const deps = makeDeps(dir, { getLspManager: () => mgr as any })
+
+      await executeToolUse(
+        { id: 'tu-e4-lsp-ast', name: 'ast_edit', input: { paths: ['x.ts', 'y.ts'], ops: [{ find: 'a', replace: 'b' }] } },
+        deps, noopCb as any, 1, false,
+      )
+      assert.deepEqual(notified.sort(), ['x.ts', 'y.ts'], 'ast_edit 的 paths 数组应被逐个通知')
+
+      notified.length = 0
+      await executeToolUse(
+        { id: 'tu-e4-lsp-ast-dry', name: 'ast_edit', input: { paths: ['x.ts'], ops: [{ find: 'a', replace: 'b' }], dryRun: true } },
+        deps, noopCb as any, 1, false,
+      )
+      assert.equal(notified.length, 0, 'dryRun 不写盘，不应通知 LSP')
+
+      notified.length = 0
+      await executeToolUse(
+        { id: 'tu-e4-lsp-hash', name: 'hash_edit', input: { file_path: 'z.ts', old_string: 'a', new_string: 'b' } },
+        deps, noopCb as any, 1, false,
+      )
+      assert.deepEqual(notified, ['z.ts'], 'hash_edit 应按 file_path 通知')
+
+      const failDeps = makeDeps(dir, {
+        getLspManager: () => mgr as any,
+        config: {
+          ...makeDeps(dir).config,
+          toolRegistry: {
+            execute: async () => ({ content: 'boom', isError: true }),
+            get: () => ({ definition: { input_schema: {} }, isConcurrencySafe: () => false }),
+            needsApproval: () => false,
+            resolveName: (n: string) => n,
+          },
+        } as any,
+      })
+      notified.length = 0
+      await executeToolUse(
+        { id: 'tu-e4-lsp-ast-fail', name: 'ast_edit', input: { paths: ['x.ts'], ops: [{ find: 'a', replace: 'b' }] } },
+        failDeps, noopCb as any, 1, false,
+      )
+      assert.equal(notified.length, 0, '执行失败不通知（保留既有 isError 门）')
+
+      notified.length = 0
+      await executeToolUse(
+        { id: 'tu-e4-lsp-edit-nopath', name: 'edit_file', input: {} },
+        deps, noopCb as any, 1, false,
+      )
+      assert.equal(notified.length, 0, '解析不出路径时不通知（保留既有空值防御，且不再以 undefined 调用）')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
   })
 })

--- a/src/agent/file-history.ts
+++ b/src/agent/file-history.ts
@@ -5,15 +5,19 @@ import type { OaiMessage } from '../api/oai-types.js'
 import { cpuPool } from '../workers/cpu-pool.js'
 import { diffLinesRaw } from '../workers/cpu-tasks.js'
 import type { RawChange } from '../workers/cpu-tasks.js'
+import { WRITE_TOOL_NAMES } from '../tools/write-tool-helpers.js'
 
 const MAX_SNAPSHOTS = 100
 
 /**
- * The write_file / edit_file tool_use ids whose calls occurred at or after
- * `messageIndex` — i.e. edits made after a conversation boundary. These key the
- * FileHistory snapshots a precise rewind to that boundary undoes. Shared by the
- * server (session-manager) and the in-process TUI rewind flow so both compute
- * the boundary identically.
+ * The write-tool tool_use ids whose calls occurred at or after `messageIndex`
+ * — i.e. edits made after a conversation boundary. These key the FileHistory
+ * snapshots a precise rewind to that boundary undoes. The tool roster is the
+ * shared WRITE_TOOL_NAMES (write_file / edit_file / hash_edit / ast_edit /
+ * apply_patch) — the same set tool-pipeline tracks via trackEdit, so every
+ * agent-edited file is rewindable regardless of which write tool made the
+ * edit. Shared by the server (session-manager) and the in-process TUI rewind
+ * flow so both compute the boundary identically.
  */
 export function collectPostBoundaryEditIds(messages: OaiMessage[], messageIndex: number): Set<string> {
   const ids = new Set<string>()
@@ -22,7 +26,7 @@ export function collectPostBoundaryEditIds(messages: OaiMessage[], messageIndex:
     if (m && m.role === 'assistant' && Array.isArray(m.tool_calls)) {
       for (const tc of m.tool_calls) {
         const name = tc.function?.name
-        if (name === 'write_file' || name === 'edit_file') ids.add(tc.id)
+        if (name && WRITE_TOOL_NAMES.has(name)) ids.add(tc.id)
       }
     }
   }
@@ -154,8 +158,10 @@ export class FileHistory {
    * was edited AFTER the boundary back to its content as of that boundary, and
    * delete files first created after it.
    *
-   * `postBoundaryIds` = the set of edit tool_use ids (write_file / edit_file)
-   * whose calls occurred after the boundary, in message order. For each file the
+   * `postBoundaryIds` = the set of write-tool tool_use ids (all of
+   * WRITE_TOOL_NAMES — write_file / edit_file / hash_edit / ast_edit /
+   * apply_patch) whose calls occurred after the boundary, in message order.
+   * For each file the
    * EARLIEST post-boundary snapshot that touched it holds the file's pre-edit
    * content — which is exactly its state at the boundary (no edits happened
    * between the boundary and that first post-boundary edit). Restoring that

--- a/src/agent/tool-pipeline.ts
+++ b/src/agent/tool-pipeline.ts
@@ -62,6 +62,7 @@ import { buildSensitivePreflightMessage, shouldRequireSensitivePreflight } from 
 import { toolTargetFromInput } from './tool-target.js'
 import { execFileGit } from '../tools/spawn-git.js'
 import { patchTargetPaths, preWriteClaimPaths } from './pre-write-claims.js'
+import { WRITE_TOOL_NAMES, extractWriteFilePaths } from '../tools/write-tool-helpers.js'
 
 /** Headless prefix on denial messages — a stable marker so worker-session's
  *  detectApprovalDeadlock can distinguish "gated by approval" from "bad JSON". */
@@ -1356,9 +1357,21 @@ async function executeToolUseInner(
       recordAgentTouchedFile(deps.cwd, tu.input.file_path, deps.config.sessionId)
    }
 
-    if (deps.config.fileHistory && (tu.name === 'write_file' || tu.name === 'edit_file') && typeof tu.input.file_path === 'string') {
-      touchActivity(activityKey, `tool:${tu.name}:pre:track-edit`)
-      await deps.config.fileHistory.trackEdit(tu.input.file_path, tu.id)
+    // E4 记账收口：五件写工具（WRITE_TOOL_NAMES 单一事实源）的编辑都要在执行
+    // 前进 file-history——这是 /undo 与边界回溯的记账源头，此前只认
+    // write_file/edit_file，hash_edit/ast_edit/apply_patch 的编辑不可回溯。
+    // 路径按工具解析（extractWriteFilePaths）：write/edit/hash_edit →
+    // file_path；ast_edit → paths 数组（dryRun 为空，预览不记账）；
+    // apply_patch → diff 的 `+++ ` 头（纯删除 /dev/null 跳过，与既有
+    // targets 提取一致），备份粒度 = 文件。
+    if (deps.config.fileHistory && WRITE_TOOL_NAMES.has(tu.name)) {
+      const editPaths = extractWriteFilePaths(tu.name, tu.input)
+      if (editPaths.length > 0) {
+        touchActivity(activityKey, `tool:${tu.name}:pre:track-edit`)
+        for (const editPath of editPaths) {
+          await deps.config.fileHistory.trackEdit(editPath, tu.id)
+        }
+      }
    }
 
     // Execute via TurnHarness
@@ -1512,8 +1525,19 @@ async function executeToolUseInner(
 
     // LSP: notify the language server that a file changed on disk.
     // Must happen BEFORE diagnostics so the server's view is current.
-    if (!harnessResult.isError && (tu.name === 'edit_file' || tu.name === 'write_file' || tu.name === 'apply_patch')) {
-      (deps.getLspManager?.() ?? deps.lspManager)?.changeFile(tu.input.file_path as string)
+    // E4 通知收口：名单用 WRITE_TOOL_NAMES，路径按工具解析——write/edit/
+    // hash_edit → file_path；ast_edit → paths 数组；apply_patch → diff 头，
+    // 用 patchTargetPaths（删除经 `--- ` 回退也在内，让 LSP 得知文件消失，
+    // 清掉过期诊断）。解析不出路径就不通知（保留既有空值防御——旧代码对
+    // apply_patch 恒传 undefined 的 file_path，通知从未真正到达）。
+    if (!harnessResult.isError && WRITE_TOOL_NAMES.has(tu.name)) {
+      const changedPaths = tu.name === 'apply_patch' && typeof tu.input.diff === 'string'
+        ? patchTargetPaths(tu.input.diff)
+        : extractWriteFilePaths(tu.name, tu.input)
+      const lsp = deps.getLspManager?.() ?? deps.lspManager
+      for (const changedPath of changedPaths) {
+        lsp?.changeFile(changedPath)
+      }
    }
 
     // T4: LSP diagnostics via lspManager (async file-level, ~2s timeout)


### PR DESCRIPTION
# PR-E4 fix(agent): hash_edit/ast_edit/apply_patch 的编辑接入撤销/回溯/LSP 三处名单——记账以 WRITE_TOOL_NAMES 为单一事实源

## 动机（病灶）
写工具家族 v3.x 扩到五件（write_file / edit_file / hash_edit / ast_edit / apply_patch），但撤销/回溯/LSP 三处名单仍停留在「写工具=write_file+edit_file 两件」的世界模型：

1. **file-history 记账盲**：`tool-pipeline.ts` 的 trackEdit 门槛（全仓唯一记账点）只认 write_file/edit_file → hash_edit/ast_edit/apply_patch 的编辑不进 file-history。file-history 是 /undo 的记账源头，`FileHistory.trackEdit` 又是写前版本化备份的唯一落点——README:1013 承诺的「每次写/编辑前版本化备份」对这三个工具不成立，编辑原语断言 repro-a-edit-primitive-guard-asymmetry 5/5 红。
2. **边界回溯盲**：`file-history.ts` 的 `collectPostBoundaryEditIds` 名单同样只有两件 → 精确边界回溯（`rewindToBoundary`，session-manager 的 `rewindFilesPrecise` 与 TUI rewind 共用）对三个新工具全盲；session-manager.ts:4897 附近「restore every agent-edited file」的注释是假承诺。
3. **LSP 通知盲**：changeFile 通知名单含 apply_patch 却读 `tu.input.file_path`——apply_patch 的 schema 只有 `{diff, check_only}`，file_path 恒 undefined（write-tool-helpers.ts 注释自己记录过这个盲区），通知从未真正到达；hash_edit/ast_edit 干脆不在名单。这是 #87（LSP 致盲）的微缩版：模型拿 3/5 写工具的通知，其余换着写就得到过期诊断。

## 修法（40-80 行，单一事实源）
- `WRITE_TOOL_NAMES`（write-tool-helpers.ts）已含全部五件写工具，直接作为三处的共用名单；路径解析复用同文件的 `extractWriteFilePaths`（各检测器已在用的既有单一事实源，不新造逻辑）：
  - write_file / edit_file / hash_edit → `input.file_path`
  - ast_edit → `input.paths` 数组（dryRun 为空，预览不记账不通知）
  - apply_patch → 解析 diff 的 `+++ ` 头
- ① trackEdit 门槛：名单换 WRITE_TOOL_NAMES，按解析出的路径逐文件 `trackEdit(path, tu.id)`（备份粒度=文件；纯删除 `+++/dev/null` 保持与既有 targets 提取一致的跳过语义）。
- ② `collectPostBoundaryEditIds`：名单换 WRITE_TOOL_NAMES（file-history.ts 新 import write-tool-helpers，纯模块无环）。
- ③ LSP changeFile：名单换 WRITE_TOOL_NAMES；apply_patch 用既有 `patchTargetPaths(diff)`（tool-pipeline.ts:83，删除目标经 `--- ` 回退也在内——让 LSP 得知文件消失、清掉过期诊断）；解析不出路径就不调用（空值防御保留，且不再以 undefined 调用 changeFile）。

### trackEdit 备份语义结论（边界回溯能恢复什么）
`trackEdit` 自带写前备份：执行前读目标文件内容落盘为 `FileBackup`（backupDir/sessionId 下按版本号命名），不依赖 git 或 checkpoint。因此三处接通后，边界回溯对 hash_edit/ast_edit/apply_patch 恢复的是「该工具最早一次编辑前」的文件内容——由于快照按 tool_use id 键控、最早一次编辑前的内容即边界时刻内容，语义与 write/edit 完全一致。依赖与既有语义相同：文件当时不存在 → null 哨兵（回溯=unlink，即删除边界后新建的文件）；存在但读取失败（AV/EDR 锁等）→ `unreadable` 标记，回溯跳过而不误删。apply_patch 的纯删除补丁不记账（跳过语义），被删文件不在此轮回溯恢复范围内（这是审计「apply_patch 回溯语义先问」的既定取舍，与既有 targets 提取口径一致）。

## 不修的后果
用 hash_edit/ast_edit/apply_patch 做的每次编辑：/undo 无从记账、精确回溯直接漏掉、LSP 拿不到通知 → 过期诊断误导后续编辑；README 的版本化备份承诺对 3/5 写门是空头支票，审计 repro 5/5 红持续成立。

## 验证
- 新增 6 条测试（三件套）：
  a. `file-history.test.ts`：collectPostBoundaryEditIds 收集五件写工具的边界后 id（非写工具不收、边界前不计）；hash_edit 记账 id 可被 `rewindToBoundary` 实际恢复。
  b. `tool-pipeline.test.ts`：hash_edit 与 apply_patch 经 executeToolUse 执行成功后 file-history 出现对应快照（messageId=tool_use id），并断言备份文件内容为**编辑前原文**；apply_patch 纯删除补丁不记账。
  c. `tool-pipeline.test.ts`（mock LSP manager，仿 serve-shared-cwd-resources 的 mock 模式）：apply_patch 的 diff 目标被逐个 changeFile（删除经 `--- ` 回退也在内）；ast_edit 按 paths 逐个通知；hash_edit 按 file_path；dryRun/执行失败/解析不出路径不通知。
- 阴性对照：`git stash push` 两处源文件 → 新增 6 条全红（114 tests / fail 6：boundary ids×2 + pipeline 记账×2 + LSP×2）→ `git stash pop` 后全绿。
- 门禁：`npx tsc --noEmit` 绿；`npm run typecheck`（守卫版）绿；tool-pipeline.test.ts 98/98（基线 94/94，任务预警的 3 条存量红在本基座 e8fdf1b1 未复现，如实记录）；file-history 16/16（基线 14/14）；rewind/session-manager 相关 130/130；LSP 模块 81/81；serve-shared-cwd-resources 合并跑 124/124。

## 影响范围
- 仅 `tool-pipeline.ts` 两处门槛与 `file-history.ts` 一处名单（含注释），行为面：五件写工具的记账/回溯/LSP 通知对齐，write_file/edit_file 既有路径行为不变（extractWriteFilePaths 对它们的解析与旧 `typeof file_path === 'string'` 门等价）。
- **R2 写前守卫不在本 PR**：那是 #111（E3 PR）的范围且在另一分支；本分支基于 main（不含 #111），不碰 R2 名单以避免合并冲突。plan_close 也不在本次名单（计划文件语义单独讨论）。
- 相邻未动（如实标注）：`tool-pipeline.ts` 的 `recordAgentTouchedFile`（checkpoint 粗回溯 scoping 用）仍是两件名单，但粗回溯靠 checkpoint 整树基线兜底、不依赖 file-history 记账，不在 E4 三处病灶内，未扩大改动面。
- 🟢 源文件均为常规模块，不在审查/保护区。
