### PR TITLE
perf(prompt): requestTimeCollapse 单遍索引化，工具结果折叠 O(n²)→O(n)

### DIFF
--- a/src/prompt/__tests__/request-time-collapse.test.ts
+++ b/src/prompt/__tests__/request-time-collapse.test.ts
@@ -268,4 +268,45 @@ describe('requestTimeCollapse', () => {
     // non-dedup tool result NOT collapsed in lightOnly mode
     assert.equal(messages[2]!.content, 'x'.repeat(500))
   })
+
+  it('dedups parallel tool calls from a single assistant message via the prebuilt index (issue #138)', () => {
+    const messages: OaiMessage[] = [
+      makeUser('turn 1'),
+      {
+        role: 'assistant',
+        content: '',
+        tool_calls: [
+          { id: 'c1', type: 'function', function: { name: 'grep', arguments: JSON.stringify({ pattern: 'foo' }) } },
+          { id: 'c2', type: 'function', function: { name: 'grep', arguments: JSON.stringify({ pattern: 'foo' }) } },
+        ],
+      },
+      makeToolResult('c1', Array.from({ length: 20 }, (_, i) => `src/f${i}.ts:1: foo`).join('\n')),
+      makeToolResult('c2', Array.from({ length: 20 }, (_, i) => `src/f${i}.ts:1: foo updated`).join('\n')),
+      makeUser('turn 2'),
+      makeUser('turn 3'),
+      makeUser('turn 4'),
+      makeUser('turn 5'),
+      makeUser('turn 6'),
+    ]
+    requestTimeCollapse(messages, 5, 1_000_000)
+    assert.match(messages[2]!.content as string, /superseded/)
+    assert.doesNotMatch(messages[4]!.content as string, /superseded/)
+  })
+
+  it('treats tool results without matching assistant calls as unknown (index miss → no dedup)', () => {
+    const messages: OaiMessage[] = [
+      makeUser('turn 1'),
+      makeToolResult('ghost-call', 'x'.repeat(500)),
+      makeUser('turn 2'),
+      makeUser('turn 3'),
+      makeUser('turn 4'),
+      makeUser('turn 5'),
+      makeUser('turn 6'),
+    ]
+    requestTimeCollapse(messages, 3, 1_000_000)
+    // 未找到 assistant tool_call → name unknown：不参与 dedup，但语义折叠照旧
+    // （与旧直线回溯一致：inferToolName 同样返回 unknown）。
+    assert.doesNotMatch(messages[1]!.content as string, /superseded/)
+    assert.match(messages[1]!.content as string, /^\[collapsed unknown:/)
+  })
 })

--- a/src/prompt/engine.ts
+++ b/src/prompt/engine.ts
@@ -1564,17 +1564,22 @@ export function requestTimeCollapse(messages: OaiMessage[], boundaryIndex: numbe
     if (m.role === 'user') currentTurn++
   }
 
+  const end = Math.min(boundaryIndex, messages.length)
+  // 单遍预建 tool_call_id → { name, target } 索引（issue #138）：此前每条 tool
+  // 消息要做 2~4 次反向线性回溯找其 assistant tool_call，最坏 O(n²)；索引化后
+  // 全程 O(1) 查找，整体 O(n)。
+  const toolCallIndex = buildToolCallIndex(messages, end)
+
   // Build dedup index: for each tool+target pair, track all occurrences
   // below the boundary so older duplicates can be folded.
   const toolOccurrences = new Map<string, number[]>()
