### PR TITLE
fix(security): 敏感文件门补齐（export_file/import_resource）、白名单收窄与 NODE_OPTIONS 摘除

### DIFF
--- a/src/agent/approval-risk.ts
+++ b/src/agent/approval-risk.ts
@@ -3,7 +3,7 @@ import { isAbsolute } from 'node:path'
 import { evaluateMcpPolicy, type McpCapability } from '../mcp/policy.js'
 import type { ContextClaim } from '../context/claims.js'
 import type { Sensorium } from './sensorium.js'
-import { detectSensitiveGitAdd } from '../tools/sensitive-file-detector.js'
+import { detectSensitiveGitAdd, AGGREGATE_ADD_MARKER } from '../tools/sensitive-file-detector.js'
 
 export type RiskLevel = 'none' | 'low' | 'medium' | 'high'
 
@@ -351,10 +351,17 @@ export function assessToolRisk(
       level = 'high'
     }
     // git add 敏感文件硬门（detectSensitiveGitAdd 此前零生产调用点）：命令文本暂存
-    // 凭据/密钥文件 → high，auto-safe 也要走审批。检测器不抛——不可解析命令只是漏报，不会崩。
-    if (detectSensitiveGitAdd(cmd).length > 0) {
+    // 凭据/密钥文件 → high，auto-safe 也要走审批。聚合形态（. / -A / --all）静态
+    // 无法核验暂存文件 → 哨兵项，medium + 建议改用 git 工具（自带敏感文件筛查）。
+    // 检测器不抛——不可解析命令只是漏报，不会崩。
+    const gitAddHits = detectSensitiveGitAdd(cmd)
+    if (gitAddHits.some(h => h !== AGGREGATE_ADD_MARKER)) {
       reasons.push('git add stages credential/key files — prompt hard-gate')
       level = 'high'
+    }
+    if (gitAddHits.includes(AGGREGATE_ADD_MARKER) && level !== 'high') {
+      reasons.push('git add 聚合形态（. / -A / --all）无法静态核验暂存文件——建议改用 git 工具（自带敏感文件筛查）')
+      level = 'medium'
     }
     // Command injection detection
     for (const p of INJECTION_PATTERNS) {

--- a/src/tools/__tests__/bash.test.ts
+++ b/src/tools/__tests__/bash.test.ts
@@ -439,4 +439,12 @@ describe('sanitizeEnv', () => {
     assert.equal(result.MAVEN_TOKEN, undefined)
     assert.equal(result.GRADLE_API_KEY, undefined)
   })
+
+  it('strips NODE_OPTIONS and JAVA_TOOL_OPTIONS (code injection surface, issue #137)', () => {
+    const env = { ...process.env, NODE_OPTIONS: '--require=/tmp/malware.js', JAVA_TOOL_OPTIONS: '-javaagent:/tmp/malware.jar', NODE_PATH: '/opt/lib' }
+    const result = sanitizeEnv(env)
+    assert.equal(result.NODE_OPTIONS, undefined)
+    assert.equal(result.JAVA_TOOL_OPTIONS, undefined)
+    assert.equal(result.NODE_PATH, '/opt/lib')
+  })
 })

--- a/src/tools/__tests__/export-file.test.ts
+++ b/src/tools/__tests__/export-file.test.ts
@@ -60,6 +60,19 @@ describe('export_file', () => {
     )
   })
 
+  it('rejects copying sensitive source files (issue #135)', async () => {
+    const dir = tempDir()
+    try {
+      const destination = join(dir, 'out.txt')
+      await assert.rejects(
+        () => exportFile({ destination_path: destination, source_path: '~/.ssh/id_rsa' }),
+        /拒绝导出敏感文件/,
+      )
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
   it('tool execute reports a useful success message', async () => {
     const dir = tempDir()
     try {

--- a/src/tools/__tests__/import-resource.test.ts
+++ b/src/tools/__tests__/import-resource.test.ts
@@ -27,6 +27,31 @@ describe('import_resource', () => {
     rmSync(tmpCwd, { recursive: true, force: true })
   })
 
+  // issue #135 — 本地导入曾是唯一不经敏感检测的读路径；敏感文件须在
+  // 任何文件系统操作前被拒绝（fail-closed，不依赖路径真实存在）。
+  it('rejects local import of sensitive files without touching the filesystem (issue #135)', async () => {
+    const result = await IMPORT_RESOURCE_TOOL.execute(makeParams({ source: '~/.ssh/id_rsa' }, tmpCwd))
+    assert.equal(result.isError, true)
+    assert.match(result.content as string, /拒绝导入敏感文件/)
+    assert.match(result.content as string, /id_rsa/)
+  })
+
+  it('rejects local import of .env variants (issue #135)', async () => {
+    for (const source of ['~/.aws/.env', 'credentials.json', '~/.npmrc']) {
+      const result = await IMPORT_RESOURCE_TOOL.execute(makeParams({ source }, tmpCwd))
+      assert.equal(result.isError, true, `expected rejection for ${source}`)
+      assert.match(result.content as string, /拒绝导入敏感文件/)
+    }
+  })
+
+  it('still imports non-sensitive local files (issue #135 regression guard)', async () => {
+    const srcFile = join(tmpCwd, 'notes.txt')
+    writeFileSync(srcFile, 'hello importer')
+    const result = await IMPORT_RESOURCE_TOOL.execute(makeParams({ source: srcFile }, tmpCwd))
+    assert.equal(result.isError, undefined)
+    assert.ok((result.content as string).includes('notes.txt'))
+  })
+
   // issue #119 — subpath 由模型/URL 构造，`blob/main/../../../../etc/passwd` 曾可
   // 越过 .rivet/external 读工作区外任意文件；审批 UI 只显示原始 URL，难以察觉。
   describe('subpath container guard', () => {

--- a/src/tools/__tests__/sensitive-file-detector.test.ts
+++ b/src/tools/__tests__/sensitive-file-detector.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict'
 import {
   detectSensitiveFile,
   detectSensitiveGitAdd,
+  AGGREGATE_ADD_MARKER,
 } from '../sensitive-file-detector.js'
 
 describe('sensitive-file-detector', () => {
@@ -65,16 +66,31 @@ describe('sensitive-file-detector', () => {
       assert.equal(detectSensitiveFile('src/env.test.ts').sensitive, false)
     })
 
-    it('does NOT detect fixtures', () => {
-      assert.equal(detectSensitiveFile('fixtures/.env').sensitive, false)
-    })
-
     it('does NOT detect regular source files', () => {
       assert.equal(detectSensitiveFile('src/agent/loop.ts').sensitive, false)
     })
 
     it('does NOT detect markdown docs', () => {
       assert.equal(detectSensitiveFile('docs/secrets.md').sensitive, false)
+    })
+  })
+
+  // issue #136 — 目录白名单收窄：scripts/、fixtures/ 不再整目录放行，真实凭证
+  // 形态（.env、credentials.json）无论在哪个目录都拦；源码/生成脚本不受影响。
+  describe('detectSensitiveFile — directory whitelist removed (issue #136)', () => {
+    it('detects .env inside scripts/', () => {
+      assert.equal(detectSensitiveFile('scripts/.env').sensitive, true)
+    })
+
+    it('detects credentials.json inside fixtures/', () => {
+      assert.equal(detectSensitiveFile('fixtures/credentials.json').sensitive, true)
+      assert.equal(detectSensitiveFile('FIXTURES/.env').sensitive, true)
+    })
+
+    it('still allows credential generation scripts and templates', () => {
+      assert.equal(detectSensitiveFile('Scripts/gen-creds.ts').sensitive, false)
+      assert.equal(detectSensitiveFile('scripts/gen-tokens.sh').sensitive, false)
+      assert.equal(detectSensitiveFile('docs/.ENV.EXAMPLE').sensitive, false)
     })
   })
 
@@ -100,7 +116,6 @@ describe('sensitive-file-detector', () => {
     })
 
     it('whitelists still apply case-insensitively', () => {
-      assert.equal(detectSensitiveFile('FIXTURES/.env').sensitive, false)
       assert.equal(detectSensitiveFile('Scripts/gen-creds.ts').sensitive, false)
       assert.equal(detectSensitiveFile('docs/.ENV.EXAMPLE').sensitive, false)
     })
@@ -166,7 +181,26 @@ describe('sensitive-file-detector', () => {
 
     it('handles git add with flags', () => {
       const files = detectSensitiveGitAdd('git add -A')
-      assert.equal(files.length, 0) // -A is a flag, not a file
+      assert.deepEqual(files, [AGGREGATE_ADD_MARKER]) // 聚合形态 → 哨兵（issue #136）
+    })
+
+    it('flags aggregate staging forms with the aggregate marker (issue #136)', () => {
+      assert.deepEqual(detectSensitiveGitAdd('git add .'), [AGGREGATE_ADD_MARKER])
+      assert.deepEqual(detectSensitiveGitAdd('git add ./'), [AGGREGATE_ADD_MARKER])
+      assert.deepEqual(detectSensitiveGitAdd('git add --all'), [AGGREGATE_ADD_MARKER])
+      assert.deepEqual(detectSensitiveGitAdd('GIT ADD -A'), [AGGREGATE_ADD_MARKER])
+    })
+
+    it('collects concrete hits alongside the aggregate marker', () => {
+      const files = detectSensitiveGitAdd('git add . .env')
+      assert.ok(files.includes(AGGREGATE_ADD_MARKER))
+      assert.ok(files.includes('.env'))
+    })
+
+    it('flags -A/--all mixed with explicit sensitive paths', () => {
+      const files = detectSensitiveGitAdd('git add -A credentials.json')
+      assert.ok(files.includes(AGGREGATE_ADD_MARKER))
+      assert.ok(files.includes('credentials.json'))
     })
 
     it('matches case-insensitively (PowerShell/cmd command casing)', () => {

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { DANGEROUS_BASH_PATTERNS } from '../agent/approval-risk.js'
-import { detectSensitiveGitAdd } from './sensitive-file-detector.js'
+import { detectSensitiveGitAdd, AGGREGATE_ADD_MARKER } from './sensitive-file-detector.js'
 import type { Tool, ToolCallParams, ToolResult } from './types.js'
 import { track } from './process-tracker.js'
 import { killProcessTree } from './process-kill.js'
@@ -108,14 +108,17 @@ const SAFE_ENV_PREFIXES = [
   // managers rely on these; stripping them broke `mvn`/`java` when launched from
   // a GUI with a minimal env. None contain sensitive keywords, so the KEY/TOKEN/
   // SECRET filter below still removes anything genuinely secret.
-  'JAVA_HOME', 'JDK_HOME', 'JRE_HOME', 'CLASSPATH', 'JAVA_TOOL_OPTIONS',
+  'JAVA_HOME', 'JDK_HOME', 'JRE_HOME', 'CLASSPATH',
   'MAVEN_', 'M2_', 'M2', 'GRADLE_', 'ANT_HOME',
   'GOPATH', 'GOROOT', 'GOBIN', 'GO111MODULE', 'GOFLAGS', 'GOPROXY',
   'CARGO_HOME', 'RUSTUP_HOME',
   'ANDROID_', 'NVM_DIR', 'PYENV', 'SDKMAN_DIR',
   'DOTNET_', 'PYTHONPATH', 'VIRTUAL_ENV', 'CONDA_',
   'PNPM_HOME', 'VOLTA_HOME', 'FNM_DIR', 'MISE_', 'ASDF_', 'RBENV_ROOT', 'GEM_',
-  'NODE_PATH', 'NODE_OPTIONS', 'KUBECONFIG', 'DOCKER_HOST',
+  // 注意：NODE_OPTIONS / JAVA_TOOL_OPTIONS 刻意排除（issue #137）——
+  // 它们可在子进程启动时注入 --require/-javaagent 任意代码，构成环境污染
+  // 攻击面；不含 KEY/TOKEN/SECRET 关键词，敏感过滤兜不住，必须显式剥离。
+  'NODE_PATH', 'KUBECONFIG', 'DOCKER_HOST',
 ] as const
 
 /** Keywords that indicate a sensitive env var — vars containing these substrings are stripped. */
@@ -1026,10 +1029,12 @@ export const BASH_TOOL: Tool = {
     )) {
       return true
     }
-    // git add 敏感文件硬门（prompt 安全纪律的运行时落地）：命令文本暂存凭据/密钥
-    // 文件 → 需审批。检测器 fail-closed 且不抛——不可解析的命令最多漏报，不会崩。
-    return detectSensitiveGitAdd(rawCommand).length > 0
-      || detectSensitiveGitAdd(rewrittenCommand).length > 0
+    // git add 敏感文件硬门（prompt 安全纪律的运行时落地）：命令文本暂存具体
+    // 凭据/密钥文件 → 需审批。聚合形态（. / -A / --all）只返回哨兵项，不在此
+    // 收审批（`git add -A && git commit` 属常规流）；哨兵由 assessToolRisk 消费
+    // 为 medium 风险理由。检测器 fail-closed 且不抛——不可解析的命令最多漏报。
+    return detectSensitiveGitAdd(rawCommand).some(h => h !== AGGREGATE_ADD_MARKER)
+      || detectSensitiveGitAdd(rewrittenCommand).some(h => h !== AGGREGATE_ADD_MARKER)
   },
 
   isConcurrencySafe: () => false,

--- a/src/tools/export-file.ts
+++ b/src/tools/export-file.ts
@@ -2,6 +2,7 @@ import { mkdir, stat, copyFile, writeFile } from 'node:fs/promises'
 import { dirname, resolve } from 'path'
 import type { Tool } from './types.js'
 import { expandHome } from '../platform.js'
+import { detectSensitiveFile } from './sensitive-file-detector.js'
 
 const MAX_EXPORT_BYTES = 50 * 1024 * 1024 // 50MB — explicit external export safety ceiling
 
@@ -49,6 +50,12 @@ export async function exportFile(input: ExportFileInput): Promise<{ path: string
 
   const sourcePath = getSourcePath(input as Record<string, unknown>)
   if (!sourcePath) throw new Error('source_path 为必填项')
+  // 敏感文件硬门（issue #135）：source_path 曾是唯一不经敏感检测的读路径，
+  // 可把 ~/.ssh/id_rsa、.env、凭证文件直接复制出项目。copy 之前先跑同一门禁。
+  const sensitiveSource = detectSensitiveFile(sourcePath)
+  if (sensitiveSource.sensitive) {
+    throw new Error(`拒绝导出敏感文件（${sensitiveSource.patternName}）：${sourcePath}。敏感文件不允许复制到项目之外。`)
+  }
   const sourceStat = await stat(sourcePath)
   if (!sourceStat.isFile()) throw new Error('source_path 必须是文件')
   if (sourceStat.size > MAX_EXPORT_BYTES) {

--- a/src/tools/import-resource.ts
+++ b/src/tools/import-resource.ts
@@ -7,6 +7,7 @@ import type { ArtifactStore } from '../artifact/store.js'
 import { expandHome } from '../platform.js'
 import { relativePosix } from '../path-format.js'
 import { httpFetchGuarded, type HttpFetchResult } from './net/http-fetch.js'
+import { detectSensitiveFile } from './sensitive-file-detector.js'
 
 type HttpFetchFn = (url: string, ...rest: unknown[]) => Promise<HttpFetchResult>
 let httpFetchForTests: HttpFetchFn | null = null
@@ -225,6 +226,18 @@ export const IMPORT_RESOURCE_TOOL: Tool = {
 async function handleLocalImport(cwd: string, importDir: string, source: string, artifactStore?: ArtifactStore): Promise<{ content: string; uiContent: string; isError?: boolean }> {
   const expanded = expandHome(source)
   const resolved = resolve(expanded)
+
+  // 敏感文件硬门（issue #135）：本地导入曾是不经敏感检测的读路径——LLM 诱导下
+  // 可把 ~/.ssh/id_rsa、.env、~/.aws/credentials 等 symlink/复制进 .rivet/external
+  // 并读入上下文。fail-closed：拒绝并给出原因。
+  const sensitive = detectSensitiveFile(resolved)
+  if (sensitive.sensitive) {
+    return {
+      content: `错误：拒绝导入敏感文件（${sensitive.patternName}）：${resolved}`,
+      isError: true,
+      uiContent: `已拦截敏感文件：${resolved}（${sensitive.patternName}）`,
+    }
+  }
 
   try {
     await lstat(resolved)

--- a/src/tools/sensitive-file-detector.ts
+++ b/src/tools/sensitive-file-detector.ts
@@ -22,9 +22,14 @@
  *
  * 白名单（不拦截）：
  *   `.env.example` / `.env.template` / `.env.sample` → 模板文件，无真实凭证
- *   `*.test.ts` / `*.spec.ts` → 测试 fixture
- *   `scripts/` 下的凭证生成脚本
+ *   `*.test.ts` / `*.spec.ts` → 测试源码
+ *   文档（.md）——不含真实凭证形态的说明文字
  *   合法源码文件（如 auth/token-manager.ts）——按扩展名区分（.ts/.js 不拦截）
+ *
+ * 注意（2026-09 收紧）：原 `scripts/`、`fixtures/` 目录白名单已移除——目录白名单
+ * 会让 scripts/.env、fixtures/credentials.json 等真实凭证形态被整目录放行。
+ * fail-closed 优先：该类文件名无论位于哪个目录都拦；凭证生成脚本（gen-creds.ts）
+ * 本就不匹配敏感模式，无需目录白名单。
  */
 
 /** 敏感文件名模式 */
@@ -93,10 +98,6 @@ const WHITELIST_PATTERNS: RegExp[] = [
   /\.env\.(?:example|template|sample)$/,
   // 测试文件
   /\.(?:test|spec)\.(?:ts|tsx|js|jsx)$/,
-  // fixtures 目录
-  /(?:^|\/)fixtures?\//,
-  // scripts 目录
-  /(?:^|\/)scripts\//,
   // 文档
   /\.md$/,
 ]
@@ -143,29 +144,44 @@ export function detectSensitiveFile(inputPath: string): SensitiveFileResult {
 }
 
 /**
+ * 聚合形态哨兵——`git add .` / `-A` / `--all` 时被暂存的文件无法从命令文本
+ * 静态枚举，检测器返回该标记项，由调用方决定处置（审批门 / 风险理由）。
+ * 与具体敏感文件名区分开，便于调用方分别措辞。
+ */
+export const AGGREGATE_ADD_MARKER = '__aggregate_add__'
+
+/**
  * 检测 bash 命令文本中是否包含 git add 敏感文件的操作。
  *
  * 正则来源：匹配 `git add .env` / `git add credentials.json` 等
  * 从命令文本中提取 git add 的参数，检查是否含敏感文件名。
  *
- * @returns 匹配到的敏感文件名数组（可能为空）
+ * 聚合形态（`.`、`./`、`-A`、`--all`）无法静态核验缓存的文件 → 返回
+ * [AGGREGATE_ADD_MARKER]。调用方应视为需要人工确认（fail-closed）。
+ *
+ * @returns 匹配到的敏感文件名数组 + 可能的聚合哨兵项（可能为空）
  */
 export function detectSensitiveGitAdd(command: string): string[] {
   // 匹配 `git add <file>` — 提取文件参数（PowerShell/cmd 命令名不区分大小写 → /gi）
   // 来源：prompt security 段 "发现此类文件出现在 git add 中时中止"
   const gitAddRe = /git\s+add\s+(.+)/gi
   const sensitiveFiles: string[] = []
+  let sawAggregate = false
 
   let match: RegExpExecArray | null
   while ((match = gitAddRe.exec(command)) !== null) {
     const args = match[1]!.trim()
     // 拆分空格分隔的参数（简化处理，不处理引号边界情况）
-    const files = args.split(/\s+/).filter(f => !f.startsWith('-'))
+    const files = args.split(/\s+/)
     for (const f of files) {
+      if (f === '.' || f === './') { sawAggregate = true; continue }
+      if (f === '-A' || f === '-a' || f === '--all') { sawAggregate = true; continue }
+      if (f.startsWith('-')) continue
       const result = detectSensitiveFile(f)
       if (result.sensitive) sensitiveFiles.push(f)
     }
   }
 
+  if (sawAggregate) sensitiveFiles.push(AGGREGATE_ADD_MARKER)
   return sensitiveFiles
 }


### PR DESCRIPTION
## 变更摘要

补齐三条敏感文件防线遗漏：export_file/import_resource 接入敏感文件门、sensitive-file-detector 目录白名单收窄、sanitizeEnv 摘除两个可注入环境变量。

## 动机

- 敏感文件门从未覆盖 export_file 复制源与 import_resource 本地导入——可把 ~/.ssh/id_rsa、.env 读出项目/读入上下文（#135）
- 目录白名单过宽（scripts/、fixtures/ 整目录放行 scripts/.env、fixtures/credentials.json）+ git add ./-A/--all 聚合形态检测盲区（#136）
- NODE_OPTIONS/JAVA_TOOL_OPTIONS 透传给子进程，环境污染即可 --require/-javaagent 注入任意代码（#137）

## 主要改动

- src/tools/export-file.ts：复制模式 source_path 先过 detectSensitiveFile，敏感文件拒绝并给出 patternName
- src/tools/import-resource.ts：handleLocalImport 在任何文件系统操作前 fail-closed 拒绝敏感源
- src/tools/sensitive-file-detector.ts：移除 scripts//fixtures/ 目录白名单（模板 .env.example、测试文件、.md 保留）；新增 AGGREGATE_ADD_MARKER，git add ./-A/--all 返回哨兵
- src/agent/approval-risk.ts：哨兵 → medium 风险理由（建议改用 git 工具）；具体敏感文件仍为 high
- src/tools/bash.ts：SAFE_ENV_PREFIXES 摘除 NODE_OPTIONS/JAVA_TOOL_OPTIONS（bash 与 monitor-tool 共用 sanitizeEnv）

## 测试

- 更新/新增用例：sensitive-file-detector（目录白名单收窄、聚合哨兵）、bash（sanitizeEnv 剥离断言）、export-file（敏感复制拒绝）、import-resource（敏感导入拒绝 + 非敏感回归）、approval-risk（哨兵链路），相关文件 268 用例通过
- npm run typecheck 干净（pre-push 钩子再次验证）
- 注：完整 npm test 在 Windows 环境有 3 个既有失败，与本变更无关（PATH 键大小写 'Path' vs 'PATH'、symlink 权限、进程终端 kill 时序），本地复跑确认非回归

## 检查清单

- [x] npm test 相关用例通过（针对性套件；全量套件见 CI）
- [x] npx tsc --noEmit 无类型错误
- [x] 变更范围最小化，无关改动已排除
- [x] 文档无需更新（安全闸门行为在代码注释中说明）

## 相关 Issue

关联 #135、#136、#137（不自动关闭，按仓库惯例由维护者处置）