-  const end = Math.min(boundaryIndex, messages.length)
   for (let i = 0; i < end; i++) {
     const msg = messages[i]!
     if (msg.role !== 'tool' || msg.content.length < 200) continue
     if (msg.content.startsWith('[collapsed ') || msg.content.startsWith('[storm-collapsed') || msg.content.startsWith('[tiered-')) continue
-    const toolName = inferToolName(messages, i)
+    const toolName = toolNameFromIndex(msg, toolCallIndex)
     if (toolName === 'grep' || toolName === 'search' || toolName === 'read_file') {
-      const target = inferToolTarget(messages, i, toolName)
+      const target = targetFromIndex(msg, toolCallIndex)
       if (target) {
         const key = `${toolName}:${target}`
         const indices = toolOccurrences.get(key)
@@ -1609,12 +1614,12 @@ export function requestTimeCollapse(messages: OaiMessage[], boundaryIndex: numbe
     if (msg.content.length < 200) continue
     if (msg.content.startsWith('[collapsed ') || msg.content.startsWith('[storm-collapsed') || msg.content.startsWith('[tiered-')) continue
 
-    const toolName = inferToolName(messages, i)
+    const toolName = toolNameFromIndex(msg, toolCallIndex)
 
     // Dedup fold: if a newer call to the same tool+target exists below boundary,
     // collapse this older result regardless of lightOnly mode.
     if (superseded.has(i)) {
-      const target = inferToolTarget(messages, i, toolName)
+      const target = targetFromIndex(msg, toolCallIndex)
       messages[i] = { ...msg, content: `[collapsed ${toolName}: superseded by later ${toolName} on ${target ?? 'same target'}]` }
       continue
     }
@@ -1630,50 +1635,50 @@ export function requestTimeCollapse(messages: OaiMessage[], boundaryIndex: numbe
   }
 }
 
-/**
- * Extract tool target from the assistant's tool_call arguments.
- * For grep/search: the pattern or path argument.
- * For read_file: the file path argument.
- */
-function inferToolTarget(messages: OaiMessage[], toolMsgIndex: number, toolName: string): string | null {
-  const toolMsg = messages[toolMsgIndex]!
-  if (toolMsg.role !== 'tool' || !('tool_call_id' in toolMsg)) return null
-  const toolCallId = (toolMsg as { tool_call_id?: string }).tool_call_id
-  if (!toolCallId) return null
+type ToolCallInfo = {
+  name: string
+  /** grep/search 的 pattern/query，read_file 的 path/file；其余工具或解析失败为 null。 */
+  target: string | null
+}
 
-  for (let j = toolMsgIndex - 1; j >= 0; j--) {
-    const prev = messages[j]!
-    if (prev.role !== 'assistant') continue
-    const calls = (prev as { tool_calls?: Array<{ id: string; function: { arguments: string } }> }).tool_calls
-    if (!calls) continue
-    const call = calls.find(c => c.id === toolCallId)
-    if (!call) continue
-    try {
-      const args = JSON.parse(call.function.arguments) as Record<string, unknown>
-      if (toolName === 'grep' || toolName === 'search') {
-        return (args['pattern'] as string | undefined) ?? (args['query'] as string | undefined) ?? null
+/** 单遍扫描 [0, end) 的 assistant 消息，预建 tool_call_id → { name, target }。 */
+function buildToolCallIndex(messages: OaiMessage[], end: number): Map<string, ToolCallInfo> {
+  const index = new Map<string, ToolCallInfo>()
+  for (let i = 0; i < end; i++) {
+    const msg = messages[i] as { role?: string; tool_calls?: Array<{ id: string; function: { name: string; arguments: string } }> }
+    if (msg.role !== 'assistant' || !msg.tool_calls?.length) continue
+    for (const call of msg.tool_calls) {
+      let target: string | null = null
+      if (call.function.name === 'grep' || call.function.name === 'search') {
+        target = parseCallTarget(call.function.arguments, ['pattern', 'query'])
+      } else if (call.function.name === 'read_file') {
+        target = parseCallTarget(call.function.arguments, ['path', 'file'])
       }
-      if (toolName === 'read_file') {
-        return (args['path'] as string | undefined) ?? (args['file'] as string | undefined) ?? null
-      }
-    } catch { return null }
+      index.set(call.id, { name: call.function.name, target })
+    }
   }
+  return index
+}
+
+function parseCallTarget(argumentsJson: string, keys: string[]): string | null {
+  try {
+    const args = JSON.parse(argumentsJson) as Record<string, unknown>
+    for (const key of keys) {
+      const value = args[key]
+      if (typeof value === 'string') return value
+    }
+  } catch { /* unparseable args → no target */ }
   return null
 }
 
-function inferToolName(messages: OaiMessage[], toolMsgIndex: number): string {
-  const toolMsg = messages[toolMsgIndex]!
-  if (toolMsg.role !== 'tool' || !('tool_call_id' in toolMsg)) return 'unknown'
-  const toolCallId = (toolMsg as { tool_call_id?: string }).tool_call_id
+function toolNameFromIndex(msg: OaiMessage, index: Map<string, ToolCallInfo>): string {
+  const toolCallId = (msg as { tool_call_id?: string }).tool_call_id
   if (!toolCallId) return 'unknown'
+  return index.get(toolCallId)?.name ?? 'unknown'
+}
 
-  for (let j = toolMsgIndex - 1; j >= 0; j--) {
-    const prev = messages[j]!
-    if (prev.role !== 'assistant') continue
-    const tc = (prev as { tool_calls?: Array<{ id: string; function?: { name: string } }> }).tool_calls
-    if (!tc) continue
-    const match = tc.find(c => c.id === toolCallId)
-    if (match?.function?.name) return match.function.name
-  }
-  return 'unknown'
+function targetFromIndex(msg: OaiMessage, index: Map<string, ToolCallInfo>): string | null {
+  const toolCallId = (msg as { tool_call_id?: string }).tool_call_id
+  if (!toolCallId) return null
+  return index.get(toolCallId)?.target ?? null
 }


### PR DESCRIPTION
## 变更摘要

requestTimeCollapse 由「逐工具消息反向线性回溯 assistant tool_call」改为「单遍预建 tool_call_id → {name, target} 索引」，构建阶段从最坏 O(n²) 降为 O(n)。

## 动机

240K+ 大上下文、工具密集轮次中，每条 tool 消息最多 4 次独立反向回溯（inferToolName×2 + inferToolTarget×2），最坏 O(结果数 × 回溯深度) ≈ O(n²)，是单轮请求构建中唯一的结构性平方病灶（#138）。

## 主要改动

- src/prompt/engine.ts：新增 buildToolCallIndex（单遍扫描 assistant 消息预建索引）、parseCallTarget、toolNameFromIndex/targetFromIndex；删除 inferToolName/inferToolTarget
- dedup 索引、superseded 折叠、reasoning 剥离三处全部改为 O(1) 索引查找；turnAge/lightOnly/frozen boundary 语义逐行保留
- 行为对齐：grep/search 取 pattern/query、read_file 取 path/file、索引 miss → 'unknown' 兜底，折叠输出字节级一致（frozen boundary 对拍通过）

## 测试

- request-time-collapse 17/17 通过（新增：单条 assistant 消息并行 tool_calls 去重、索引 miss 用例）
- engine.test 35/35 通过；npm run typecheck 干净
- 无性能回退断言类测试（算法复杂度由结构保证；原实现无公开基准可对拍）

## 检查清单

- [x] npm test 相关用例通过（针对性套件；全量套件见 CI）
- [x] npx tsc --noEmit 无类型错误
- [x] 变更范围最小化，无关改动已排除
- [x] 文档无需更新（纯内部实现等价替换）

## 相关 Issue

关联 #138（不自动关闭，按仓库惯例由维护者处置）